### PR TITLE
Add core array and scalar support

### DIFF
--- a/libcudf-sys/.clangd
+++ b/libcudf-sys/.clangd
@@ -2,7 +2,7 @@
 # This config is scoped to the libcudf-sys directory only
 
 CompileFlags:
-  CompilationDatabase: .
+  CompilationDatabase: ..
   Add:
     - -ferror-limit=0
   Remove:

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -1,12 +1,18 @@
 #include "column.h"
+#include "cudf/null_mask.hpp"
+#include "cudf/types.hpp"
+#include <cuda_runtime_api.h>
 #include "data_type.h"
 #include "scalar.h"
 #include "libcudf-sys/src/lib.rs.h"
 
+#include <cinttypes>
+#include <cstdint>
 #include <cudf/column/column.hpp>
 #include <cudf/interop.hpp>
 #include <cudf/copying.hpp>
 
+#include <memory>
 #include <nanoarrow/nanoarrow.h>
 #include <nanoarrow/nanoarrow_device.h>
 
@@ -18,6 +24,7 @@ namespace libcudf_bridge {
 
     ColumnView::~ColumnView() = default;
 
+    // Get number of elements
     size_t ColumnView::size() const {
         if (!inner) {
             return 0;
@@ -25,16 +32,18 @@ namespace libcudf_bridge {
         return inner->size();
     }
 
+    // Get the column's data as an FFI Arrow Array
     void ColumnView::to_arrow_array(uint8_t *out_array_ptr) const {
         if (!inner) {
             throw std::runtime_error("Cannot convert null column view to arrow array");
         }
         auto device_array_unique = cudf::to_arrow_host(*this->inner);
-        auto *out_array = reinterpret_cast<ArrowDeviceArray *>(out_array_ptr);
+        auto *out_array = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
         *out_array = *device_array_unique.get();
         device_array_unique.release();
     }
 
+    // Get the raw device pointer to the column view's data
     [[nodiscard]] uint64_t ColumnView::data_ptr() const {
         if (!inner) {
             return 0;
@@ -42,6 +51,7 @@ namespace libcudf_bridge {
         return reinterpret_cast<uint64_t>(inner->head());
     }
 
+    // Get the data type of the column view
     [[nodiscard]] std::unique_ptr<DataType> ColumnView::data_type() const {
         if (!inner) {
             throw std::runtime_error("Cannot get data type of null column view");
@@ -58,6 +68,7 @@ namespace libcudf_bridge {
         return std::make_unique<DataType>(type_id);
     }
 
+    // Clone this column view
     [[nodiscard]] std::unique_ptr<ColumnView> ColumnView::clone() const {
         auto cloned = std::make_unique<ColumnView>();
         if (inner) {
@@ -66,7 +77,7 @@ namespace libcudf_bridge {
         return cloned;
     }
 
-    // Gets the current offset in case this column is a slice of another one
+    // Get the offset of the current ColumnView in case it was a slice of another one
     int32_t ColumnView::offset() const {
         if (!inner) {
             throw std::runtime_error("Cannot offset of null column view");
@@ -82,12 +93,98 @@ namespace libcudf_bridge {
         return 0;
     }
 
+    // Helper functions for memory size calculations
+    size_t calculate_buffer_memory_size(const cudf::column_view& view) {
+        // Calculate size based on data type
+        size_t data_size = cudf::size_of(view.type()) * view.size();
+
+        // For strings add offset buffer size
+        if (view.type().id() == cudf::type_id::STRING) {
+            data_size += (view.size() + 1) * sizeof(int32_t);
+        }
+
+        // For nested types recursively add child buffer sizes
+        for (cudf::size_type i = 0; i < view.num_children(); ++i) {
+            data_size += calculate_buffer_memory_size(view.child(i));
+        }
+
+        return data_size;
+    }
+
+    size_t calculate_null_mask_size(const cudf::column_view& view) {
+        size_t size = 0;
+
+        if (view.nullable()) {
+            size += cudf::bitmask_allocation_size_bytes(view.size());
+        }
+
+        for (cudf::size_type i = 0; i < view.num_children(); ++i) {
+            size += calculate_null_mask_size(view.child(i));
+        }
+
+        return size;
+    }
+
+    size_t calculate_array_memory_size(const cudf::column_view& view) {
+        return calculate_buffer_memory_size(view) + calculate_null_mask_size(view);
+    }
+
+    // Get buffer memory size (data + offsets, no null mask)
+    [[nodiscard]] size_t ColumnView::get_buffer_memory_size() const {
+        if (!inner) {
+            return 0;
+        }
+        return calculate_buffer_memory_size(*inner);
+    }
+
+    // Get total array memory size (data + offsets + null mask + children)
+    [[nodiscard]] size_t ColumnView::get_array_memory_size() const {
+        if (!inner) {
+            return 0;
+        }
+        return calculate_array_memory_size(*inner);
+    }
+
+    // Transfer the null buffer
+    [[nodiscard]] rust::Vec<uint8_t> ColumnView::get_null_buffer() const {
+        if (!inner || inner->null_count() == 0) {
+            return rust::Vec<uint8_t>();
+        }
+
+        const auto& view = *inner;
+
+        // Calculate null mask size
+        size_t mask_size = cudf::bitmask_allocation_size_bytes(view.size());
+
+        rust::Vec<uint8_t> host_buffer;
+        host_buffer.reserve(mask_size);
+
+        // Resize to actual size so cudaMemcpy has a valid destination
+        for (size_t i = 0; i < mask_size; ++i) {
+            host_buffer.push_back(0);
+        }
+
+        cudaError_t err = cudaMemcpy(
+            host_buffer.data(),
+            view.null_mask(),
+            mask_size,
+            cudaMemcpyDeviceToHost
+        );
+
+        if (err != cudaSuccess) {
+            throw std::runtime_error(std::string("cudaMemcpy failed: ") + cudaGetErrorString(err));
+        }
+
+        return host_buffer;
+    }
+
     // Column implementation
     Column::Column() : inner(nullptr) {
     }
 
     Column::~Column() = default;
 
+    // Get number of elements
     size_t Column::size() const {
         if (!inner) {
             return 0;
@@ -95,6 +192,7 @@ namespace libcudf_bridge {
         return inner->size();
     }
 
+    // Get the column as a read-only view
     [[nodiscard]] std::unique_ptr<ColumnView> Column::view() const {
         if (!inner) {
             throw std::runtime_error("Cannot get view of null column");
@@ -104,6 +202,7 @@ namespace libcudf_bridge {
         return result;
     }
 
+    // Get the data type of the column
     [[nodiscard]] std::unique_ptr<DataType> Column::data_type() const {
         if (!inner) {
             throw std::runtime_error("Cannot get data type of null column");
@@ -120,7 +219,7 @@ namespace libcudf_bridge {
         return std::make_unique<DataType>(type_id);
     }
 
-    // Helper function to create Column from unique_ptr
+    // Helper function to create Column from unique_ptr<cudf::column>
     Column column_from_unique_ptr(std::unique_ptr<cudf::column> col) {
         Column c;
         c.inner = std::move(col);

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -11,6 +11,11 @@
 namespace libcudf_bridge {
     struct DataType;
 
+    // Helper functions for memory size calculations
+    size_t calculate_buffer_memory_size(const cudf::column_view& view);
+    size_t calculate_null_mask_size(const cudf::column_view& view);
+    size_t calculate_array_memory_size(const cudf::column_view& view);
+
     // Opaque wrapper for cuDF column_view
     struct ColumnView {
         std::unique_ptr<cudf::column_view> inner;
@@ -39,6 +44,15 @@ namespace libcudf_bridge {
 
         // Returns how many nulls this column has
         [[nodiscard]] int32_t null_count() const;
+
+        // Get buffer memory size (data + offsets, no null mask)
+        [[nodiscard]] size_t get_buffer_memory_size() const;
+
+        // Get total array memory size (data + offsets + null mask + children)
+        [[nodiscard]] size_t get_array_memory_size() const;
+
+        // Transfer the null buffer
+        [[nodiscard]] rust::Vec<uint8_t> get_null_buffer() const;
     };
 
     // Opaque wrapper for cuDF column
@@ -76,4 +90,5 @@ namespace libcudf_bridge {
 
     // Extract a scalar from a column at the specified index
     std::unique_ptr<Scalar> get_element(const ColumnView &column, size_t index);
+
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/groupby.cpp
+++ b/libcudf-sys/src/groupby.cpp
@@ -15,6 +15,10 @@ namespace libcudf_bridge {
         return columns.size();
     }
 
+    bool ColumnVectorHelper::is_empty() const {
+        return columns.empty();
+    }
+
     std::unique_ptr<Column> ColumnVectorHelper::release(size_t index) {
         if (index >= columns.size()) {
             throw std::out_of_range("Index out of bounds");
@@ -90,6 +94,10 @@ namespace libcudf_bridge {
 
     size_t GroupByResult::len() const {
         return results.size();
+    }
+
+    bool GroupByResult::is_empty() const {
+        return results.empty();
     }
 
     std::unique_ptr<ColumnVectorHelper> GroupByResult::release_result(size_t index) {

--- a/libcudf-sys/src/groupby.h
+++ b/libcudf-sys/src/groupby.h
@@ -17,6 +17,7 @@ namespace libcudf_bridge {
         ~ColumnVectorHelper();
 
         [[nodiscard]] size_t len() const;
+        [[nodiscard]] bool is_empty() const;
         [[nodiscard]] std::unique_ptr<Column> release(size_t index);
     };
 
@@ -32,6 +33,8 @@ namespace libcudf_bridge {
         [[nodiscard]] std::unique_ptr<Table> release_keys();
 
         [[nodiscard]] size_t len() const;
+
+        [[nodiscard]] bool is_empty() const;
 
         [[nodiscard]] std::unique_ptr<ColumnVectorHelper> release_result(size_t index);
     };

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -3,6 +3,18 @@
 //! This crate provides unsafe bindings to the cuDF C++ library.
 //! For a safe, idiomatic Rust API, use the `libcudf-rs` crate instead.
 
+use arrow::ffi::FFI_ArrowArray;
+
+/// FFI bindings to cuDF C++ library
+///
+/// This is a thin wrapper over cuDF C++ APIs. Safety documentation is provided
+/// at the higher-level `libcudf-rs` wrapper layer where safe APIs are exposed.
+///
+/// The cxx macro generates code that clippy cannot see source documentation for,
+/// so we allow missing_safety_doc here. All safety contracts are documented in:
+/// - The C++ cuDF library headers
+/// - The safe wrapper functions in `libcudf-rs`
+#[allow(clippy::missing_safety_doc)]
 #[cxx::bridge(namespace = "libcudf_bridge")]
 pub mod ffi {
     // Opaque C++ types
@@ -95,6 +107,9 @@ pub mod ffi {
         /// Get the number of columns in the helper
         fn len(self: &ColumnVectorHelper) -> usize;
 
+        /// Check if the helper contains no columns
+        fn is_empty(self: &ColumnVectorHelper) -> bool;
+
         /// Release and take ownership of a column at the specified index
         fn release(self: Pin<&mut ColumnVectorHelper>, index: usize) -> UniquePtr<Column>;
 
@@ -113,6 +128,9 @@ pub mod ffi {
 
         /// Get the number of aggregation requests
         fn len(self: &GroupByResult) -> usize;
+
+        /// Check if there are no aggregation results
+        fn is_empty(self: &GroupByResult) -> bool;
 
         /// Release and take ownership of the aggregation result at the specified index
         fn release_result(
@@ -147,12 +165,24 @@ pub mod ffi {
         fn column(self: &TableView, index: i32) -> UniquePtr<ColumnView>;
 
         /// Get the table view schema as an FFI ArrowSchema
+        ///
+        /// # Safety
+        ///
+        /// `out_schema_ptr` must point to a valid `ArrowSchema`. Caller must release it.
         unsafe fn to_arrow_schema(self: &TableView, out_schema_ptr: *mut u8);
 
         /// Get the table view data as an FFI ArrowArray
+        ///
+        /// # Safety
+        ///
+        /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
         unsafe fn to_arrow_array(self: &TableView, out_array_ptr: *mut u8);
 
         /// Clone this table view
+        ///
+        /// Note: Cannot implement `Clone` trait due to cxx FFI limitations.
+        /// This creates a deep copy of the view structure (not the underlying data).
+        #[allow(clippy::should_implement_trait)]
         fn clone(self: &TableView) -> UniquePtr<TableView>;
 
         // Column methods
@@ -170,6 +200,10 @@ pub mod ffi {
         fn view(self: &Column) -> UniquePtr<ColumnView>;
 
         /// Get the column view data as an FFI ArrowArray
+        ///
+        /// # Safety
+        ///
+        /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
         unsafe fn to_arrow_array(self: &ColumnView, out_array_ptr: *mut u8);
 
         /// Get the raw device pointer to the column view's data
@@ -179,6 +213,10 @@ pub mod ffi {
         fn data_type(self: &ColumnView) -> UniquePtr<DataType>;
 
         /// Clone this column view
+        ///
+        /// Note: Cannot implement `Clone` trait due to cxx FFI limitations.
+        /// This creates a deep copy of the view structure (not the underlying data).
+        #[allow(clippy::should_implement_trait)]
         fn clone(self: &ColumnView) -> UniquePtr<ColumnView>;
 
         /// Get the offset of the current ColumnView in case it was a slice of another one
@@ -186,6 +224,15 @@ pub mod ffi {
 
         /// Get the number of null values in the column
         fn null_count(self: &ColumnView) -> i32;
+
+        /// Get buffer memory size (data + offsets, no null mask)
+        fn get_buffer_memory_size(self: &ColumnView) -> usize;
+
+        /// Get total array memory size (data + offsets + null mask + children)
+        fn get_array_memory_size(self: &ColumnView) -> usize;
+
+        /// Transfer the null buffer
+        fn get_null_buffer(self: &ColumnView) -> Vec<u8>;
 
         // DataType methods
         /// Get the type_id
@@ -195,6 +242,13 @@ pub mod ffi {
         fn scale(self: &DataType) -> i32;
 
         // Scalar methods
+        /// Get the scalar data as an FFI ArrowArray
+        ///
+        /// # Safety
+        ///
+        /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
+        unsafe fn to_arrow_array(self: &Scalar, out_array_ptr: *mut u8);
+
         /// Check if the scalar is valid (not null)
         fn is_valid(self: &Scalar) -> bool;
 
@@ -202,6 +256,10 @@ pub mod ffi {
         fn data_type(self: &Scalar) -> UniquePtr<DataType>;
 
         /// Clone this scalar (deep copy)
+        ///
+        /// Note: Cannot implement `Clone` trait due to cxx FFI limitations.
+        /// This creates a deep copy of the scalar and its data.
+        #[allow(clippy::should_implement_trait)]
         fn clone(self: &Scalar) -> UniquePtr<Scalar>;
 
         // Factory functions
@@ -254,10 +312,7 @@ pub mod ffi {
         ///
         /// Reorders the rows of `source_table` according to the indices in `gather_map`.
         /// The resulting table will have the same number of rows as `gather_map` has elements.
-        fn gather(
-            source_table: &TableView,
-            gather_map: &ColumnView,
-        ) -> Result<UniquePtr<Table>>;
+        fn gather(source_table: &TableView, gather_map: &ColumnView) -> Result<UniquePtr<Table>>;
 
         /// Create a sliced view of a column
         ///
@@ -433,12 +488,20 @@ pub mod ffi {
         // Arrow interop - direct cuDF calls
 
         /// Convert an Arrow DeviceArray to a cuDF table
+        ///
+        /// # Safety
+        ///
+        /// Pointers must be valid Arrow C Data Interface structures.
         unsafe fn table_from_arrow_host(
             schema_ptr: *const u8,
             device_array_ptr: *const u8,
         ) -> Result<UniquePtr<Table>>;
 
         /// Convert an Arrow array to a cuDF column
+        ///
+        /// # Safety
+        ///
+        /// Pointers must be valid Arrow C Data Interface structures.
         unsafe fn column_from_arrow(
             schema_ptr: *const u8,
             array_ptr: *const u8,
@@ -628,6 +691,105 @@ pub struct ArrowDeviceArray {
     pub sync_event: *mut std::ffi::c_void,
     /// Reserved bytes for future expansion
     pub reserved: [i64; 3],
+}
+
+/// Arrow C Device Data Interface device types
+///
+/// These values correspond to the device types defined in the Arrow C Device
+/// Data Interface specification.
+///
+/// See: <https://arrow.apache.org/docs/format/CDeviceDataInterface.html>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum ArrowDeviceType {
+    Cpu = 1,
+    Cuda = 2,
+    CudaHost = 3,
+    OpenCL = 4,
+    Vulkan = 5,
+    Metal = 6,
+    VulkanHost = 7,
+    OpenCLHost = 8,
+    CudaManaged = 9,
+    OneAPI = 10,
+    WebGPU = 11,
+    Hexagon = 12,
+}
+
+impl ArrowDeviceType {
+    /// Device ID for CPU devices (-1 indicates no specific device)
+    pub const CPU_DEVICE_ID: i64 = -1;
+}
+
+impl From<ArrowDeviceType> for i32 {
+    fn from(dt: ArrowDeviceType) -> i32 {
+        dt as i32
+    }
+}
+
+impl ArrowDeviceArray {
+    /// Create a new CPU-resident ArrowDeviceArray
+    ///
+    /// Initializes an empty array structure for CPU (host) memory.
+    /// The device_id is set to -1 (no specific device) and device_type to CPU.
+    pub fn new_cpu() -> Self {
+        Self {
+            array: arrow::ffi::FFI_ArrowArray::empty(),
+            device_id: ArrowDeviceType::CPU_DEVICE_ID,
+            device_type: ArrowDeviceType::Cpu.into(),
+            sync_event: std::ptr::null_mut(),
+            reserved: [0; 3],
+        }
+    }
+
+    /// Create a new CUDA device ArrowDeviceArray
+    ///
+    /// Initializes an empty array structure for CUDA GPU memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `device_id` - The CUDA device ID (0, 1, 2, etc.)
+    pub fn new_cuda(device_id: i64) -> Self {
+        Self {
+            array: arrow::ffi::FFI_ArrowArray::empty(),
+            device_id,
+            device_type: ArrowDeviceType::Cuda.into(),
+            sync_event: std::ptr::null_mut(),
+            reserved: [0; 3],
+        }
+    }
+
+    /// Sets the array field (builder pattern)
+    ///
+    /// # Arguments
+    ///
+    /// * `array` - The Arrow C FFI array structure
+    pub fn with_array(mut self, array: FFI_ArrowArray) -> Self {
+        self.array = array;
+        self
+    }
+
+    /// Sets the sync event field (builder pattern)
+    ///
+    /// # Arguments
+    ///
+    /// * `sync_event` - Pointer to a synchronization event (e.g., CUDA event)
+    pub fn with_sync_event(mut self, sync_event: *mut std::ffi::c_void) -> Self {
+        self.sync_event = sync_event;
+        self
+    }
+
+    /// Sets the device ID field (builder pattern)
+    ///
+    /// Useful for changing the device ID after initial construction.
+    ///
+    /// # Arguments
+    ///
+    /// * `device_id` - The device ID (-1 for CPU, 0+ for GPU devices)
+    pub fn with_device_id(mut self, device_id: i64) -> Self {
+        self.device_id = device_id;
+        self
+    }
 }
 
 // Thread safety implementations for cuDF types
@@ -854,12 +1016,8 @@ mod tests {
         let col2 = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
-        let result = ffi::binary_operation_col_col(
-            &col1,
-            &col2,
-            BinaryOperator::Add as i32,
-            &output_type,
-        )?;
+        let result =
+            ffi::binary_operation_col_col(&col1, &col2, BinaryOperator::Add as i32, &output_type)?;
 
         assert_eq!(result.size(), col1.size());
         assert_eq!(result.size(), col2.size());
@@ -877,12 +1035,8 @@ mod tests {
         let col2 = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
-        let result = ffi::binary_operation_col_col(
-            &col1,
-            &col2,
-            BinaryOperator::Mul as i32,
-            &output_type,
-        )?;
+        let result =
+            ffi::binary_operation_col_col(&col1, &col2, BinaryOperator::Mul as i32, &output_type)?;
 
         assert_eq!(result.size(), col1.size());
         assert_snapshot!(pretty_column(&result.view(), DataType::Float64)?);

--- a/libcudf-sys/src/scalar.cpp
+++ b/libcudf-sys/src/scalar.cpp
@@ -2,8 +2,12 @@
 #include "data_type.h"
 #include "libcudf-sys/src/lib.rs.h"
 
+#include <cudf/interop.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/types.hpp>
+#include <nanoarrow/nanoarrow.h>
+#include <nanoarrow/nanoarrow_device.h>
 #include <stdexcept>
 
 namespace libcudf_bridge {
@@ -13,6 +17,19 @@ namespace libcudf_bridge {
 
     Scalar::~Scalar() = default;
 
+    // Get the scalar's data as an FFI Arrow Array
+    void Scalar::to_arrow_array(uint8_t *out_array_ptr) const {
+        if (!inner) {
+            throw std::runtime_error("Cannot convert null column view to arrow array");
+        }
+        std::unique_ptr<cudf::column> single_element_col = cudf::make_column_from_scalar(*inner, 1);
+        auto device_array_unique = cudf::to_arrow_host(single_element_col->view());
+        auto *out_array = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
+        *out_array = *device_array_unique.get();
+        device_array_unique.release();
+    }
+
+    // Check if the scalar is valid (not null)
     bool Scalar::is_valid() const {
         if (!inner) {
             return false;
@@ -20,6 +37,7 @@ namespace libcudf_bridge {
         return inner->is_valid();
     }
 
+    // Get the data type of the scalar
     [[nodiscard]] std::unique_ptr<DataType> Scalar::data_type() const {
         auto dtype = inner->type();
         auto type_id = static_cast<int32_t>(dtype.id());
@@ -34,6 +52,7 @@ namespace libcudf_bridge {
         }
     }
 
+    // Clone this scalar (deep copy)
     [[nodiscard]] std::unique_ptr<Scalar> Scalar::clone() const {
         auto cloned = std::make_unique<Scalar>();
 

--- a/libcudf-sys/src/scalar.h
+++ b/libcudf-sys/src/scalar.h
@@ -21,6 +21,9 @@ namespace libcudf_bridge {
 
         ~Scalar();
 
+        // Get the scalar's data as an FFI Arrow Array
+        void to_arrow_array(uint8_t *out_array_ptr) const;
+
         // Check if the scalar is valid (not null)
         [[nodiscard]] bool is_valid() const;
 

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -2,13 +2,13 @@ use crate::cudf_reference::CuDFRef;
 use crate::data_type::cudf_type_to_arrow;
 use crate::{slice_column, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef};
-use arrow::buffer::NullBuffer;
-use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
+use arrow::ffi::FFI_ArrowSchema;
 use arrow_schema::DataType;
 use cxx::UniquePtr;
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// A view into a cuDF column stored in GPU memory
 ///
@@ -23,6 +23,7 @@ pub struct CuDFColumnView {
     pub(crate) _ref: Option<Arc<dyn CuDFRef>>,
     inner: UniquePtr<libcudf_sys::ffi::ColumnView>,
     dt: DataType,
+    null_buf: OnceLock<Option<NullBuffer>>,
 }
 
 impl CuDFColumnView {
@@ -36,7 +37,12 @@ impl CuDFColumnView {
         let cudf_dtype = inner.data_type();
         let dt = cudf_type_to_arrow(&cudf_dtype);
         let dt = dt.unwrap_or(DataType::Null);
-        Self { _ref, inner, dt }
+        Self {
+            _ref,
+            inner,
+            dt,
+            null_buf: OnceLock::new(),
+        }
     }
 
     pub(crate) fn inner(&self) -> &UniquePtr<libcudf_sys::ffi::ColumnView> {
@@ -71,13 +77,7 @@ impl CuDFColumnView {
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn to_arrow_host(&self) -> Result<ArrayRef, CuDFError> {
-        let mut device_array = libcudf_sys::ArrowDeviceArray {
-            array: FFI_ArrowArray::empty(),
-            device_id: -1,
-            device_type: 1, // CPU
-            sync_event: std::ptr::null_mut(),
-            reserved: [0; 3],
-        };
+        let mut device_array = libcudf_sys::ArrowDeviceArray::new_cpu();
 
         // Create schema from the column's data type
         let ffi_schema = FFI_ArrowSchema::try_from(self.data_type())?;
@@ -107,6 +107,7 @@ impl Clone for CuDFColumnView {
             _ref: self._ref.clone(),
             inner: cloned_inner,
             dt: self.dt.clone(),
+            null_buf: self.null_buf.clone(),
         }
     }
 }
@@ -128,11 +129,14 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn to_data(&self) -> ArrayData {
-        ArrayData::new_empty(&self.dt)
+        // WARNING: This performs a full GPU to CPU data transfer.
+        self.to_arrow_host()
+            .expect("Failed to convert GPU column to host Arrow")
+            .to_data()
     }
 
     fn into_data(self) -> ArrayData {
-        ArrayData::new_empty(&self.dt)
+        self.to_data()
     }
 
     fn data_type(&self) -> &DataType {
@@ -152,31 +156,50 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn offset(&self) -> usize {
-        todo!()
+        self.inner.offset() as usize
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
-        todo!()
+        self.null_buf
+            .get_or_init(|| {
+                if self.null_count() == 0 {
+                    return None;
+                }
+
+                let null_bytes = self.inner().get_null_buffer();
+                let offset = self.inner().offset() as usize;
+                let length = self.inner().size();
+
+                let buffer = Buffer::from_vec(null_bytes);
+                let boolean_buffer = BooleanBuffer::new(buffer, offset, length);
+                Some(NullBuffer::new(boolean_buffer))
+            })
+            .as_ref()
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        todo!()
+        self.inner().get_buffer_memory_size()
     }
 
     fn get_array_memory_size(&self) -> usize {
-        todo!()
+        self.inner().get_array_memory_size()
     }
 
     fn logical_nulls(&self) -> Option<NullBuffer> {
-        todo!()
+        // TODO: For now only primitive types are supported
+        // In this case logical_nulls == physical_nulls
+        self.nulls().cloned()
     }
 
-    fn is_null(&self, _index: usize) -> bool {
-        todo!()
+    fn is_null(&self, index: usize) -> bool {
+        match self.nulls() {
+            Some(nulls) => nulls.is_null(index),
+            None => false,
+        }
     }
 
-    fn is_valid(&self, _index: usize) -> bool {
-        todo!()
+    fn is_valid(&self, index: usize) -> bool {
+        !self.is_null(index)
     }
 
     fn null_count(&self) -> usize {
@@ -184,11 +207,14 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn logical_null_count(&self) -> usize {
-        todo!()
+        // TODO: For now only primitive types are supported
+        // In this case logical_null_count == physical_null_count
+        self.null_count()
     }
 
     fn is_nullable(&self) -> bool {
-        todo!()
+        // All cuDF columns can potentially have nulls
+        true
     }
 }
 
@@ -199,7 +225,7 @@ mod tests {
     use arrow::array::Int32Array;
 
     #[test]
-    fn test_column_view_clone() {
+    fn test_column_view_clone() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let column = CuDFColumn::from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
@@ -216,10 +242,12 @@ mod tests {
             original_ptr, cloned_ptr,
             "Cloned view should point to the same GPU memory"
         );
+
+        Ok(())
     }
 
     #[test]
-    fn test_multiple_clones() {
+    fn test_multiple_clones() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![10, 20, 30]);
         let column = CuDFColumn::from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
@@ -242,10 +270,12 @@ mod tests {
         drop(column);
         assert_eq!(clone1.inner.data_ptr(), ptr);
         assert_eq!(clone1.len(), 3);
+
+        Ok(())
     }
 
     #[test]
-    fn test_column_data_is_on_gpu() {
+    fn test_column_data_is_on_gpu() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let column = CuDFColumn::from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
@@ -282,5 +312,265 @@ mod tests {
                 panic!("Unexpected memory type: {:?}", attrs.type_);
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_buffer_memory_size_int32() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let size = column.get_buffer_memory_size();
+        assert_eq!(size, 20, "Int32 column should be 20 bytes");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_buffer_memory_size_large() -> Result<(), Box<dyn std::error::Error>> {
+        let data: Vec<i32> = (0..1_000_000).collect();
+        let array = Int32Array::from(data);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let size = column.get_buffer_memory_size();
+        assert_eq!(size, 4_000_000, "1M Int32 elements should be 4MB");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_array_memory_size_no_nulls() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let buffer_size = column.get_buffer_memory_size();
+        let array_size = column.get_array_memory_size();
+
+        // With no nulls, array_size should equal buffer_size
+        assert_eq!(
+            array_size, buffer_size,
+            "Array size should equal buffer size when no nulls"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_array_memory_size_with_nulls() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let buffer_size = column.get_buffer_memory_size();
+        let array_size = column.get_array_memory_size();
+
+        // With nulls -> array_size = buffer_size + null_mask_size
+        assert!(
+            array_size > buffer_size,
+            "Array size should be larger than buffer size when nulls present"
+        );
+
+        let null_overhead = array_size - buffer_size;
+        assert!(
+            (1..=128).contains(&null_overhead),
+            "Null mask overhead should be between 2 and 128 bytes, got {}",
+            null_overhead
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nulls_no_nulls_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls();
+        assert!(nulls.is_none(), "Column with no nulls should return None");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nulls_with_nulls_returns_buffer() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls();
+        assert!(
+            nulls.is_some(),
+            "Column with nulls should return Some(NullBuffer)"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nulls_correct_bit_pattern() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(10), None, Some(30), None, Some(50)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls().expect("Should have null buffer");
+        assert!(nulls.is_valid(0), "Element 0 should be valid (Some(10))");
+        assert!(nulls.is_null(1), "Element 1 should be null");
+        assert!(nulls.is_valid(2), "Element 2 should be valid (Some(30))");
+        assert!(nulls.is_null(3), "Element 3 should be null");
+        assert!(nulls.is_valid(4), "Element 4 should be valid (Some(50))");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nulls_cached_same_reference() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls1 = column.nulls();
+        let nulls2 = column.nulls();
+
+        // Should return references to the same cached NullBuffer
+        assert!(nulls1.is_some());
+        assert!(nulls2.is_some());
+
+        let ptr1 = nulls1.unwrap() as *const _;
+        let ptr2 = nulls2.unwrap() as *const _;
+        assert_eq!(
+            ptr1, ptr2,
+            "Subsequent calls should return same cached buffer"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_null_uses_null_buffer() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        assert!(!column.is_null(0), "Index 0 should not be null");
+        assert!(column.is_null(1), "Index 1 should be null");
+        assert!(!column.is_null(2), "Index 2 should not be null");
+        assert!(column.is_null(3), "Index 3 should be null");
+        assert!(!column.is_null(4), "Index 4 should not be null");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_valid_inverse_of_is_null() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        for i in 0..3 {
+            assert_eq!(
+                column.is_valid(i),
+                !column.is_null(i),
+                "is_valid should be inverse of is_null at index {}",
+                i
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_count_matches_null_buffer() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5), None]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let null_count = column.null_count();
+
+        // Should have 3 nulls (indices 1, 3, 5)
+        assert_eq!(null_count, 3, "Should have 3 nulls");
+
+        let manual_count = (0..column.len()).filter(|&i| column.is_null(i)).count();
+        assert_eq!(
+            null_count, manual_count,
+            "null_count() should match manual count"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nulls_with_large_column() -> Result<(), Box<dyn std::error::Error>> {
+        let data: Vec<Option<i32>> = (0..10_000)
+            .map(|i| if i % 2 == 0 { Some(i) } else { None })
+            .collect();
+        let array = Int32Array::from(data);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let nulls = column.nulls().expect("Should have null buffer");
+
+        // Verify pattern: even indices valid, odd indices null
+        for i in 0..100 {
+            if i % 2 == 0 {
+                assert!(nulls.is_valid(i), "Even index {} should be valid", i);
+            } else {
+                assert!(nulls.is_null(i), "Odd index {} should be null", i);
+            }
+        }
+
+        assert_eq!(column.null_count(), 5_000, "Should have 5,000 nulls");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_logical_nulls_equals_physical_nulls() -> Result<(), Box<dyn std::error::Error>> {
+        // For primitive types, logical_nulls should equal physical nulls
+        let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let column = CuDFColumn::from_arrow_host(&array)
+            .expect("Failed to convert Arrow array to column")
+            .into_view();
+
+        let physical = column.nulls();
+        let logical = column.logical_nulls();
+
+        match (physical, logical) {
+            (Some(p), Some(l)) => {
+                // Both should have same null pattern
+                for i in 0..3 {
+                    assert_eq!(
+                        p.is_null(i),
+                        l.is_null(i),
+                        "Physical and logical nulls should match at index {}",
+                        i
+                    );
+                }
+            }
+            (None, None) => {
+                // Both None is valid
+            }
+            _ => {
+                panic!("Physical and logical nulls should both be Some or both None");
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -35,10 +35,7 @@ use std::sync::Arc;
 /// let sorted = gather(&view, &indices_view)?;
 /// # Ok::<(), libcudf_rs::CuDFError>(())
 /// ```
-pub fn gather(
-    table: &CuDFTableView,
-    gather_map: &CuDFColumnView,
-) -> Result<CuDFTable, CuDFError> {
+pub fn gather(table: &CuDFTableView, gather_map: &CuDFColumnView) -> Result<CuDFTable, CuDFError> {
     let inner = ffi::gather(table.inner(), gather_map.inner())?;
     Ok(CuDFTable::from_inner(inner))
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -6,6 +6,7 @@ use arrow_schema::DataType;
 use cxx::UniquePtr;
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
+use std::sync::{Arc, RwLock};
 
 /// A single value stored in GPU memory
 ///
@@ -15,6 +16,7 @@ use std::fmt::{Debug, Formatter};
 pub struct CuDFScalar {
     inner: UniquePtr<libcudf_sys::ffi::Scalar>,
     dt: DataType,
+    cached_scalar: RwLock<Option<Arc<ArrayData>>>,
 }
 
 impl CuDFScalar {
@@ -23,12 +25,75 @@ impl CuDFScalar {
         let cudf_dtype = inner.data_type();
         let dt = cudf_type_to_arrow(&cudf_dtype);
         let dt = dt.unwrap_or(DataType::Null);
-        Self { inner, dt }
+        let cached_scalar = RwLock::new(None);
+        Self {
+            inner,
+            dt,
+            cached_scalar,
+        }
     }
 
     /// Get a reference to the underlying cuDF scalar
     pub(crate) fn inner(&self) -> &UniquePtr<libcudf_sys::ffi::Scalar> {
         &self.inner
+    }
+
+    /// Convert the cuDF scalar to a single-element Arrow array, copying data from GPU to host
+    ///
+    /// This copies the GPU data back to the CPU and creates an Arrow array containing a single
+    /// element.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The cuDF scalar cannot be converted to Arrow format
+    /// - There is an error copying data from GPU to host
+    /// - There is insufficient memory for the conversion
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use arrow::array::{Array, Int32Array, Scalar};
+    /// use libcudf_rs::CuDFScalar;
+    ///
+    /// // Create a cuDF scalar from an Arrow scalar
+    /// let array = Int32Array::from(vec![42]);
+    /// let scalar = Scalar::new(&array);
+    /// let cudf_scalar = CuDFScalar::from_arrow_host(scalar)?;
+    ///
+    /// // Convert back to Arrow (GPU → CPU)
+    /// let arrow_array = cudf_scalar.to_arrow_host()?;
+    ///
+    /// // Verify the result
+    /// assert_eq!(arrow_array.len(), 1);
+    /// assert_eq!(arrow_array.null_count(), 0);
+    ///
+    /// // Downcast to specific type and get value
+    /// let int32_array = arrow_array
+    ///     .as_any()
+    ///     .downcast_ref::<Int32Array>()
+    ///     .expect("Expected Int32Array");
+    /// assert_eq!(int32_array.value(0), 42);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
+    /// ```
+    pub fn to_arrow_host(&self) -> Result<ArrayRef, CuDFError> {
+        let mut device_array = libcudf_sys::ArrowDeviceArray::new_cpu();
+
+        // Convert the scalar to Arrow format (copying from GPU to host)
+        // cuDF's to_arrow_array expects an ArrowDeviceArray pointer
+        unsafe {
+            let device_array_ptr =
+                &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
+            self.inner.to_arrow_array(device_array_ptr);
+        }
+
+        // Convert from FFI structures to Arrow ArrayData
+        // Extract just the ArrowArray part
+        let array_data =
+            unsafe { arrow::ffi::from_ffi_and_data_type(device_array.array, self.dt.clone())? };
+
+        // Create an ArrayRef from the ArrayData
+        Ok(arrow::array::make_array(array_data))
     }
 
     /// Convert an Arrow scalar to a cuDF scalar
@@ -65,6 +130,54 @@ impl CuDFScalar {
 
         Ok(Self::new(cudf_scalar))
     }
+
+    /// Get or compute the cached ArrayData for this scalar
+    ///
+    /// This method lazily converts the GPU scalar to CPU ArrayData and caches the results. This
+    /// avoids subsequent calls performing more expensive GPU->CPU transfer by returning the cached
+    /// data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The scalar cannot be converted to Arrow format
+    /// - There is insufficient memory for the conversion
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use arrow::array::{Int32Array, Scalar};
+    /// use libcudf_rs::CuDFScalar;
+    ///
+    /// let array = Int32Array::from(vec![42]);
+    /// let scalar = Scalar::new(&array);
+    /// let cudf_scalar = CuDFScalar::from_arrow_host(scalar)?;
+    ///
+    /// // First call: converts GPU -> CPU and caches
+    /// let data1 = cudf_scalar.get_scalar_data()?;
+    ///
+    /// // Second call: returns cached data
+    /// let data2 = cudf_scalar.get_scalar_data()?;
+    ///
+    /// assert_eq!(data1.len(), 1);
+    /// assert_eq!(data2.len(), 1);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
+    /// ```
+    pub fn get_scalar_data(&self) -> Result<Arc<ArrayData>, CuDFError> {
+        if let Ok(cache) = self.cached_scalar.read() {
+            if let Some(cached_data) = cache.as_ref() {
+                return Ok(Arc::clone(cached_data));
+            }
+        }
+
+        let array_ref = self.to_arrow_host()?;
+        let array_data = Arc::new(array_ref.to_data());
+        if let Ok(mut cache) = self.cached_scalar.write() {
+            *cache = Some(Arc::clone(&array_data));
+        }
+
+        Ok(array_data)
+    }
 }
 
 impl Debug for CuDFScalar {
@@ -75,7 +188,11 @@ impl Debug for CuDFScalar {
 
 impl Clone for CuDFScalar {
     fn clone(&self) -> Self {
-        Self::new(self.inner.clone())
+        Self {
+            inner: self.inner.clone(),
+            dt: self.dt.clone(),
+            cached_scalar: RwLock::new(None),
+        }
     }
 }
 
@@ -85,19 +202,30 @@ unsafe impl Array for CuDFScalar {
     }
 
     fn to_data(&self) -> ArrayData {
-        ArrayData::new_empty(&self.dt)
+        // WARNING: This performs a full GPU to CPU data transfer.
+        self.to_arrow_host()
+            .expect("Failed to convert GPU scalar to host Arrow")
+            .to_data()
     }
 
     fn into_data(self) -> ArrayData {
-        ArrayData::new_empty(&self.dt)
+        self.to_data()
     }
 
     fn data_type(&self) -> &DataType {
         &self.dt
     }
 
-    fn slice(&self, _offset: usize, _length: usize) -> ArrayRef {
-        todo!()
+    fn slice(&self, offset: usize, length: usize) -> ArrayRef {
+        if offset >= 1 || length == 0 {
+            arrow::array::new_empty_array(&self.dt)
+        } else {
+            Arc::new(Self {
+                inner: self.inner.clone(),
+                dt: self.dt.clone(),
+                cached_scalar: RwLock::new(None),
+            })
+        }
     }
 
     fn len(&self) -> usize {
@@ -113,15 +241,20 @@ unsafe impl Array for CuDFScalar {
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
-        todo!()
+        None
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        todo!()
+        self.get_scalar_data()
+            .map(|data| data.get_buffer_memory_size())
+            .unwrap_or(0)
     }
 
     fn get_array_memory_size(&self) -> usize {
-        todo!()
+        // Array memory = buffer memory + null bitmap
+        self.get_scalar_data()
+            .map(|data| data.get_array_memory_size())
+            .unwrap_or(0)
     }
 }
 
@@ -130,65 +263,505 @@ mod tests {
     use super::*;
     use arrow::array::*;
 
+    /// Assert Array trait basic properties
+    fn assert_array_trait_basics(scalar: &CuDFScalar, expected_type: &DataType) {
+        assert_eq!(scalar.len(), 1, "Scalar length should always be 1");
+        assert!(!scalar.is_empty(), "Scalar should never be empty");
+        assert_eq!(scalar.offset(), 0, "Scalar offset should always be 0");
+        assert_eq!(scalar.data_type(), expected_type, "Data type mismatch");
+        assert!(
+            scalar.nulls().is_none(),
+            "nulls() should return None for scalars"
+        );
+    }
+
+    /// Test comprehensive slice behavior for a scalar
+    fn assert_slice_behavior(scalar: &CuDFScalar) {
+        let dt = scalar.data_type();
+
+        // slice(0, 1) -> returns self
+        let sliced = scalar.slice(0, 1);
+        assert_eq!(sliced.len(), 1, "slice(0, 1) should return self");
+        assert_eq!(sliced.data_type(), dt, "slice(0, 1) should preserve type");
+
+        // slice(0, 0) -> returns empty
+        let empty = scalar.slice(0, 0);
+        assert_eq!(empty.len(), 0, "slice(0, 0) should return empty array");
+        assert_eq!(empty.data_type(), dt, "Empty slice should preserve type");
+
+        // slice(1, 1) -> returns empty (offset beyond bounds)
+        let oob = scalar.slice(1, 1);
+        assert_eq!(oob.len(), 0, "slice(1, 1) should return empty array");
+
+        // slice(5, 10) -> returns empty (way out of bounds)
+        let far_oob = scalar.slice(5, 10);
+        assert_eq!(far_oob.len(), 0, "slice(5, 10) should return empty array");
+
+        // slice(0, 100) -> returns self (length clamped)
+        let oversized = scalar.slice(0, 100);
+        assert_eq!(
+            oversized.len(),
+            1,
+            "slice(0, 100) should return self (clamped)"
+        );
+    }
+
+    /// Verify slice clears cache
+    fn assert_slice_clears_cache(scalar: &CuDFScalar) {
+        // First call to populate cache
+        let _ = scalar.get_buffer_memory_size();
+
+        // Slice creates new instance
+        let sliced = scalar.slice(0, 1);
+
+        // Both scalars should still work independently
+        assert!(scalar.get_buffer_memory_size() > 0);
+        assert!(sliced.get_buffer_memory_size() > 0);
+    }
+
+    /// Assert memory size for a scalar
+    fn assert_memory_size(scalar: &CuDFScalar, expected_buffer_size: usize, type_name: &str) {
+        let buffer_size = scalar.get_buffer_memory_size();
+        let array_size = scalar.get_array_memory_size();
+
+        assert_eq!(
+            buffer_size, expected_buffer_size,
+            "Buffer size mismatch for {}",
+            type_name
+        );
+
+        // Array size should include null bitmap overhead
+        assert!(
+            array_size >= buffer_size,
+            "Array size ({}) should be >= buffer size ({})",
+            array_size,
+            buffer_size
+        );
+    }
+
     #[test]
-    fn test_from_arrow_host_int32() {
+    fn test_to_arrow_host_int32() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![42]);
-        let scalar = Scalar::new(&array);
-        let cudf_scalar =
-            CuDFScalar::from_arrow_host(scalar).expect("Failed to convert Arrow scalar to cuDF");
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let result = cudf_scalar.to_arrow_host()?;
 
-        assert_eq!(cudf_scalar.data_type(), &DataType::Int32);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), &DataType::Int32);
+        let result_array = result.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(result_array.value(0), 42);
+
+        Ok(())
     }
 
     #[test]
-    fn test_from_arrow_host_int64() {
-        let array = Int64Array::from(vec![12345]);
-        let scalar = Scalar::new(&array);
-        let cudf_scalar =
-            CuDFScalar::from_arrow_host(scalar).expect("Failed to convert Arrow scalar to cuDF");
+    fn test_to_arrow_host_int64() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int64Array::from(vec![12345_i64]);
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let result = cudf_scalar.to_arrow_host()?;
 
-        assert_eq!(cudf_scalar.data_type(), &DataType::Int64);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), &DataType::Int64);
+        let result_array = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(result_array.value(0), 12345);
+
+        Ok(())
     }
 
     #[test]
-    fn test_from_arrow_host_float64() {
+    fn test_to_arrow_host_float64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Float64Array::from(vec![std::f64::consts::PI]);
-        let scalar = Scalar::new(&array);
-        let cudf_scalar =
-            CuDFScalar::from_arrow_host(scalar).expect("Failed to convert Arrow scalar to cuDF");
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let result = cudf_scalar.to_arrow_host()?;
 
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), &DataType::Float64);
+        let result_array = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert_eq!(result_array.value(0), std::f64::consts::PI);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_arrow_host_boolean() -> Result<(), Box<dyn std::error::Error>> {
+        let array = BooleanArray::from(vec![true]);
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let result = cudf_scalar.to_arrow_host()?;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), &DataType::Boolean);
+        let result_array = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert!(result_array.value(0));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_arrow_host_string() -> Result<(), Box<dyn std::error::Error>> {
+        let array = StringArray::from(vec!["hello world"]);
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let result = cudf_scalar.to_arrow_host()?;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), &DataType::Utf8);
+        let result_array = result.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(result_array.value(0), "hello world");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_slice_behavior_int32() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        assert_slice_behavior(&scalar);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_slice_behavior_float64() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+            std::f64::consts::PI,
+        ])))
+        .expect("Failed to create scalar");
+        assert_slice_behavior(&scalar);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_slice_behavior_string() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
+            .expect("Failed to create scalar");
+        assert_slice_behavior(&scalar);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_slice_behavior_null() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+            .expect("Failed to create scalar");
+        assert_slice_behavior(&scalar);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_slice_clears_cache() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![999])))
+            .expect("Failed to create scalar");
+        assert_slice_clears_cache(&scalar);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_basics_int32() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        assert_array_trait_basics(&scalar, &DataType::Int32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_basics_string() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
+            .expect("Failed to create scalar");
+        assert_array_trait_basics(&scalar, &DataType::Utf8);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_basics_boolean() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&BooleanArray::from(vec![true])))
+            .expect("Failed to create scalar");
+        assert_array_trait_basics(&scalar, &DataType::Boolean);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_trait_basics_null() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+            .expect("Failed to create scalar");
+        assert_array_trait_basics(&scalar, &DataType::Int32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_any_downcast() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        assert!(scalar.as_any().downcast_ref::<CuDFScalar>().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_caching_works_int32() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        let size1 = scalar.get_buffer_memory_size();
+        let size2 = scalar.get_buffer_memory_size();
+        assert_eq!(size1, size2, "Cached and uncached sizes should match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_caching_works_string() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["cached"])))
+            .expect("Failed to create scalar");
+        let size1 = scalar.get_buffer_memory_size();
+        let size2 = scalar.get_buffer_memory_size();
+        assert_eq!(size1, size2, "Cached and uncached sizes should match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_caching_memory_sizes() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
+            .expect("Failed to create scalar");
+
+        // Buffer size caching
+        let size1 = scalar.get_buffer_memory_size();
+        assert!(size1 > 0, "Buffer size should be positive");
+        let size2 = scalar.get_buffer_memory_size();
+        assert_eq!(size1, size2, "Cached buffer size should match");
+
+        // Array size caching
+        let array_size1 = scalar.get_array_memory_size();
+        assert!(array_size1 > 0, "Array size should be positive");
+        let array_size2 = scalar.get_array_memory_size();
+        assert_eq!(array_size1, array_size2, "Cached array size should match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_caching_clone_clears_cache() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+
+        // Populate cache
+        let _ = scalar.get_buffer_memory_size();
+
+        // Clone should have empty cache
+        let cloned = scalar.clone();
+
+        assert!(scalar.get_buffer_memory_size() > 0);
+        assert!(cloned.get_buffer_memory_size() > 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_caching_slice_clears_cache() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+
+        // Populate original cache
+        let original_size = scalar.get_buffer_memory_size();
+
+        // Slice creates new instance with empty cache
+        let sliced = scalar.slice(0, 1);
+        let sliced_size = sliced.get_buffer_memory_size();
+
+        // Both should have same size but independent caches
+        assert_eq!(original_size, sliced_size);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_memory_size() -> Result<(), Box<dyn std::error::Error>> {
+        let int32_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        assert_memory_size(&int32_scalar, 4, "Int32");
+
+        let int64_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
+            .expect("Failed to create scalar");
+        assert_memory_size(&int64_scalar, 8, "Int64");
+
+        let float_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+            std::f64::consts::PI,
+        ])))
+        .expect("Failed to create scalar");
+        assert_memory_size(&float_scalar, 8, "Float64");
+
+        let bool_scalar = CuDFScalar::from_arrow_host(Scalar::new(&BooleanArray::from(vec![true])))
+            .expect("Failed to create scalar");
+        let buffer_size = bool_scalar.get_buffer_memory_size();
+        let array_size = bool_scalar.get_array_memory_size();
+        assert!(buffer_size > 0, "Boolean buffer size should be positive");
+        assert!(
+            array_size >= buffer_size,
+            "Array size should be >= buffer size"
+        );
+
+        let test_string = "hello world";
+        let string_scalar =
+            CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec![test_string])))
+                .expect("Failed to create scalar");
+        let buffer_size = string_scalar.get_buffer_memory_size();
+        let array_size = string_scalar.get_array_memory_size();
+        // For strings, size should be at least the string length
+        assert!(
+            buffer_size >= test_string.len(),
+            "Buffer size should be at least string length"
+        );
+        assert!(array_size >= buffer_size);
+
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+            .expect("Failed to create scalar");
+        let buffer_size = scalar.get_buffer_memory_size();
+        let array_size = scalar.get_array_memory_size();
+        // Null scalar should still have some memory overhead
+        assert!(
+            array_size >= buffer_size,
+            "Array size should be >= buffer size"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_handling() -> Result<(), Box<dyn std::error::Error>> {
+        let null_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+            .expect("Failed to create scalar");
+        assert!(!null_scalar.inner().is_valid(), "Scalar should be null");
+
+        let valid_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        assert!(valid_scalar.inner().is_valid(), "Scalar should be valid");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_scalar_to_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))?;
+        let result = scalar.to_arrow_host()?;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), &DataType::Int32);
+        assert_eq!(
+            result.null_count(),
+            1,
+            "Null scalar should have null_count = 1"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_data_conversions() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+
+        let data = scalar.to_data();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data.data_type(), &DataType::Int32);
+
+        let scalar2 = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        let data2 = scalar2.into_data();
+        assert_eq!(data2.len(), 1);
+        assert_eq!(data2.data_type(), &DataType::Int32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_data_type_preserved_int32() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to create scalar");
+        assert_eq!(scalar.data_type(), &DataType::Int32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_data_type_preserved_float64() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+            std::f64::consts::PI,
+        ])))
+        .expect("Failed to create scalar");
+        assert_eq!(scalar.data_type(), &DataType::Float64);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_data_type_preserved_string() -> Result<(), Box<dyn std::error::Error>> {
+        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
+            .expect("Failed to create scalar");
+        assert_eq!(scalar.data_type(), &DataType::Utf8);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_host_int32() -> Result<(), Box<dyn std::error::Error>> {
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+            .expect("Failed to convert Int32");
+        assert_eq!(cudf_scalar.data_type(), &DataType::Int32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_host_int64() -> Result<(), Box<dyn std::error::Error>> {
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
+            .expect("Failed to convert Int64");
+        assert_eq!(cudf_scalar.data_type(), &DataType::Int64);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_host_float64() -> Result<(), Box<dyn std::error::Error>> {
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+            std::f64::consts::PI,
+        ])))
+        .expect("Failed to convert Float64");
         assert_eq!(cudf_scalar.data_type(), &DataType::Float64);
+
+        Ok(())
     }
 
     #[test]
-    fn test_from_arrow_host_string() {
-        let array = StringArray::from(vec!["hello"]);
-        let scalar = Scalar::new(&array);
-        let cudf_scalar = CuDFScalar::from_arrow_host(scalar)
-            .expect("Failed to convert Arrow string scalar to cuDF");
-
+    fn test_from_arrow_host_string() -> Result<(), Box<dyn std::error::Error>> {
+        let cudf_scalar =
+            CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["hello"])))
+                .expect("Failed to convert String");
         assert_eq!(cudf_scalar.data_type(), &DataType::Utf8);
+
+        Ok(())
     }
 
     #[test]
-    fn test_from_arrow_host_null() {
-        let array = Int32Array::from(vec![None]);
-        let scalar = Scalar::new(&array);
-        let cudf_scalar = CuDFScalar::from_arrow_host(scalar)
-            .expect("Failed to convert null Arrow scalar to cuDF");
-
+    fn test_from_arrow_host_null() -> Result<(), Box<dyn std::error::Error>> {
+        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+            .expect("Failed to convert null");
         assert_eq!(cudf_scalar.data_type(), &DataType::Int32);
         assert!(!cudf_scalar.inner().is_valid());
+
+        Ok(())
     }
 
     #[test]
-    fn test_from_arrow_host_clone() {
-        let array = Int32Array::from(vec![999]);
-        let scalar = Scalar::new(&array);
-        let cudf_scalar =
-            CuDFScalar::from_arrow_host(scalar).expect("Failed to convert Arrow scalar to cuDF");
+    fn test_scalar_clone() -> Result<(), Box<dyn std::error::Error>> {
+        let original = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![999])))
+            .expect("Failed to create scalar");
+        let cloned = original.clone();
+        assert_eq!(cloned.data_type(), original.data_type());
 
-        let cloned = cudf_scalar.clone();
-        assert_eq!(cloned.data_type(), cudf_scalar.data_type());
+        Ok(())
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -145,13 +145,7 @@ impl CuDFTable {
         let ffi_array = FFI_ArrowArray::new(&array_data);
         let ffi_schema = FFI_ArrowSchema::try_from(schema)?;
 
-        let device_array = ArrowDeviceArray {
-            array: ffi_array,
-            device_id: -1,
-            device_type: 1, // CPU
-            sync_event: std::ptr::null_mut(),
-            reserved: [0; 3],
-        };
+        let device_array = ArrowDeviceArray::new_cpu().with_array(ffi_array);
 
         let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;


### PR DESCRIPTION
## Summary

It adds the core Arrow `Array` behavior and scalar plumbing needed by later aggregation and DataFusion work:

- complete more of `CuDFColumnView`'s `Array` implementation, including offsets, null buffers, validity checks, memory sizing, and host conversion through Arrow device arrays
- add the matching thin `libcudf-sys` FFI for column/scalar cloning, memory sizing, null mask access, and scalar conversion
- add root `CuDFScalar` host conversion and `Array` behavior
- keep upstream dependency versions intact; this PR does not change `Cargo.toml` or `Cargo.lock`

## Validation

- `cargo fmt --all`
- `git diff --cached --check`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p libcudf-rs --locked`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-rs --lib --locked` (`72 passed`)
