### PR TITLE
missing array trait methods on ColumnView

### DIFF
--- a/libcudf-datafusion/src/expr/binary.rs
+++ b/libcudf-datafusion/src/expr/binary.rs
@@ -90,13 +90,17 @@ impl PhysicalExpr for CuDFBinaryExpr {
         // Cast the result if needed to match the expected output type.
         if let ColumnarValue::Array(arr) = &result {
             if arr.data_type() != &expected_output_type {
-                if let (DataType::Decimal128(_, result_scale), DataType::Decimal128(_expected_prec, expected_scale)) =
-                    (arr.data_type(), &expected_output_type) {
+                if let (
+                    DataType::Decimal128(_, result_scale),
+                    DataType::Decimal128(_expected_prec, expected_scale),
+                ) = (arr.data_type(), &expected_output_type)
+                {
                     if result_scale == expected_scale {
                         // Same scale, just different precision. Arrow's cast doesn't handle this,
                         // so we manually change the precision metadata while keeping the same i128 values.
                         let decimal_array = arr.as_primitive::<arrow::datatypes::Decimal128Type>();
-                        let casted = decimal_array.clone()
+                        let casted = decimal_array
+                            .clone()
                             .with_precision_and_scale(*_expected_prec, *expected_scale)
                             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
                         result = ColumnarValue::Array(Arc::new(casted));

--- a/libcudf-sys/.clangd
+++ b/libcudf-sys/.clangd
@@ -2,7 +2,7 @@
 # This config is scoped to the libcudf-sys directory only
 
 CompileFlags:
-  CompilationDatabase: .
+  CompilationDatabase: ..
   Add:
     - -ferror-limit=0
   Remove:

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -172,14 +172,6 @@ namespace libcudf_bridge {
         return host_buffer;
     }
 
-    [[nodiscard]] size_t ColumnView::get_null_buffer_size() const {
-        if (!inner || inner->null_count() == 0) {
-            return 0;
-        }
-
-        return cudf::bitmask_allocation_size_bytes(inner->size());
-    }
-
     // Column implementation
     Column::Column() : inner(nullptr) {
     }

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -1,12 +1,18 @@
 #include "column.h"
+#include "cudf/null_mask.hpp"
+#include "cudf/types.hpp"
+#include <cuda_runtime_api.h>
 #include "data_type.h"
 #include "scalar.h"
 #include "libcudf-sys/src/lib.rs.h"
 
+#include <cinttypes>
+#include <cstdint>
 #include <cudf/column/column.hpp>
 #include <cudf/interop.hpp>
 #include <cudf/copying.hpp>
 
+#include <memory>
 #include <nanoarrow/nanoarrow.h>
 #include <nanoarrow/nanoarrow_device.h>
 
@@ -80,6 +86,96 @@ namespace libcudf_bridge {
             return inner->null_count();
         }
         return 0;
+    }
+
+    // Get buffer memory size (data + offsets, no null mask)
+    [[nodiscard]] size_t ColumnView::get_buffer_memory_size() const {
+        if (!inner) {
+            return 0;
+        }
+
+        const auto& view = *inner;
+
+        // Calculate size based on data type
+        size_t data_size = cudf::size_of(view.type()) *view.size();
+
+        // For strings add offset buffer size
+        if (view.type().id() == cudf::type_id::STRING) {
+            data_size += (view.size() + 1) * sizeof(int32_t);
+        }
+
+        // For nested types recursively add child buffer sizes
+        for (cudf::size_type i = 0; i < view.num_children(); ++i) {
+            ColumnView child_wrapper;
+            child_wrapper.inner = std::make_unique<cudf::column_view>(view.child(i));
+            data_size += child_wrapper.get_buffer_memory_size();
+        }
+
+        return data_size;
+    }
+
+    // Get total array memory size (data + offsets + null mask + children)
+    [[nodiscard]] size_t ColumnView::get_array_memory_size() const {
+        if (!inner) {
+            return 0;
+        }
+
+        size_t total_size = this->get_buffer_memory_size();
+
+        const auto& view = *inner;
+
+        // Add null mask size
+        if (view.nullable()) {
+            total_size += cudf::bitmask_allocation_size_bytes(view.size());
+        }
+
+        // For nested types add child null masks recursively
+        for (cudf::size_type i = 0; i < view.num_children(); ++i) {
+            auto child = view.child(i);
+            total_size += cudf::bitmask_allocation_size_bytes(child.size());
+        }
+
+        return total_size;
+    }
+
+    [[nodiscard]] rust::Vec<uint8_t> ColumnView::get_null_buffer() const {
+        if (!inner || inner->null_count() == 0) {
+            return rust::Vec<uint8_t>();
+        }
+
+        const auto& view = *inner;
+
+        // Calculate null mask size
+        size_t mask_size = cudf::bitmask_allocation_size_bytes(view.size());
+
+        rust::Vec<uint8_t> host_buffer;
+        host_buffer.reserve(mask_size);
+
+        // Resize to actual size so cudaMemcpy has a valid destination
+        for (size_t i = 0; i < mask_size; ++i) {
+            host_buffer.push_back(0);
+        }
+
+        cudaError_t err = cudaMemcpy(
+            host_buffer.data(),
+            view.null_mask(),
+            mask_size,
+            cudaMemcpyDeviceToHost
+        );
+
+        if (err != cudaSuccess) {
+            throw std::runtime_error(std::string("cudaMemcpy failed: ") + cudaGetErrorString(err));
+        }
+
+        return host_buffer;
+    }
+
+    [[nodiscard]] size_t ColumnView::get_null_buffer_size() const {
+        if (!inner || inner->null_count() == 0) {
+            return 0;
+        }
+
+        return cudf::bitmask_allocation_size_bytes(inner->size());
     }
 
     // Column implementation

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -105,23 +105,22 @@ namespace libcudf_bridge {
         return data_size;
     }
 
-    size_t calculate_array_memory_size(const cudf::column_view& view) {
-        size_t total_size = calculate_buffer_memory_size(view);
+    size_t calculate_null_mask_size(const cudf::column_view& view) {
+        size_t size = 0;
 
-        // Add null mask size
         if (view.nullable()) {
-            total_size += cudf::bitmask_allocation_size_bytes(view.size());
+            size += cudf::bitmask_allocation_size_bytes(view.size());
         }
 
-        // For nested types add child null masks recursively
         for (cudf::size_type i = 0; i < view.num_children(); ++i) {
-            auto child = view.child(i);
-            if (child.nullable()) {
-                total_size += cudf::bitmask_allocation_size_bytes(child.size());
-            }
+            size += calculate_null_mask_size(view.child(i));
         }
 
-        return total_size;
+        return size;
+    }
+
+    size_t calculate_array_memory_size(const cudf::column_view& view) {
+        return calculate_buffer_memory_size(view) + calculate_null_mask_size(view);
     }
 
     // Get buffer memory size (data + offsets, no null mask)

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -88,16 +88,9 @@ namespace libcudf_bridge {
         return 0;
     }
 
-    // Get buffer memory size (data + offsets, no null mask)
-    [[nodiscard]] size_t ColumnView::get_buffer_memory_size() const {
-        if (!inner) {
-            return 0;
-        }
-
-        const auto& view = *inner;
-
+    size_t calculate_buffer_memory_size(const cudf::column_view& view) {
         // Calculate size based on data type
-        size_t data_size = cudf::size_of(view.type()) *view.size();
+        size_t data_size = cudf::size_of(view.type()) * view.size();
 
         // For strings add offset buffer size
         if (view.type().id() == cudf::type_id::STRING) {
@@ -106,23 +99,14 @@ namespace libcudf_bridge {
 
         // For nested types recursively add child buffer sizes
         for (cudf::size_type i = 0; i < view.num_children(); ++i) {
-            ColumnView child_wrapper;
-            child_wrapper.inner = std::make_unique<cudf::column_view>(view.child(i));
-            data_size += child_wrapper.get_buffer_memory_size();
+            data_size += calculate_buffer_memory_size(view.child(i));
         }
 
         return data_size;
     }
 
-    // Get total array memory size (data + offsets + null mask + children)
-    [[nodiscard]] size_t ColumnView::get_array_memory_size() const {
-        if (!inner) {
-            return 0;
-        }
-
-        size_t total_size = this->get_buffer_memory_size();
-
-        const auto& view = *inner;
+    size_t calculate_array_memory_size(const cudf::column_view& view) {
+        size_t total_size = calculate_buffer_memory_size(view);
 
         // Add null mask size
         if (view.nullable()) {
@@ -132,10 +116,28 @@ namespace libcudf_bridge {
         // For nested types add child null masks recursively
         for (cudf::size_type i = 0; i < view.num_children(); ++i) {
             auto child = view.child(i);
-            total_size += cudf::bitmask_allocation_size_bytes(child.size());
+            if (child.nullable()) {
+                total_size += cudf::bitmask_allocation_size_bytes(child.size());
+            }
         }
 
         return total_size;
+    }
+
+    // Get buffer memory size (data + offsets, no null mask)
+    [[nodiscard]] size_t ColumnView::get_buffer_memory_size() const {
+        if (!inner) {
+            return 0;
+        }
+        return calculate_buffer_memory_size(*inner);
+    }
+
+    // Get total array memory size (data + offsets + null mask + children)
+    [[nodiscard]] size_t ColumnView::get_array_memory_size() const {
+        if (!inner) {
+            return 0;
+        }
+        return calculate_array_memory_size(*inner);
     }
 
     [[nodiscard]] rust::Vec<uint8_t> ColumnView::get_null_buffer() const {

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -13,6 +13,7 @@ namespace libcudf_bridge {
 
     // Helper functions for memory size calculations
     size_t calculate_buffer_memory_size(const cudf::column_view& view);
+    size_t calculate_null_mask_size(const cudf::column_view& view);
     size_t calculate_array_memory_size(const cudf::column_view& view);
 
     // Opaque wrapper for cuDF column_view

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -52,9 +52,6 @@ namespace libcudf_bridge {
 
         /// Transfer the null buffer
         [[nodiscard]] rust::Vec<uint8_t> get_null_buffer() const;
-
-        /// Get null buffer size in bytes
-        [[nodiscard]] size_t get_null_buffer_size() const;
     };
 
     // Opaque wrapper for cuDF column

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -39,6 +39,18 @@ namespace libcudf_bridge {
 
         // Returns how many nulls this column has
         [[nodiscard]] int32_t null_count() const;
+
+        /// Get buffer memory size (data + offsets, no null mask)
+        [[nodiscard]] size_t get_buffer_memory_size() const;
+
+        /// Get total array memory size (data + offsets + null mask + children)
+        [[nodiscard]] size_t get_array_memory_size() const;
+
+        /// Transfer the null buffer
+        [[nodiscard]] rust::Vec<uint8_t> get_null_buffer() const;
+
+        /// Get null buffer size in bytes
+        [[nodiscard]] size_t get_null_buffer_size() const;
     };
 
     // Opaque wrapper for cuDF column
@@ -76,4 +88,5 @@ namespace libcudf_bridge {
 
     // Extract a scalar from a column at the specified index
     std::unique_ptr<Scalar> get_element(const ColumnView &column, size_t index);
+
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -11,6 +11,10 @@
 namespace libcudf_bridge {
     struct DataType;
 
+    // Helper functions for memory size calculations
+    size_t calculate_buffer_memory_size(const cudf::column_view& view);
+    size_t calculate_array_memory_size(const cudf::column_view& view);
+
     // Opaque wrapper for cuDF column_view
     struct ColumnView {
         std::unique_ptr<cudf::column_view> inner;

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -187,6 +187,18 @@ pub mod ffi {
         /// Get the number of null values in the column
         fn null_count(self: &ColumnView) -> i32;
 
+        /// Get buffer memory size (data + offsets, no null mask)
+        fn get_buffer_memory_size(self: &ColumnView) -> usize;
+
+        /// Get total array memory size (data + offsets + null mask + children)
+        fn get_array_memory_size(self: &ColumnView) -> usize;
+
+        /// Transfer the null buffer
+        fn get_null_buffer(self: &ColumnView) -> Vec<u8>;
+
+        /// Get null buffer size
+        fn get_null_buffer_size(self: &ColumnView) -> usize;
+
         // DataType methods
         /// Get the type_id
         fn id(self: &DataType) -> i32;

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -254,10 +254,7 @@ pub mod ffi {
         ///
         /// Reorders the rows of `source_table` according to the indices in `gather_map`.
         /// The resulting table will have the same number of rows as `gather_map` has elements.
-        fn gather(
-            source_table: &TableView,
-            gather_map: &ColumnView,
-        ) -> Result<UniquePtr<Table>>;
+        fn gather(source_table: &TableView, gather_map: &ColumnView) -> Result<UniquePtr<Table>>;
 
         /// Create a sliced view of a column
         ///
@@ -854,12 +851,8 @@ mod tests {
         let col2 = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
-        let result = ffi::binary_operation_col_col(
-            &col1,
-            &col2,
-            BinaryOperator::Add as i32,
-            &output_type,
-        )?;
+        let result =
+            ffi::binary_operation_col_col(&col1, &col2, BinaryOperator::Add as i32, &output_type)?;
 
         assert_eq!(result.size(), col1.size());
         assert_eq!(result.size(), col2.size());
@@ -877,12 +870,8 @@ mod tests {
         let col2 = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
-        let result = ffi::binary_operation_col_col(
-            &col1,
-            &col2,
-            BinaryOperator::Mul as i32,
-            &output_type,
-        )?;
+        let result =
+            ffi::binary_operation_col_col(&col1, &col2, BinaryOperator::Mul as i32, &output_type)?;
 
         assert_eq!(result.size(), col1.size());
         assert_snapshot!(pretty_column(&result.view(), DataType::Float64)?);

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -196,9 +196,6 @@ pub mod ffi {
         /// Transfer the null buffer
         fn get_null_buffer(self: &ColumnView) -> Vec<u8>;
 
-        /// Get null buffer size
-        fn get_null_buffer_size(self: &ColumnView) -> usize;
-
         // DataType methods
         /// Get the type_id
         fn id(self: &DataType) -> i32;

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -314,4 +314,236 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_get_buffer_memory_size_int32() {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let size = column.get_buffer_memory_size();
+        assert_eq!(size, 20, "Int32 column should be 20 bytes");
+    }
+
+    #[test]
+    fn test_get_buffer_memory_size_large() {
+        let data: Vec<i32> = (0..1_000_000).collect();
+        let array = Int32Array::from(data);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let size = column.get_buffer_memory_size();
+        assert_eq!(size, 4_000_000, "1M Int32 elements should be 4MB");
+    }
+
+    #[test]
+    fn test_get_array_memory_size_no_nulls() {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let buffer_size = column.get_buffer_memory_size();
+        let array_size = column.get_array_memory_size();
+
+        // With no nulls, array_size should equal buffer_size
+        assert_eq!(
+            array_size, buffer_size,
+            "Array size should equal buffer size when no nulls"
+        );
+    }
+
+    #[test]
+    fn test_get_array_memory_size_with_nulls() {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let buffer_size = column.get_buffer_memory_size();
+        let array_size = column.get_array_memory_size();
+
+        // With nulls -> array_size = buffer_size + null_mask_size
+        assert!(
+            array_size > buffer_size,
+            "Array size should be larger than buffer size when nulls present"
+        );
+
+        let null_overhead = array_size - buffer_size;
+        assert!(
+            null_overhead >= 1 && null_overhead <= 128,
+            "Null mask overhead should be between 1 and 128 bytes, got {}",
+            null_overhead
+        );
+    }
+
+    #[test]
+    fn test_nulls_no_nulls_returns_none() {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls();
+        assert!(nulls.is_none(), "Column with no nulls should return None");
+    }
+
+    #[test]
+    fn test_nulls_with_nulls_returns_buffer() {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls();
+        assert!(
+            nulls.is_some(),
+            "Column with nulls should return Some(NullBuffer)"
+        );
+    }
+
+    #[test]
+    fn test_nulls_correct_bit_pattern() {
+        let array = Int32Array::from(vec![Some(10), None, Some(30), None, Some(50)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls().expect("Should have null buffer");
+        assert!(nulls.is_valid(0), "Element 0 should be valid (Some(10))");
+        assert!(nulls.is_null(1), "Element 1 should be null");
+        assert!(nulls.is_valid(2), "Element 2 should be valid (Some(30))");
+        assert!(nulls.is_null(3), "Element 3 should be null");
+        assert!(nulls.is_valid(4), "Element 4 should be valid (Some(50))");
+    }
+
+    #[test]
+    fn test_nulls_cached_same_reference() {
+        let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls1 = column.nulls();
+        let nulls2 = column.nulls();
+
+        // Should return references to the same cached NullBuffer
+        assert!(nulls1.is_some());
+        assert!(nulls2.is_some());
+
+        let ptr1 = nulls1.unwrap() as *const _;
+        let ptr2 = nulls2.unwrap() as *const _;
+        assert_eq!(
+            ptr1, ptr2,
+            "Subsequent calls should return same cached buffer"
+        );
+    }
+
+    #[test]
+    fn test_is_null_uses_null_buffer() {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        assert!(!column.is_null(0), "Index 0 should not be null");
+        assert!(column.is_null(1), "Index 1 should be null");
+        assert!(!column.is_null(2), "Index 2 should not be null");
+        assert!(column.is_null(3), "Index 3 should be null");
+        assert!(!column.is_null(4), "Index 4 should not be null");
+    }
+
+    #[test]
+    fn test_is_valid_inverse_of_is_null() {
+        let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        for i in 0..3 {
+            assert_eq!(
+                column.is_valid(i),
+                !column.is_null(i),
+                "is_valid should be inverse of is_null at index {}",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_null_count_matches_null_buffer() {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5), None]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let null_count = column.null_count();
+
+        // Should have 3 nulls (indices 1, 3, 5)
+        assert_eq!(null_count, 3, "Should have 3 nulls");
+
+        let manual_count = (0..column.len()).filter(|&i| column.is_null(i)).count();
+        assert_eq!(
+            null_count, manual_count,
+            "null_count() should match manual count"
+        );
+    }
+
+    #[test]
+    fn test_nulls_with_large_column() {
+        let data: Vec<Option<i32>> = (0..10_000)
+            .map(|i| if i % 2 == 0 { Some(i) } else { None })
+            .collect();
+        let array = Int32Array::from(data);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls().expect("Should have null buffer");
+
+        // Verify pattern: even indices valid, odd indices null
+        for i in 0..100 {
+            if i % 2 == 0 {
+                assert!(nulls.is_valid(i), "Even index {} should be valid", i);
+            } else {
+                assert!(nulls.is_null(i), "Odd index {} should be null", i);
+            }
+        }
+
+        assert_eq!(column.null_count(), 5_000, "Should have 5,000 nulls");
+    }
+
+    #[test]
+    fn test_logical_nulls_equals_physical_nulls() {
+        // For primitive types, logical_nulls should equal physical nulls
+        let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let physical = column.nulls();
+        let logical = column.logical_nulls();
+
+        match (physical, logical) {
+            (Some(p), Some(l)) => {
+                // Both should have same null pattern
+                for i in 0..3 {
+                    assert_eq!(
+                        p.is_null(i),
+                        l.is_null(i),
+                        "Physical and logical nulls should match at index {}",
+                        i
+                    );
+                }
+            }
+            (None, None) => {
+                // Both None is valid
+            }
+            _ => {
+                panic!("Physical and logical nulls should both be Some or both None");
+            }
+        }
+    }
 }

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -3,12 +3,13 @@ use crate::data_type::cudf_type_to_arrow;
 use crate::{slice_column, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef};
 use arrow::buffer::NullBuffer;
+use arrow::compute::is_null;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_schema::DataType;
 use cxx::UniquePtr;
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// A view into a cuDF column stored in GPU memory
 ///
@@ -23,6 +24,7 @@ pub struct CuDFColumnView {
     pub(crate) _ref: Option<Arc<dyn CuDFRef>>,
     inner: UniquePtr<libcudf_sys::ffi::ColumnView>,
     dt: DataType,
+    null_buf: OnceLock<Option<NullBuffer>>,
 }
 
 impl CuDFColumnView {
@@ -36,7 +38,12 @@ impl CuDFColumnView {
         let cudf_dtype = inner.data_type();
         let dt = cudf_type_to_arrow(&cudf_dtype);
         let dt = dt.unwrap_or(DataType::Null);
-        Self { _ref, inner, dt }
+        Self {
+            _ref,
+            inner,
+            dt,
+            null_buf: OnceLock::new(),
+        }
     }
 
     pub(crate) fn inner(&self) -> &UniquePtr<libcudf_sys::ffi::ColumnView> {
@@ -107,6 +114,7 @@ impl Clone for CuDFColumnView {
             _ref: self._ref.clone(),
             inner: cloned_inner,
             dt: self.dt.clone(),
+            null_buf: self.null_buf.clone(),
         }
     }
 }
@@ -128,11 +136,13 @@ impl Array for CuDFColumnView {
     }
 
     fn to_data(&self) -> ArrayData {
-        ArrayData::new_empty(&self.dt)
+        self.to_arrow_host()
+            .expect("Failed to convert GPU column to host Arrow")
+            .to_data()
     }
 
     fn into_data(self) -> ArrayData {
-        ArrayData::new_empty(&self.dt)
+        self.to_data()
     }
 
     fn data_type(&self) -> &DataType {
@@ -152,31 +162,61 @@ impl Array for CuDFColumnView {
     }
 
     fn offset(&self) -> usize {
-        todo!()
+        self.inner.offset()
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
-        todo!()
+        // TODO: This should use FFI to transfer ONLY the null bitmap from GPU,
+        // not the entire column data.
+        // Add column_view_get_null_buffer() to libcudf-sys and call it here.
+        self.null_buf
+            .get_or_init(|| {
+                if self.null_count() == 0 {
+                    return None;
+                }
+                let array_data = self.to_data();
+                array_data.nulls().cloned()
+            })
+            .as_ref()
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        todo!()
+        // TODO: This should use FFI to query cuDF metadata directly instead of
+        // transferring all data from GPU to CPU (no allocation)
+        // Add column_view_get_buffer_memory_size() to libcudf-sys and call it here.
+        let data = self.to_data();
+        data.buffers().iter().map(|b| b.len()).sum()
     }
 
     fn get_array_memory_size(&self) -> usize {
-        todo!()
+        // TODO: This should use FFI to query cuDF metadata directly instead of
+        // transferring all data from GPU to CPU (no allocation).
+        // Add column_view_get_array_memory_size() to libcudf-sys and call it here.
+        let data = self.to_data();
+        let buffer_size: usize = data.buffers().iter().map(|b| b.len()).sum();
+        let null_size = data.nulls().map(|n| n.buffer().len()).unwrap_or(0);
+        let child_size: usize = (0..data.num_children())
+            .filter_map(|i| data.child_data().get(i))
+            .map(|child| child.get_array_memory_size())
+            .sum();
+        buffer_size + null_size + child_size
     }
 
     fn logical_nulls(&self) -> Option<NullBuffer> {
-        todo!()
+        // TODO: For now only primitive types are supported
+        // In this case logical_nulls == physical_nulls
+        self.nulls().cloned()
     }
 
-    fn is_null(&self, _index: usize) -> bool {
-        todo!()
+    fn is_null(&self, index: usize) -> bool {
+        match self.nulls() {
+            Some(nulls) => nulls.is_null(index),
+            None => false,
+        }
     }
 
-    fn is_valid(&self, _index: usize) -> bool {
-        todo!()
+    fn is_valid(&self, index: usize) -> bool {
+        !self.is_null(index)
     }
 
     fn null_count(&self) -> usize {
@@ -184,11 +224,14 @@ impl Array for CuDFColumnView {
     }
 
     fn logical_null_count(&self) -> usize {
-        todo!()
+        // TODO: For now only primitive types are supported
+        // In this case logical_null_count == physical_null_count
+        self.null_count()
     }
 
     fn is_nullable(&self) -> bool {
-        todo!()
+        // All cuDF columns can potentially have nulls
+        true
     }
 }
 

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -2,8 +2,7 @@ use crate::cudf_reference::CuDFRef;
 use crate::data_type::cudf_type_to_arrow;
 use crate::{slice_column, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef};
-use arrow::buffer::NullBuffer;
-use arrow::compute::is_null;
+use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_schema::DataType;
 use cxx::UniquePtr;
@@ -162,44 +161,33 @@ impl Array for CuDFColumnView {
     }
 
     fn offset(&self) -> usize {
-        self.inner.offset()
+        self.inner.offset() as usize
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
-        // TODO: This should use FFI to transfer ONLY the null bitmap from GPU,
-        // not the entire column data.
-        // Add column_view_get_null_buffer() to libcudf-sys and call it here.
         self.null_buf
             .get_or_init(|| {
                 if self.null_count() == 0 {
                     return None;
                 }
-                let array_data = self.to_data();
-                array_data.nulls().cloned()
+
+                let null_bytes = self.inner().get_null_buffer();
+                let offset = self.inner().offset() as usize;
+                let length = self.inner().size();
+
+                let buffer = Buffer::from_vec(null_bytes);
+                let boolean_buffer = BooleanBuffer::new(buffer, offset, length);
+                Some(NullBuffer::new(boolean_buffer))
             })
             .as_ref()
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        // TODO: This should use FFI to query cuDF metadata directly instead of
-        // transferring all data from GPU to CPU (no allocation)
-        // Add column_view_get_buffer_memory_size() to libcudf-sys and call it here.
-        let data = self.to_data();
-        data.buffers().iter().map(|b| b.len()).sum()
+        self.inner().get_buffer_memory_size()
     }
 
     fn get_array_memory_size(&self) -> usize {
-        // TODO: This should use FFI to query cuDF metadata directly instead of
-        // transferring all data from GPU to CPU (no allocation).
-        // Add column_view_get_array_memory_size() to libcudf-sys and call it here.
-        let data = self.to_data();
-        let buffer_size: usize = data.buffers().iter().map(|b| b.len()).sum();
-        let null_size = data.nulls().map(|n| n.buffer().len()).unwrap_or(0);
-        let child_size: usize = (0..data.num_children())
-            .filter_map(|i| data.child_data().get(i))
-            .map(|child| child.get_array_memory_size())
-            .sum();
-        buffer_size + null_size + child_size
+        self.inner().get_array_memory_size()
     }
 
     fn logical_nulls(&self) -> Option<NullBuffer> {

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -135,6 +135,7 @@ impl Array for CuDFColumnView {
     }
 
     fn to_data(&self) -> ArrayData {
+        // WARNING: This performs a full GPU to CPU data transfer.
         self.to_arrow_host()
             .expect("Failed to convert GPU column to host Arrow")
             .to_data()

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -35,10 +35,7 @@ use std::sync::Arc;
 /// let sorted = gather(&view, &indices_view)?;
 /// # Ok::<(), libcudf_rs::CuDFError>(())
 /// ```
-pub fn gather(
-    table: &CuDFTableView,
-    gather_map: &CuDFColumnView,
-) -> Result<CuDFTable, CuDFError> {
+pub fn gather(table: &CuDFTableView, gather_map: &CuDFColumnView) -> Result<CuDFTable, CuDFError> {
     let inner = ffi::gather(table.inner(), gather_map.inner())?;
     Ok(CuDFTable::from_inner(inner))
 }


### PR DESCRIPTION
I added the remaining array trait methods for the ColumnView and also worked with ffi 

Pretty fun 😄 

Also, there was some genera `cargo fmt` and `clang` fixes I did

Here is docs I used: [Arrow Array Trait](https://docs.rs/arrow/latest/arrow/array/trait.Array.html), [libcudf Column View](https://docs.rapids.ai/api/libcudf/stable/classcudf_1_1column__view.html)

cc: @gabotechs @notfilippo 