### PR TITLE
Add aggregation and cast primitives

### DIFF
--- a/libcudf-sys/src/aggregation.cpp
+++ b/libcudf-sys/src/aggregation.cpp
@@ -39,6 +39,30 @@ namespace libcudf_bridge {
         return result;
     }
 
+    std::unique_ptr<Aggregation> make_variance_aggregation(int32_t ddof) {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_variance_aggregation<cudf::reduce_aggregation>(ddof);
+        return result;
+    }
+
+    std::unique_ptr<Aggregation> make_std_aggregation(int32_t ddof) {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_std_aggregation<cudf::reduce_aggregation>(ddof);
+        return result;
+    }
+
+    std::unique_ptr<Aggregation> make_nunique_aggregation() {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_nunique_aggregation<cudf::reduce_aggregation>();
+        return result;
+    }
+
+    std::unique_ptr<Aggregation> make_median_aggregation() {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_median_aggregation<cudf::reduce_aggregation>();
+        return result;
+    }
+
     // Aggregation factory functions - direct cuDF mappings (for groupby)
     std::unique_ptr<Aggregation> make_sum_aggregation_groupby() {
         auto result = std::make_unique<Aggregation>();
@@ -69,6 +93,31 @@ namespace libcudf_bridge {
         result->inner = cudf::make_count_aggregation<cudf::groupby_aggregation>();
         return result;
     }
+
+    std::unique_ptr<Aggregation> make_variance_aggregation_groupby(int32_t ddof) {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_variance_aggregation<cudf::groupby_aggregation>(ddof);
+        return result;
+    }
+
+    std::unique_ptr<Aggregation> make_std_aggregation_groupby(int32_t ddof) {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_std_aggregation<cudf::groupby_aggregation>(ddof);
+        return result;
+    }
+
+    std::unique_ptr<Aggregation> make_nunique_aggregation_groupby() {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
+        return result;
+    }
+
+    std::unique_ptr<Aggregation> make_median_aggregation_groupby() {
+        auto result = std::make_unique<Aggregation>();
+        result->inner = cudf::make_median_aggregation<cudf::groupby_aggregation>();
+        return result;
+    }
+
 
     // Reduction - direct cuDF mapping
     std::unique_ptr<Scalar> reduce(const Column &col, const Aggregation &agg, int32_t output_type_id) {

--- a/libcudf-sys/src/aggregation.h
+++ b/libcudf-sys/src/aggregation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include "rust/cxx.h"
 #include "column.h"
@@ -22,6 +23,10 @@ namespace libcudf_bridge {
     std::unique_ptr<Aggregation> make_max_aggregation();
     std::unique_ptr<Aggregation> make_mean_aggregation();
     std::unique_ptr<Aggregation> make_count_aggregation();
+    std::unique_ptr<Aggregation> make_variance_aggregation(int32_t ddof);
+    std::unique_ptr<Aggregation> make_std_aggregation(int32_t ddof);
+    std::unique_ptr<Aggregation> make_nunique_aggregation();
+    std::unique_ptr<Aggregation> make_median_aggregation();
 
     // Aggregation factory functions - direct cuDF mappings (for groupby)
     std::unique_ptr<Aggregation> make_sum_aggregation_groupby();
@@ -29,6 +34,10 @@ namespace libcudf_bridge {
     std::unique_ptr<Aggregation> make_max_aggregation_groupby();
     std::unique_ptr<Aggregation> make_mean_aggregation_groupby();
     std::unique_ptr<Aggregation> make_count_aggregation_groupby();
+    std::unique_ptr<Aggregation> make_variance_aggregation_groupby(int32_t ddof);
+    std::unique_ptr<Aggregation> make_std_aggregation_groupby(int32_t ddof);
+    std::unique_ptr<Aggregation> make_nunique_aggregation_groupby();
+    std::unique_ptr<Aggregation> make_median_aggregation_groupby();
 
     // Reduction - direct cuDF mapping
     std::unique_ptr<Scalar> reduce(const Column &col, const Aggregation &agg, int32_t output_type_id);

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -11,6 +11,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/interop.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/unary.hpp>
 
 #include <memory>
 #include <nanoarrow/nanoarrow.h>
@@ -224,6 +225,16 @@ namespace libcudf_bridge {
         Column c;
         c.inner = std::move(col);
         return c;
+    }
+
+    // Cast a column to a different data type
+    std::unique_ptr<Column> cast_column(const ColumnView &input, const DataType &target_type) {
+        if (!input.inner) {
+            throw std::runtime_error("Cannot cast null column view");
+        }
+        auto result = std::make_unique<Column>();
+        result->inner = cudf::cast(*input.inner, target_type.inner);
+        return result;
     }
 
     // Extract a scalar from a column at the specified index

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -91,4 +91,7 @@ namespace libcudf_bridge {
     // Extract a scalar from a column at the specified index
     std::unique_ptr<Scalar> get_element(const ColumnView &column, size_t index);
 
+    // Cast a column to a different data type
+    std::unique_ptr<Column> cast_column(const ColumnView &input, const DataType &target_type);
+
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -443,6 +443,18 @@ pub mod ffi {
         /// Create a COUNT aggregation
         fn make_count_aggregation() -> UniquePtr<Aggregation>;
 
+        /// Create a VARIANCE aggregation
+        fn make_variance_aggregation(ddof: i32) -> UniquePtr<Aggregation>;
+
+        /// Create a STD aggregation
+        fn make_std_aggregation(ddof: i32) -> UniquePtr<Aggregation>;
+
+        /// Create a NUNIQUE aggregation
+        fn make_nunique_aggregation() -> UniquePtr<Aggregation>;
+
+        /// Create a MEDIAN aggregation
+        fn make_median_aggregation() -> UniquePtr<Aggregation>;
+
         // Aggregation factory functions - direct cuDF mappings (for groupby)
 
         /// Create a SUM aggregation for groupby operations
@@ -459,6 +471,18 @@ pub mod ffi {
 
         /// Create a COUNT aggregation for groupby operations
         fn make_count_aggregation_groupby() -> UniquePtr<Aggregation>;
+
+        /// Create a VARIANCE aggregation for groupby operations
+        fn make_variance_aggregation_groupby(ddof: i32) -> UniquePtr<Aggregation>;
+
+        /// Create a STD aggregation for groupby operations
+        fn make_std_aggregation_groupby(ddof: i32) -> UniquePtr<Aggregation>;
+
+        /// Create a NUNIQUE aggregation for groupby operations
+        fn make_nunique_aggregation_groupby() -> UniquePtr<Aggregation>;
+
+        /// Create a MEDIAN aggregation for groupby operations
+        fn make_median_aggregation_groupby() -> UniquePtr<Aggregation>;
 
         // Reduction - direct cuDF mapping
 
@@ -506,6 +530,9 @@ pub mod ffi {
             schema_ptr: *const u8,
             array_ptr: *const u8,
         ) -> Result<UniquePtr<Column>>;
+
+        /// Cast a column to a different data type using GPU-native cudf::cast
+        fn cast_column(input: &ColumnView, target_type: &DataType) -> Result<UniquePtr<Column>>;
 
         /// Extract a scalar from a column at the specified index
         fn get_element(column: &ColumnView, index: usize) -> UniquePtr<Scalar>;

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -3,10 +3,11 @@ use crate::errors::Result;
 use crate::table_view::CuDFTableView;
 use crate::{CuDFColumn, CuDFColumnView, CuDFTable};
 use cxx::UniquePtr;
-use libcudf_sys::ffi;
 use libcudf_sys::ffi::{
-    aggregation_request_create, make_count_aggregation_groupby, make_max_aggregation_groupby,
-    make_mean_aggregation_groupby, make_min_aggregation_groupby, make_sum_aggregation_groupby,
+    self, aggregation_request_create, make_count_aggregation_groupby, make_max_aggregation_groupby,
+    make_mean_aggregation_groupby, make_median_aggregation_groupby, make_min_aggregation_groupby,
+    make_nunique_aggregation_groupby, make_std_aggregation_groupby, make_sum_aggregation_groupby,
+    make_variance_aggregation_groupby,
 };
 use std::sync::Arc;
 
@@ -127,8 +128,22 @@ pub enum AggregationOp {
     MAX,
     /// Arithmetic mean
     MEAN,
-    /// Count of values
+    /// Count of non-null values
     COUNT,
+    /// Variance with delta degrees of freedom
+    ///
+    /// - `ddof = 0`: Population std dev
+    /// - `ddof = 1`: Sample std dev
+    VARIANCE { ddof: i32 },
+    /// Standard deviation with delta degrees of freedom
+    ///
+    /// - `ddof = 0`: Population std dev
+    /// - `ddof = 1`: Sample std dev
+    STD { ddof: i32 },
+    /// Count of distinct, non-null values
+    NUNIQUE,
+    /// Median value
+    MEDIAN,
 }
 
 impl AggregationOp {
@@ -150,6 +165,203 @@ impl AggregationOp {
             MAX => Aggregation::new(make_max_aggregation_groupby()),
             MEAN => Aggregation::new(make_mean_aggregation_groupby()),
             COUNT => Aggregation::new(make_count_aggregation_groupby()),
+            VARIANCE { ddof } => Aggregation::new(make_variance_aggregation_groupby(*ddof)),
+            STD { ddof } => Aggregation::new(make_std_aggregation_groupby(*ddof)),
+            NUNIQUE => Aggregation::new(make_nunique_aggregation_groupby()),
+            MEDIAN => Aggregation::new(make_median_aggregation_groupby()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{make_array, Array, Float64Array, Int32Array, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_sum_integers() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // SUM([1, 2, 3, 4, 5]) = 15
+        let values = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let result = run_single_group_agg::<Int64Array>(&values, AggregationOp::SUM)?;
+        assert_eq!(result.value(0), 15);
+        Ok(())
+    }
+
+    #[test]
+    fn test_sum_with_nulls() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // SUM([1, NULL, 3, NULL, 5]) = 9
+        let values = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let result = run_single_group_agg::<Int64Array>(&values, AggregationOp::SUM)?;
+        assert_eq!(result.value(0), 9);
+        Ok(())
+    }
+
+    #[test]
+    fn test_min() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // MIN([5, 2, 8, 1, 9]) = 1
+        let values = Int32Array::from(vec![5, 2, 8, 1, 9]);
+        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::MIN)?;
+        assert_eq!(result.value(0), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_max() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // MAX([5, 2, 8, 1, 9]) = 9
+        let values = Int32Array::from(vec![5, 2, 8, 1, 9]);
+        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::MAX)?;
+        assert_eq!(result.value(0), 9);
+        Ok(())
+    }
+
+    #[test]
+    fn test_mean() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // MEAN([10, 20, 30, 40, 50]) = 30
+        let values = Float64Array::from(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        let result = run_single_group_agg::<Float64Array>(&values, AggregationOp::MEAN)?;
+        assert!((result.value(0) - 30.0).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn test_count() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // COUNT([1, 2, 3, 4, 5]) = 5
+        let values = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::COUNT)?;
+        assert_eq!(result.value(0), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn test_count_excludes_nulls() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // COUNT([1, NULL, 3, NULL, 5]) = 3
+        let values = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::COUNT)?;
+        assert_eq!(result.value(0), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_variance_sample() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // VARIANCE([1, 2, 3, 4, 5]) with ddof=1 = 2.5
+        let values = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+        let result =
+            run_single_group_agg::<Float64Array>(&values, AggregationOp::VARIANCE { ddof: 1 })?;
+        assert!((result.value(0) - 2.5).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn test_std_sample() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // STD([1, 2, 3, 4, 5]) with ddof=1 = sqrt(2.5)
+        let values = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+        let result = run_single_group_agg::<Float64Array>(&values, AggregationOp::STD { ddof: 1 })?;
+        let expected = (2.5_f64).sqrt();
+        assert!((result.value(0) - expected).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn test_nunique() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // NUNIQUE([1, 2, 2, 3, 3, 3]) = 3
+        let values = Int32Array::from(vec![1, 2, 2, 3, 3, 3]);
+        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::NUNIQUE)?;
+        assert_eq!(result.value(0), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_median() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // MEDIAN([1, 2, 3, 4, 5]) = 3
+        let values = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let result = run_single_group_agg::<Float64Array>(&values, AggregationOp::MEDIAN)?;
+        assert!((result.value(0) - 3.0).abs() < 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_groups() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // Group 1: [1, 2, 3] sums to 6.
+        // Group 2: [10, 20] sums to 30.
+        let values = Int32Array::from(vec![1, 2, 3, 10, 20]);
+        let keys = Int32Array::from(vec![1, 1, 1, 2, 2]);
+
+        let values_col = CuDFColumn::from_arrow_host(&values)?;
+        let schema = Arc::new(Schema::new(vec![Field::new("key", DataType::Int32, false)]));
+        let keys_batch = RecordBatch::try_new(schema, vec![Arc::new(keys)])?;
+        let keys_table = CuDFTable::from_arrow_host(keys_batch)?;
+        let groupby = CuDFGroupBy::from_table_view(keys_table.into_view());
+
+        let mut request = AggregationRequest::from_column_view(values_col.into_view());
+        request.add(AggregationOp::SUM.group_by());
+
+        let (result_keys, results) = groupby.aggregate(&[request])?;
+
+        assert_eq!(result_keys.num_rows(), 2);
+
+        let sum_col = results
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let sum_array = sum_col.into_view().to_arrow_host()?;
+        let sum_values = sum_array.as_any().downcast_ref::<Int64Array>().unwrap();
+
+        // Should have sums [6, 30] in some order
+        let sum1 = sum_values.value(0);
+        let sum2 = sum_values.value(1);
+        assert!(
+            (sum1 == 6 && sum2 == 30) || (sum1 == 30 && sum2 == 6),
+            "Expected sums [6, 30], got [{}, {}]",
+            sum1,
+            sum2
+        );
+
+        Ok(())
+    }
+
+    fn make_keys_table(keys: &dyn Array) -> Result<CuDFTable> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "key",
+            keys.data_type().clone(),
+            false,
+        )]));
+        let keys_data = keys.to_data();
+        let batch = RecordBatch::try_new(schema, vec![make_array(keys_data)])?;
+        CuDFTable::from_arrow_host(batch)
+    }
+
+    fn run_single_group_agg<T: Array + Clone + 'static>(
+        values: &dyn Array,
+        agg_op: AggregationOp,
+    ) -> Result<Arc<T>> {
+        let n = values.len();
+        let keys = Int32Array::from(vec![1; n]);
+
+        let values_col = CuDFColumn::from_arrow_host(values)?;
+        let keys_table = make_keys_table(&keys)?;
+        let groupby = CuDFGroupBy::from_table_view(keys_table.into_view());
+
+        let mut request = AggregationRequest::from_column_view(values_col.into_view());
+        request.add(agg_op.group_by());
+
+        let (_result_keys, results) = groupby.aggregate(&[request])?;
+        let result_col = results
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let result_array = result_col.into_view().to_arrow_host()?;
+
+        Ok(Arc::new(
+            (*result_array.as_any().downcast_ref::<T>().unwrap()).clone(),
+        ))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use cudf_array::*;
 pub use cudf_reference::CuDFRef;
 pub use errors::{CuDFError, Result};
 pub use group_by::*;
-pub use operations::{apply_boolean_mask, gather, slice_column};
+pub use operations::{apply_boolean_mask, cast, gather, slice_column};
 pub use scalar::CuDFScalar;
 pub use sort::{sort, sort_by_all, stable_sorted_order, SortOrder};
 pub use table::*;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,4 +1,6 @@
-use crate::{CuDFColumnView, CuDFError, CuDFRef, CuDFTable, CuDFTableView};
+use crate::data_type::arrow_type_to_cudf_data_type;
+use crate::{CuDFColumn, CuDFColumnView, CuDFError, CuDFRef, CuDFTable, CuDFTableView};
+use arrow_schema::{ArrowError, DataType};
 use libcudf_sys::ffi;
 use std::sync::Arc;
 
@@ -133,4 +135,134 @@ pub fn slice_column(
         inner,
         Some(Arc::new(column.clone()) as Arc<dyn CuDFRef>),
     ))
+}
+
+/// Cast a column to a different data type on the GPU
+///
+/// Uses cuDF's native `cudf::cast()` to perform type conversion entirely on the GPU,
+/// avoiding any GPU->CPU->GPU round-trips.
+///
+/// # Arguments
+///
+/// * `column` - The column view to cast
+/// * `target_type` - The Arrow data type to cast to
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The target type is not supported by cuDF
+/// - The cast is not supported (e.g., string to numeric)
+/// - There is insufficient GPU memory
+pub fn cast(column: &CuDFColumnView, target_type: &DataType) -> Result<CuDFColumn, CuDFError> {
+    let cudf_dt = arrow_type_to_cudf_data_type(target_type).ok_or_else(|| {
+        CuDFError::ArrowError(ArrowError::NotYetImplemented(format!(
+            "Arrow type {} not supported in cuDF cast",
+            target_type
+        )))
+    })?;
+    let result = ffi::cast_column(column.inner(), &cudf_dt)?;
+    Ok(CuDFColumn::new(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::*;
+
+    #[test]
+    fn test_cast_int32_to_int64() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let casted = cast(&column, &DataType::Int64)?;
+        let result = casted.into_view().to_arrow_host()?;
+
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(result.values(), &[1i64, 2, 3, 4, 5]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_int32_to_float64() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![1, 2, 3]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let casted = cast(&column, &DataType::Float64)?;
+        let result = casted.into_view().to_arrow_host()?;
+
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert_eq!(result.values(), &[1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_float64_to_int64() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Float64Array::from(vec![1.9, 2.1, 3.5]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let casted = cast(&column, &DataType::Int64)?;
+        let result = casted.into_view().to_arrow_host()?;
+
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        // cuDF truncates toward zero
+        assert_eq!(result.values(), &[1i64, 2, 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_with_nulls() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let casted = cast(&column, &DataType::Int64)?;
+        let view = casted.into_view();
+        let result = view.to_arrow_host()?;
+
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(result.len(), 5);
+        assert!(result.is_valid(0));
+        assert!(result.is_null(1));
+        assert!(result.is_valid(2));
+        assert!(result.is_null(3));
+        assert!(result.is_valid(4));
+        assert_eq!(result.value(0), 1);
+        assert_eq!(result.value(2), 3);
+        assert_eq!(result.value(4), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_int64_to_uint64() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int64Array::from(vec![1, 2, 3]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let casted = cast(&column, &DataType::UInt64)?;
+        let result = casted.into_view().to_arrow_host()?;
+
+        let result = result.as_any().downcast_ref::<UInt64Array>().unwrap();
+        assert_eq!(result.values(), &[1u64, 2, 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_preserves_length() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![10, 20, 30, 40, 50]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let casted = cast(&column, &DataType::Float32)?;
+        let view = casted.into_view();
+        assert_eq!(view.len(), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_unsupported_type_returns_error() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Int32Array::from(vec![1, 2, 3]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        // Interval types are not supported by cuDF
+        let result = cast(&column, &DataType::Null);
+        assert!(result.is_err());
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

It adds the lower-level aggregation and cast primitives needed before wiring additional DataFusion aggregate execution:

- expose more direct cuDF aggregation factories through `libcudf-sys`
- add root `AggregationOp` variants for variance, standard deviation, distinct count, and median
- add GPU-native `cast()` support using cuDF column casting
- add focused root crate tests for groupby aggregation behavior and casting
- keep upstream dependency versions intact; this PR does not change `Cargo.toml` or `Cargo.lock`

## Validation

- `cargo fmt --all`
- `git diff --check`
- `git diff --cached --check`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p libcudf-rs --locked`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-rs --lib --locked` (`91 passed`)

## Note

`cargo test -p libcudf-datafusion --locked` currently has unrelated baseline snapshot failures on `gabotechs/main` because two tests use `LIMIT 1` without a deterministic row order. I verified the same failures on `gabotechs-main`; this PR keeps that issue out of scope.
