### PR TITLE
Add DataFusion aggregate execution

### DIFF
--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -146,6 +146,10 @@ impl ExecutionPlan for CuDFAggregateExec {
 }
 #[cfg(test)]
 mod test {
+    use crate::aggregate::op::avg::avg;
+    use crate::aggregate::op::count::count;
+    use crate::aggregate::op::max::max;
+    use crate::aggregate::op::min::min;
     use crate::aggregate::op::sum::sum;
     use crate::aggregate::CuDFAggregateExec;
     use crate::assert_snapshot;
@@ -154,6 +158,7 @@ mod test {
     use arrow::util::pretty::pretty_format_batches;
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
+    use datafusion_expr::AggregateUDF;
     use datafusion_physical_plan::aggregates::PhysicalGroupBy;
     use datafusion_physical_plan::expressions::col;
     use datafusion_physical_plan::test::TestMemoryExec;
@@ -162,8 +167,12 @@ mod test {
     use std::error::Error;
     use std::sync::Arc;
 
-    #[tokio::test]
-    async fn test_group_by_sum() -> Result<(), Box<dyn Error>> {
+    /// Helper function to run a group-by aggregation test
+    async fn run_group_by_test(
+        agg_fn: Arc<AggregateUDF>,
+        agg_column: &str,
+        agg_alias: &str,
+    ) -> Result<String, Box<dyn Error>> {
         let batch = record_batch!(
             ("a", Int64, [1, 4, 3]),
             ("b", Float64, [Some(4.0), None, Some(5.0)]),
@@ -183,12 +192,12 @@ mod test {
 
         let group_by = PhysicalGroupBy::new_single(vec![(col("c", &schema)?, "c".to_string())]);
 
-        let sum = AggregateExprBuilder::new(sum(), vec![col("a", &schema)?])
+        let agg = AggregateExprBuilder::new(agg_fn, vec![col(agg_column, &schema)?])
             .schema(schema)
-            .alias("SUM(a)")
+            .alias(agg_alias)
             .build()?;
 
-        let aggregate = CuDFAggregateExec::try_new(Arc::new(load), group_by, vec![Arc::new(sum)])?;
+        let aggregate = CuDFAggregateExec::try_new(Arc::new(load), group_by, vec![Arc::new(agg)])?;
 
         let unload = CuDFUnloadExec::new(Arc::new(aggregate));
 
@@ -198,6 +207,12 @@ mod test {
         let batches = result.try_collect::<Vec<_>>().await?;
 
         let output = pretty_format_batches(&batches)?.to_string();
+        Ok(output)
+    }
+
+    #[tokio::test]
+    async fn test_group_by_sum() -> Result<(), Box<dyn Error>> {
+        let output = run_group_by_test(sum(), "a", "SUM(a)").await?;
 
         // Note: cuDF's SUM always returns Int64 for integer inputs
         assert_snapshot!(output, @r"
@@ -206,6 +221,70 @@ mod test {
         +-------+--------+
         | world | 9      |
         | hello | 15     |
+        +-------+--------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_group_by_min() -> Result<(), Box<dyn Error>> {
+        let output = run_group_by_test(min(), "a", "MIN(a)").await?;
+
+        assert_snapshot!(output, @r"
+        +-------+--------+
+        | c     | MIN(a) |
+        +-------+--------+
+        | world | 3      |
+        | hello | 1      |
+        +-------+--------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_group_by_max() -> Result<(), Box<dyn Error>> {
+        let output = run_group_by_test(max(), "a", "MAX(a)").await?;
+
+        assert_snapshot!(output, @r"
+        +-------+--------+
+        | c     | MAX(a) |
+        +-------+--------+
+        | world | 3      |
+        | hello | 4      |
+        +-------+--------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_group_by_count() -> Result<(), Box<dyn Error>> {
+        let output = run_group_by_test(count(), "a", "COUNT(a)").await?;
+
+        assert_snapshot!(output, @r"
+        +-------+----------+
+        | c     | COUNT(a) |
+        +-------+----------+
+        | world | 3        |
+        | hello | 6        |
+        +-------+----------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_group_by_avg() -> Result<(), Box<dyn Error>> {
+        let output = run_group_by_test(avg(), "a", "AVG(a)").await?;
+
+        assert_snapshot!(output, @r"
+        +-------+--------+
+        | c     | AVG(a) |
+        +-------+--------+
+        | world | 3.0    |
+        | hello | 2.5    |
         +-------+--------+
         ");
 

--- a/libcudf-datafusion/src/aggregate/op/avg.rs
+++ b/libcudf-datafusion/src/aggregate/op/avg.rs
@@ -1,0 +1,73 @@
+use crate::aggregate::op::udf::CuDFAggregateUDF;
+use crate::aggregate::CuDFAggregationOp;
+use crate::errors::cudf_to_df;
+use arrow_schema::DataType;
+use datafusion::common::exec_err;
+use datafusion::error::Result;
+use datafusion::functions_aggregate::average::Avg;
+use datafusion_expr::AggregateUDF;
+use libcudf_rs::{cudf_binary_op, AggregationOp, AggregationRequest, CuDFBinaryOp, CuDFColumnView};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+pub fn avg() -> Arc<AggregateUDF> {
+    let udf = CuDFAggregateUDF::new(Arc::new(Avg::default()), Arc::new(CuDFAvg));
+    Arc::new(AggregateUDF::new_from_impl(udf))
+}
+
+#[derive(Debug, Default)]
+pub struct CuDFAvg;
+
+impl CuDFAggregationOp for CuDFAvg {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        // Partial: COUNT and SUM input values per batch
+        if args.len() != 1 {
+            return exec_err!("AVG expects 1 argument, got {}", args.len());
+        }
+
+        let mut sum_request = AggregationRequest::from_column_view(args[0].clone());
+        sum_request.add(AggregationOp::SUM.group_by());
+
+        let mut count_request = AggregationRequest::from_column_view(args[0].clone());
+        count_request.add(AggregationOp::COUNT.group_by());
+
+        Ok(vec![sum_request, count_request])
+    }
+
+    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        // Final: SUM the partial sums and counts
+        if args.len() != 2 {
+            return exec_err!("AVG final expects 2 arguments, got {}", args.len());
+        }
+
+        let mut sum_request = AggregationRequest::from_column_view(args[0].clone());
+        sum_request.add(AggregationOp::SUM.group_by());
+
+        let mut count_request = AggregationRequest::from_column_view(args[1].clone());
+        count_request.add(AggregationOp::SUM.group_by());
+
+        Ok(vec![sum_request, count_request])
+    }
+
+    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        // Merge: final sum / count
+        if args.len() != 2 {
+            return exec_err!("AVG merge expects 2 argument, got {}", args.len());
+        }
+
+        let result = cudf_binary_op(
+            libcudf_rs::CuDFColumnViewOrScalar::ColumnView(args[0].clone()),
+            libcudf_rs::CuDFColumnViewOrScalar::ColumnView(args[1].clone()),
+            CuDFBinaryOp::Div,
+            &DataType::Float64,
+        )
+        .map_err(cudf_to_df)?;
+
+        match result {
+            libcudf_rs::CuDFColumnViewOrScalar::ColumnView(view) => Ok(view),
+            libcudf_rs::CuDFColumnViewOrScalar::Scalar(_) => {
+                exec_err!("AVG merge expects ColumnView, got Scalar")
+            }
+        }
+    }
+}

--- a/libcudf-datafusion/src/aggregate/op/count.rs
+++ b/libcudf-datafusion/src/aggregate/op/count.rs
@@ -1,0 +1,62 @@
+use crate::aggregate::op::udf::CuDFAggregateUDF;
+use crate::aggregate::CuDFAggregationOp;
+use crate::errors::cudf_to_df;
+use arrow::compute::cast;
+use arrow_schema::DataType;
+use datafusion::common::exec_err;
+use datafusion::error::Result;
+use datafusion::functions_aggregate::count::Count;
+use datafusion_expr::AggregateUDF;
+use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+pub fn count() -> Arc<AggregateUDF> {
+    let udf = CuDFAggregateUDF::new(Arc::new(Count::default()), Arc::new(CuDFCount));
+    Arc::new(AggregateUDF::new_from_impl(udf))
+}
+
+#[derive(Debug, Default)]
+pub struct CuDFCount;
+
+impl CuDFAggregationOp for CuDFCount {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        // Partial: COUNT input values per batch
+        if args.len() != 1 {
+            return exec_err!("COUNT expects 1 argument, got {}", args.len());
+        }
+
+        let mut request = AggregationRequest::from_column_view(args[0].clone());
+        request.add(AggregationOp::COUNT.group_by());
+
+        Ok(vec![request])
+    }
+
+    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        // Final: SUM the partial counts
+        if args.len() != 1 {
+            return exec_err!("COUNT final expects 1 argument, got {}", args.len());
+        }
+
+        let mut request = AggregationRequest::from_column_view(args[0].clone());
+        request.add(AggregationOp::SUM.group_by());
+
+        Ok(vec![request])
+    }
+
+    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if args.len() != 1 {
+            return exec_err!("COUNT merge expects 1 argument, got {}", args.len());
+        }
+
+        // cuDF COUNT returns Int32, but DataFusion expects Int64
+        // Cast to Int64 to match DataFusion's expectation
+        let result_array = args[0].to_arrow_host().map_err(cudf_to_df)?;
+        let casted = cast(&result_array, &DataType::Int64)?;
+
+        // Convert back to CuDFColumn and return view
+        let column =
+            libcudf_rs::CuDFColumn::from_arrow_host(casted.as_ref()).map_err(cudf_to_df)?;
+        Ok(column.into_view())
+    }
+}

--- a/libcudf-datafusion/src/aggregate/op/max.rs
+++ b/libcudf-datafusion/src/aggregate/op/max.rs
@@ -1,0 +1,42 @@
+use crate::aggregate::op::udf::CuDFAggregateUDF;
+use crate::aggregate::CuDFAggregationOp;
+use datafusion::common::exec_err;
+use datafusion::error::Result;
+use datafusion::functions_aggregate::min_max::Max;
+use datafusion_expr::AggregateUDF;
+use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+pub fn max() -> Arc<AggregateUDF> {
+    let udf = CuDFAggregateUDF::new(Arc::new(Max::default()), Arc::new(CuDFMax));
+    Arc::new(AggregateUDF::new_from_impl(udf))
+}
+
+#[derive(Debug, Default)]
+pub struct CuDFMax;
+
+impl CuDFAggregationOp for CuDFMax {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        self.final_requests(args)
+    }
+
+    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if args.len() != 1 {
+            return exec_err!("MAX expects 1 argument, got {}", args.len());
+        }
+
+        let mut request = AggregationRequest::from_column_view(args[0].clone());
+        request.add(AggregationOp::MAX.group_by());
+
+        Ok(vec![request])
+    }
+
+    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if args.len() != 1 {
+            return exec_err!("MAX merge expects 1 argument, got {}", args.len());
+        }
+
+        Ok(args[0].clone())
+    }
+}

--- a/libcudf-datafusion/src/aggregate/op/min.rs
+++ b/libcudf-datafusion/src/aggregate/op/min.rs
@@ -1,0 +1,42 @@
+use crate::aggregate::op::udf::CuDFAggregateUDF;
+use crate::aggregate::CuDFAggregationOp;
+use datafusion::common::exec_err;
+use datafusion::error::Result;
+use datafusion::functions_aggregate::min_max::Min;
+use datafusion_expr::AggregateUDF;
+use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+pub fn min() -> Arc<AggregateUDF> {
+    let udf = CuDFAggregateUDF::new(Arc::new(Min::default()), Arc::new(CuDFMin));
+    Arc::new(AggregateUDF::new_from_impl(udf))
+}
+
+#[derive(Debug, Default)]
+pub struct CuDFMin;
+
+impl CuDFAggregationOp for CuDFMin {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        self.final_requests(args)
+    }
+
+    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if args.len() != 1 {
+            return exec_err!("MIN expects 1 argument, got {}", args.len());
+        }
+
+        let mut request = AggregationRequest::from_column_view(args[0].clone());
+        request.add(AggregationOp::MIN.group_by());
+
+        Ok(vec![request])
+    }
+
+    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if args.len() != 1 {
+            return exec_err!("MIN merge expects 1 argument, got {}", args.len());
+        }
+
+        Ok(args[0].clone())
+    }
+}

--- a/libcudf-datafusion/src/aggregate/op/mod.rs
+++ b/libcudf-datafusion/src/aggregate/op/mod.rs
@@ -2,6 +2,10 @@ use datafusion::error::Result;
 use libcudf_rs::{AggregationRequest, CuDFColumnView};
 use std::fmt::Debug;
 
+pub mod avg;
+pub mod count;
+pub mod max;
+pub mod min;
 pub mod sum;
 pub mod udf;
 

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -21,6 +21,32 @@ enum State {
     Done,
 }
 
+/// Results from partial aggregations across batches: `batches -> result groups -> columns`
+/// - Outer Vec: Batches (one entry per input batch processed)
+/// - Middle Vec: Result groups (one per aggregation request sent to cuDF)
+/// - Inner Vec: Columns in that result group (typically 1, but >=2 for multi-column ops like AVG)
+///
+/// Use `column_mapping` to determine which result groups belong to which operation.
+type PartialResults = Vec<Vec<Vec<CuDFColumn>>>;
+
+/// Tracks which result groups belong to each aggregation operation.
+///
+/// Enables correct slicing of multi-column aggregations like AVG (uses sum and count).
+///
+/// Example for `[SUM, AVG, MAX]`:
+/// ```text
+/// column_mapping = [
+///   ColumnRange { start: 0, count: 1 }, -> SUM uses result group 0
+///   ColumnRange { start: 1, count: 2 }, -> AVG uses result groups 1-2
+///   ColumnRange { start: 3, count: 1 }, -> MAX uses result group 3
+/// ]
+/// ```
+#[derive(Debug, Clone)]
+struct ColumnRange {
+    start: usize, // Starting index in result groups
+    count: usize, // Number of result groups this operation uses
+}
+
 pub struct Stream {
     input: SendableRecordBatchStream,
     output_schema: SchemaRef,
@@ -34,7 +60,10 @@ pub struct Stream {
     state: State,
 
     keys: Vec<CuDFTable>,
-    results: Vec<Vec<Vec<CuDFColumn>>>,
+
+    results: PartialResults,
+
+    column_mapping: Vec<ColumnRange>,
 }
 
 impl Stream {
@@ -72,11 +101,14 @@ impl Stream {
             state: State::ReceivingInput,
             keys: vec![],
             results: vec![],
+            column_mapping: vec![],
         }
     }
-}
 
-impl Stream {
+    /// Concatenate unique group keys from all batches.
+    ///
+    /// Consumes `self.keys` and produces a single table containing all unique group keys that will
+    /// be used for the final aggregation phase.
     fn concat_keys(&mut self) -> Result<CuDFTable> {
         let mut keys = Vec::with_capacity(self.keys.len());
         for table in std::mem::take(&mut self.keys) {
@@ -85,7 +117,33 @@ impl Stream {
         CuDFTable::concat(keys).map_err(cudf_to_df)
     }
 
+    /// Concatenate partial aggregation results from all batches.
+    ///
+    /// This groups columns by their result group index (middle Vec in PartialResults),
+    /// concatenates across batches, then returns them in the same grouped structure.
+    ///
+    /// # Steps
+    /// 1. Group columns by result group index across all batches
+    /// 2. For each result group, concatenate columns from all batches
+    /// 3. Return concatenated results in same structure as input
+    ///
+    /// # Example
+    /// ```text
+    /// Input (3 batches, 2 result groups each):
+    /// [
+    ///   [[col_b1_g0], [col_b1_g1]], -> Batch 1
+    ///   [[col_b2_g0], [col_b2_g1]], -> Batch 2
+    ///   [[col_b3_g0], [col_b3_g1]]  -> Batch 3
+    /// ]
+    ///
+    /// Output (2 result groups, concatenated across batches):
+    /// [
+    ///   [concat(col_b1_g0, col_b2_g0, col_b3_g0)], -> Group 0
+    ///   [concat(col_b1_g1, col_b2_g1, col_b3_g1)]  -> Group 1
+    /// ]
+    /// ```
     fn concat_partial_results(&mut self) -> Result<Vec<Vec<CuDFColumnView>>> {
+        // Infer structure from first batch
         let first = self.results.first().expect("at least one result");
         let mut partial_columns = Vec::with_capacity(first.len());
         for agg_results in first {
@@ -95,6 +153,7 @@ impl Stream {
             ])
         }
 
+        // Group columns by result group index across batches
         for results in std::mem::take(&mut self.results) {
             for (r_i, columns) in results.into_iter().enumerate() {
                 for (c_i, column) in columns.into_iter().enumerate() {
@@ -103,6 +162,7 @@ impl Stream {
             }
         }
 
+        // Concatenate each group
         partial_columns
             .into_iter()
             .map(|columns| {
@@ -114,10 +174,20 @@ impl Stream {
             .collect()
     }
 
+    /// Build the final output RecordBatch from aggregation results.
+    ///
+    /// Combines group keys with merged aggregation results into a single RecordBatch
+    /// matching the output schema.
+    ///
+    /// # Steps
+    /// 1. Add group key columns to output
+    /// 2. For each aggregation operation, extract its columns using column_mapping
+    /// 3. Call merge() to combine multi-column results (e.g., AVG: sum/count → average)
+    /// 4. Add merged result to output
     fn build_final_batch(
         &self,
         keys: CuDFTable,
-        results: Vec<Vec<CuDFColumn>>,
+        mut results: Vec<Vec<CuDFColumn>>,
     ) -> Result<RecordBatch> {
         let groups = keys.into_columns();
         let mut arrays: Vec<ArrayRef> =
@@ -126,17 +196,133 @@ impl Stream {
             arrays.push(Arc::new(group.into_view()))
         }
 
-        for (r_i, result) in results.into_iter().enumerate() {
-            let aggr = &self.aggregate_ops[r_i];
-            let args = result
-                .into_iter()
-                .map(|c| c.into_view())
-                .collect::<Vec<_>>();
+        for (aggr, mapping) in self.aggregate_ops.iter().zip(&self.column_mapping) {
+            // Use mapping to extract the correct columns for this operation
+            let range = mapping.start..(mapping.start + mapping.count);
+            let mut args: Vec<CuDFColumnView> = Vec::new();
+            for i in range {
+                for col in results[i].drain(..) {
+                    args.push(col.into_view());
+                }
+            }
             let merged = aggr.merge(&args)?;
             arrays.push(Arc::new(merged));
         }
 
         Ok(RecordBatch::try_new(self.output_schema.clone(), arrays)?)
+    }
+
+    /// Evaluate group keys from a batch and create a CuDFGroupBy instance.
+    ///
+    /// Extracts the group key columns from the input batch and prepares them
+    /// for use in GPU aggregation.
+    fn evaluate_batch_groups(&self, batch: &RecordBatch) -> Result<CuDFGroupBy> {
+        let grouping_sets = evaluate_group_by(&self.group_by, batch)?;
+
+        if grouping_sets.len() != 1 {
+            return exec_err!("Expected single grouping set, got {}", grouping_sets.len());
+        }
+
+        let group = &grouping_sets[0];
+        let column_views = group
+            .iter()
+            .map(|x| x.as_any().downcast_ref::<CuDFColumnView>().unwrap())
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let table_view = CuDFTableView::from_column_views(column_views).map_err(cudf_to_df)?;
+
+        Ok(CuDFGroupBy::from_table_view(table_view))
+    }
+
+    /// Evaluate aggregate function arguments from a batch.
+    ///
+    /// Extracts and validates the argument columns for each aggregation operation,
+    /// ensuring they are CuDFColumnViews suitable for GPU processing.
+    fn evaluate_batch_arguments(&self, batch: &RecordBatch) -> Result<Vec<Vec<CuDFColumnView>>> {
+        let evaluated_arguments = evaluate_many(&self.aggregate_args, batch)?;
+
+        evaluated_arguments
+            .iter()
+            .map(|args| {
+                args.iter()
+                    .map(|arg| {
+                        let Some(view) = arg.as_any().downcast_ref::<CuDFColumnView>() else {
+                            return internal_err!("Expected Array to be of type CuDFColumnView");
+                        };
+                        Ok(view.clone())
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Build aggregation requests for partial phase.
+    ///
+    /// On first call, also computes and stores the column mapping that describes
+    /// which result groups belong to which operations. On subsequent calls, reuses
+    /// the existing mapping.
+    ///
+    /// Returns the list of aggregation requests to send to cuDF.
+    fn build_partial_requests(
+        &mut self,
+        evaluated_views: Vec<Vec<CuDFColumnView>>,
+    ) -> Result<Vec<libcudf_rs::AggregationRequest>> {
+        let mut requests = Vec::with_capacity(evaluated_views.len());
+
+        let is_first_batch = self.column_mapping.is_empty();
+
+        if is_first_batch {
+            // First batch: build mapping
+            let mut col_offset = 0;
+            let mut column_mapping = Vec::with_capacity(self.aggregate_ops.len());
+
+            for (agg, args) in self.aggregate_ops.iter().zip(evaluated_views) {
+                let op_requests = agg.partial_requests(&args)?;
+                let col_count = op_requests.len();
+
+                column_mapping.push(ColumnRange {
+                    start: col_offset,
+                    count: col_count,
+                });
+
+                col_offset += col_count;
+                requests.extend(op_requests);
+            }
+
+            self.column_mapping = column_mapping;
+        } else {
+            // Subsequent batches: reuse mapping
+            for (agg, args) in self.aggregate_ops.iter().zip(evaluated_views) {
+                requests.extend(agg.partial_requests(&args)?);
+            }
+        }
+
+        Ok(requests)
+    }
+
+    /// Build aggregation requests for final phase.
+    ///
+    /// Uses the column mapping to correctly slice concatenated partial results,
+    /// ensuring each operation receives all its columns (e.g., AVG gets both sum and count).
+    fn build_final_requests(
+        &self,
+        concatenated_columns: &[Vec<CuDFColumnView>],
+    ) -> Result<Vec<libcudf_rs::AggregationRequest>> {
+        let mut requests = Vec::with_capacity(self.aggregate_expr.len());
+
+        for (agg, mapping) in self.aggregate_ops.iter().zip(&self.column_mapping) {
+            // Slice to get columns for this operation
+            let range = mapping.start..(mapping.start + mapping.count);
+            let op_columns: Vec<CuDFColumnView> = concatenated_columns[range]
+                .iter()
+                .flat_map(|cols| cols.iter().cloned())
+                .collect();
+
+            requests.extend(agg.final_requests(&op_columns)?);
+        }
+
+        Ok(requests)
     }
 }
 
@@ -154,48 +340,10 @@ impl futures::Stream for Stream {
                         }
                         Some(Err(err)) => return Poll::Ready(Some(Err(err))),
                         Some(Ok(batch)) => {
-                            let grouping_sets = evaluate_group_by(&self.group_by, &batch)?;
-                            if grouping_sets.len() != 1 {
-                                return Poll::Ready(Some(exec_err!(
-                                    "Expected single grouping set, got {}",
-                                    grouping_sets.len()
-                                )));
-                            }
+                            let group_by = self.evaluate_batch_groups(&batch)?;
+                            let evaluated_views = self.evaluate_batch_arguments(&batch)?;
+                            let requests = self.build_partial_requests(evaluated_views)?;
 
-                            let group = &grouping_sets[0];
-                            let column_views = group
-                                .into_iter()
-                                .map(|x| x.as_any().downcast_ref::<CuDFColumnView>().unwrap())
-                                .cloned()
-                                .collect::<Vec<_>>();
-
-                            let table_view = CuDFTableView::from_column_views(column_views)
-                                .map_err(cudf_to_df)?;
-                            let group_by = CuDFGroupBy::from_table_view(table_view);
-
-                            let evaluated_arguments = evaluate_many(&self.aggregate_args, &batch)?;
-                            let evaluated_views = evaluated_arguments
-                                .iter()
-                                .map(|args| {
-                                    args.iter()
-                                        .map(|arg| {
-                                            let Some(view) =
-                                                arg.as_any().downcast_ref::<CuDFColumnView>()
-                                            else {
-                                                return internal_err!(
-                                                    "Expected Array to be of type CuDFColumnView"
-                                                );
-                                            };
-                                            Ok(view.clone())
-                                        })
-                                        .collect()
-                                })
-                                .collect::<Result<Vec<Vec<_>>>>()?;
-
-                            let mut requests = Vec::with_capacity(evaluated_views.len());
-                            for (agg, args) in self.aggregate_ops.iter().zip(evaluated_views) {
-                                requests.extend(agg.partial_requests(&args)?)
-                            }
                             let (keys, results) =
                                 group_by.aggregate(&requests).map_err(cudf_to_df)?;
 
@@ -213,11 +361,7 @@ impl futures::Stream for Stream {
                     let group_by = CuDFGroupBy::from_table_view(keys_table.into_view());
 
                     let concatenated_columns = self.concat_partial_results()?;
-
-                    let mut requests = Vec::with_capacity(self.aggregate_expr.len());
-                    for (agg, args) in self.aggregate_ops.iter().zip(concatenated_columns.iter()) {
-                        requests.extend(agg.final_requests(args)?);
-                    }
+                    let requests = self.build_final_requests(&concatenated_columns)?;
 
                     let (keys, results) = group_by.aggregate(&requests).map_err(cudf_to_df)?;
                     let output = self.build_final_batch(keys, results)?;


### PR DESCRIPTION
## Summary

Adds the first DataFusion aggregate execution layer on top of the core aggregation primitives merged in the prior PR.

This wires SUM, MIN, MAX, COUNT, and AVG through `libcudf-datafusion`, including grouped aggregate streams and aggregate expression plumbing.

## Notes

- Keeps the root `libcudf-rs` and `libcudf-sys` aggregation API from the previous PR intact.
- Does not include dependency or lockfile changes.
- The original fork commit attempted to remove `NUNIQUE`; this PR intentionally preserves it because it is now already merged upstream.

## Validation

- `cargo fmt --all`
- `cargo check -p libcudf-datafusion --locked`
- `cargo test -p libcudf-datafusion aggregate::test --lib --locked`

Focused aggregate tests pass locally: 5 passed, 15 filtered out.

Full `cargo test -p libcudf-datafusion --locked` still has unrelated upstream baseline snapshot failures from nondeterministic `LIMIT 1` reads over the weather parquet directory; this was verified separately on `gabotechs/main`.
