### PR TITLE
Redesign DataFusion aggregate stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "clap",
+ "criterion",
  "datafusion",
  "datafusion-cli",
  "datafusion-expr",

--- a/libcudf-datafusion/Cargo.toml
+++ b/libcudf-datafusion/Cargo.toml
@@ -51,6 +51,7 @@ tpch = ["integration"]
 
 [dev-dependencies]
 tokio = { version = "1.41", features = ["full"] }
+criterion = { version = "0.7", features = ["html_reports"] }
 
 # integration tests deps
 insta = { version = "1.43.1", features = ["filters"] }
@@ -59,6 +60,10 @@ tpchgen-arrow = { git = "https://github.com/clflushopt/tpchgen-rs", rev = "31d51
 parquet = { version = "58" }
 pretty_assertions = { version = "1.4" }
 
+
+[[bench]]
+name = "aggregate"
+harness = false
 
 [[bin]]
 name = "cli"

--- a/libcudf-datafusion/benches/aggregate.rs
+++ b/libcudf-datafusion/benches/aggregate.rs
@@ -1,0 +1,164 @@
+use arrow::array::{Float64Array, Int64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use datafusion::datasource::MemTable;
+use datafusion::execution::SessionStateBuilder;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_physical_plan::{execute_stream, ExecutionPlan};
+use futures_util::TryStreamExt;
+use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
+use libcudf_datafusion::{CuDFConfig, HostToCuDFRule};
+use std::hint::black_box;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Int64, false),
+        Field::new("val", DataType::Float64, false),
+    ]))
+}
+
+fn make_batches(n: usize) -> Vec<RecordBatch> {
+    let schema = schema();
+    let batch_size = 8192;
+    let mut batches = Vec::new();
+    let mut offset = 0;
+    while offset < n {
+        let len = batch_size.min(n - offset);
+        let keys: Int64Array = (offset..offset + len)
+            .map(|i| (i % 100_000) as i64)
+            .collect();
+        let vals: Float64Array = (offset..offset + len).map(|i| i as f64 * 0.7).collect();
+        batches.push(
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(keys), Arc::new(vals)]).unwrap(),
+        );
+        offset += len;
+    }
+    batches
+}
+
+async fn cpu_ctx(batches: Vec<RecordBatch>) -> SessionContext {
+    let schema = schema();
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "t",
+        Arc::new(MemTable::try_new(schema, vec![batches]).unwrap()),
+    )
+    .unwrap();
+    ctx
+}
+
+async fn gpu_ctx(batches: Vec<RecordBatch>) -> SessionContext {
+    let schema = schema();
+    let mut cudf_config = CuDFConfig::default();
+    cudf_config.enable = true;
+    let config = SessionConfig::new().with_option_extension(cudf_config);
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_config(config)
+        .with_physical_optimizer_rule(Arc::new(HostToCuDFRule))
+        .build();
+    let ctx = SessionContext::from(state);
+    ctx.register_udaf((*avg()).clone());
+    ctx.register_udaf((*count()).clone());
+    ctx.register_udaf((*max()).clone());
+    ctx.register_udaf((*min()).clone());
+    ctx.register_udaf((*sum()).clone());
+    ctx.register_table(
+        "t",
+        Arc::new(MemTable::try_new(schema, vec![batches]).unwrap()),
+    )
+    .unwrap();
+    ctx
+}
+
+async fn build_plan(ctx: &SessionContext, sql: &str) -> Arc<dyn ExecutionPlan> {
+    ctx.sql(sql)
+        .await
+        .unwrap()
+        .create_physical_plan()
+        .await
+        .unwrap()
+}
+
+fn bench_group(c: &mut Criterion, group_name: &str, sql: &str) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group(group_name);
+
+    for &n in &[1_000_000usize, 5_000_000, 20_000_000] {
+        group.throughput(Throughput::Elements(n as u64));
+
+        let batches = make_batches(n);
+        let cpu = rt.block_on(cpu_ctx(batches.clone()));
+        let gpu = rt.block_on(gpu_ctx(batches));
+
+        let cpu_task_ctx = cpu.task_ctx();
+        let gpu_task_ctx = gpu.task_ctx();
+
+        group.bench_with_input(BenchmarkId::new("cpu", n), &n, |b, _| {
+            b.iter_batched(
+                || rt.block_on(build_plan(&cpu, sql)),
+                |plan| {
+                    rt.block_on(async {
+                        let stream = execute_stream(plan, cpu_task_ctx.clone()).unwrap();
+                        black_box(stream.try_collect::<Vec<_>>().await.unwrap());
+                    })
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        group.bench_with_input(BenchmarkId::new("gpu", n), &n, |b, _| {
+            b.iter_batched(
+                || rt.block_on(build_plan(&gpu, sql)),
+                |plan| {
+                    rt.block_on(async {
+                        let stream = execute_stream(plan, gpu_task_ctx.clone()).unwrap();
+                        black_box(stream.try_collect::<Vec<_>>().await.unwrap());
+                    })
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_sum(c: &mut Criterion) {
+    bench_group(c, "sum", "SELECT key, SUM(val) FROM t GROUP BY key");
+}
+
+fn bench_count(c: &mut Criterion) {
+    bench_group(c, "count", "SELECT key, COUNT(val) FROM t GROUP BY key");
+}
+
+fn bench_avg(c: &mut Criterion) {
+    bench_group(c, "avg", "SELECT key, AVG(val) FROM t GROUP BY key");
+}
+
+fn bench_min_max(c: &mut Criterion) {
+    bench_group(
+        c,
+        "min_max",
+        "SELECT key, MIN(val), MAX(val) FROM t GROUP BY key",
+    );
+}
+
+fn bench_combined(c: &mut Criterion) {
+    bench_group(
+        c,
+        "combined",
+        "SELECT key, COUNT(val), SUM(val), AVG(val), MIN(val), MAX(val) FROM t GROUP BY key",
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_sum,
+    bench_count,
+    bench_avg,
+    bench_min_max,
+    bench_combined
+);
+criterion_main!(benches);

--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -14,11 +14,22 @@ use std::sync::Arc;
 mod op;
 mod stream;
 
+pub use op::avg::avg;
+pub use op::count::count;
+pub use op::max::max;
+pub use op::min::min;
+pub use op::sum::sum;
+pub(crate) use op::udf::CuDFAggregateUDF;
 pub(crate) use op::CuDFAggregationOp;
 
+/// GPU-accelerated GROUP BY aggregate execution node.
+///
+/// Replaces DataFusion's `AggregateExec` for queries where all aggregate
+/// functions have cuDF implementations.
 #[derive(Debug)]
 pub struct CuDFAggregateExec {
     input: Arc<dyn ExecutionPlan>,
+    mode: AggregateMode,
     group_by: PhysicalGroupBy,
     aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
 
@@ -28,11 +39,13 @@ pub struct CuDFAggregateExec {
 impl CuDFAggregateExec {
     pub fn try_new(
         input: Arc<dyn ExecutionPlan>,
+        mode: AggregateMode,
         group_by: PhysicalGroupBy,
         aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
     ) -> Result<Self> {
         let input_schema = input.schema();
 
+        // Non-single grouping sets (CUBE, ROLLUP) add an extra column for the grouping ID.
         let group_by_fields = {
             let num_exprs = group_by.expr().len();
             if !group_by.is_single() {
@@ -43,13 +56,24 @@ impl CuDFAggregateExec {
         };
 
         let group_by_schema = group_by.group_schema(&input_schema)?;
-        let group_by_exprs = group_by_schema.fields.iter().cloned().take(group_by_fields);
+        let group_by_exprs = group_by_schema.fields.iter().take(group_by_fields).cloned();
 
         let mut fields = Vec::with_capacity(group_by_fields + aggr_expr.len());
 
         fields.extend(group_by_exprs);
-        for expr in &aggr_expr {
-            fields.push(expr.field());
+
+        // Partial mode emits intermediate state columns (e.g., AVG emits [count, sum]).
+        // All other modes emit the final result column (e.g., AVG emits [avg]).
+        if mode == AggregateMode::Partial {
+            for expr in &aggr_expr {
+                for field in expr.state_fields()? {
+                    fields.push(field);
+                }
+            }
+        } else {
+            for expr in &aggr_expr {
+                fields.push(expr.field());
+            }
         }
 
         let output_schema = Arc::new(Schema::new_with_metadata(
@@ -58,19 +82,20 @@ impl CuDFAggregateExec {
         ));
 
         let group_by_expr_mapping =
-            ProjectionMapping::try_new(group_by.expr().into_iter().cloned(), &input.schema())?;
+            ProjectionMapping::try_new(group_by.expr().iter().cloned(), &input.schema())?;
 
         let plan_properties = Arc::new(AggregateExec::compute_properties(
             &input,
             output_schema,
             &group_by_expr_mapping,
-            &AggregateMode::Single,
+            &mode,
             &InputOrderMode::Linear,
             &aggr_expr,
         )?);
 
         Ok(Self {
             input,
+            mode,
             group_by,
             aggr_expr,
             plan_properties,
@@ -81,6 +106,7 @@ impl CuDFAggregateExec {
 impl DisplayAs for CuDFAggregateExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "CuDFAggregateExec: ")?;
+        write!(f, "mode={:?}, ", self.mode)?;
         write!(f, "group_by=[")?;
         for (i, (expr, alias)) in self.group_by.expr().iter().enumerate() {
             if i > 0 {
@@ -122,6 +148,7 @@ impl ExecutionPlan for CuDFAggregateExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let new = Self::try_new(
             children[0].clone(),
+            self.mode,
             self.group_by.clone(),
             self.aggr_expr.clone(),
         )?;
@@ -138,9 +165,10 @@ impl ExecutionPlan for CuDFAggregateExec {
         let stream = stream::Stream::new(
             input,
             self.schema(),
+            self.mode,
             self.group_by.clone(),
             self.aggr_expr.clone(),
-        );
+        )?;
         Ok(Box::pin(stream))
     }
 }
@@ -159,7 +187,7 @@ mod test {
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
     use datafusion_expr::AggregateUDF;
-    use datafusion_physical_plan::aggregates::PhysicalGroupBy;
+    use datafusion_physical_plan::aggregates::{AggregateMode, PhysicalGroupBy};
     use datafusion_physical_plan::expressions::col;
     use datafusion_physical_plan::test::TestMemoryExec;
     use datafusion_physical_plan::ExecutionPlan;
@@ -167,7 +195,11 @@ mod test {
     use std::error::Error;
     use std::sync::Arc;
 
-    /// Helper function to run a group-by aggregation test
+    /// Run a GROUP BY aggregation through the full GPU pipeline:
+    /// TestMemoryExec -> CuDFLoadExec -> CuDFAggregateExec -> CuDFUnloadExec.
+    ///
+    /// Sends 3 identical batches (to exercise cross-batch rolling merge) and
+    /// groups by column "c".
     async fn run_group_by_test(
         agg_fn: Arc<AggregateUDF>,
         agg_column: &str,
@@ -197,7 +229,12 @@ mod test {
             .alias(agg_alias)
             .build()?;
 
-        let aggregate = CuDFAggregateExec::try_new(Arc::new(load), group_by, vec![Arc::new(agg)])?;
+        let aggregate = CuDFAggregateExec::try_new(
+            Arc::new(load),
+            AggregateMode::Single,
+            group_by,
+            vec![Arc::new(agg)],
+        )?;
 
         let unload = CuDFUnloadExec::new(Arc::new(aggregate));
 
@@ -289,5 +326,131 @@ mod test {
         ");
 
         Ok(())
+    }
+}
+
+/// Integration tests: full SQL pipeline through TestFramework against real weather data.
+///
+/// Each test runs the same query on CPU and GPU, asserts the plan uses `CuDFAggregateExec`,
+/// and verifies GPU results match CPU results exactly (ORDER BY ensures stable row ordering).
+#[cfg(test)]
+mod integration {
+    use crate::test_utils::TestFramework;
+    use arrow::array::{Array, Float64Array, RecordBatch};
+    use datafusion::common::assert_contains;
+    use std::error::Error;
+
+    /// Compare two sets of record batches, rounding Float64 values to `decimals`
+    /// decimal places before comparing.
+    ///
+    /// This absorbs last-ULP differences between cuDF's GPU arithmetic and
+    /// DataFusion's CPU arithmetic (e.g. `19.243023255813952` vs `...956`).
+    /// Non-float columns are compared for exact equality.
+    /// Rows are expected to already be in the same order.
+    fn assert_batches_approx_eq(gpu: &[RecordBatch], cpu: &[RecordBatch], decimals: u32) {
+        let factor = 10f64.powi(decimals as i32);
+        assert_eq!(gpu.len(), cpu.len(), "batch count mismatch");
+        for (b, (g, c)) in gpu.iter().zip(cpu.iter()).enumerate() {
+            assert_eq!(g.num_rows(), c.num_rows(), "batch {b}: row count mismatch");
+            assert_eq!(g.num_columns(), c.num_columns(), "batch {b}: column count");
+            for col in 0..g.num_columns() {
+                let gc = g.column(col);
+                let cc = c.column(col);
+                if let (Some(gf), Some(cf)) = (
+                    gc.as_any().downcast_ref::<Float64Array>(),
+                    cc.as_any().downcast_ref::<Float64Array>(),
+                ) {
+                    for row in 0..gf.len() {
+                        let gv = (gf.value(row) * factor).round() / factor;
+                        let cv = (cf.value(row) * factor).round() / factor;
+                        assert_eq!(gv, cv, "batch {b}, col {col}, row {row}");
+                    }
+                } else {
+                    assert_eq!(gc.as_ref(), cc.as_ref(), "batch {b}, col {col}");
+                }
+            }
+        }
+    }
+
+    async fn check(sql: &str) -> Result<(), Box<dyn Error>> {
+        let tf = TestFramework::new().await;
+        let cudf_sql = format!("SET cudf.enable=true; {sql}");
+
+        let cudf = tf.execute(&cudf_sql).await?;
+        let cpu = tf.execute(sql).await?;
+
+        assert_contains!(&cudf.plan, "CuDFAggregateExec");
+        assert_batches_approx_eq(&cudf.batches, &cpu.batches, 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sum() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday", SUM("Rainfall") as total_rain
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_count() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday", COUNT("Rainfall") as n
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_avg() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday", AVG("MinTemp") as avg_min
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_min_max() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday", MIN("MinTemp") as lo, MAX("MaxTemp") as hi
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_multiple_aggregates() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday",
+                   COUNT("Rainfall") as n,
+                   SUM("Rainfall") as total,
+                   AVG("MaxTemp") as avg_max,
+                   MIN("MinTemp") as lo,
+                   MAX("MaxTemp") as hi
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
     }
 }

--- a/libcudf-datafusion/src/aggregate/op/avg.rs
+++ b/libcudf-datafusion/src/aggregate/op/avg.rs
@@ -6,8 +6,10 @@ use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::average::Avg;
 use datafusion_expr::AggregateUDF;
-use libcudf_rs::{cudf_binary_op, AggregationOp, AggregationRequest, CuDFBinaryOp, CuDFColumnView};
-use std::fmt::Debug;
+use libcudf_rs::{
+    cudf_binary_op, AggregationOp, AggregationRequest, CuDFBinaryOp, CuDFColumn, CuDFColumnView,
+    CuDFColumnViewOrScalar,
+};
 use std::sync::Arc;
 
 pub fn avg() -> Arc<AggregateUDF> {
@@ -19,54 +21,70 @@ pub fn avg() -> Arc<AggregateUDF> {
 pub struct CuDFAvg;
 
 impl CuDFAggregationOp for CuDFAvg {
+    fn num_state_columns(&self) -> usize {
+        2 // [count, sum]
+    }
+
     fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        // Partial: COUNT and SUM input values per batch
         if args.len() != 1 {
             return exec_err!("AVG expects 1 argument, got {}", args.len());
         }
 
-        let mut sum_request = AggregationRequest::from_column_view(args[0].clone());
-        sum_request.add(AggregationOp::SUM.group_by());
-
         let mut count_request = AggregationRequest::from_column_view(args[0].clone());
         count_request.add(AggregationOp::COUNT.group_by());
 
-        Ok(vec![sum_request, count_request])
-    }
-
-    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        // Final: SUM the partial sums and counts
-        if args.len() != 2 {
-            return exec_err!("AVG final expects 2 arguments, got {}", args.len());
-        }
-
         let mut sum_request = AggregationRequest::from_column_view(args[0].clone());
         sum_request.add(AggregationOp::SUM.group_by());
 
-        let mut count_request = AggregationRequest::from_column_view(args[1].clone());
-        count_request.add(AggregationOp::SUM.group_by());
-
-        Ok(vec![sum_request, count_request])
+        Ok(vec![count_request, sum_request])
     }
 
-    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
-        // Merge: final sum / count
-        if args.len() != 2 {
-            return exec_err!("AVG merge expects 2 argument, got {}", args.len());
+    fn normalize_partial_state(&self, mut cols: Vec<CuDFColumn>) -> Result<Vec<CuDFColumn>> {
+        // count column: cuDF COUNT returns Int32 -> cast to Int64 to match merge_requests output
+        let sum = cols.remove(1);
+        let count = cols.remove(0);
+        let casted_count =
+            libcudf_rs::cast(&count.into_view(), &DataType::Int64).map_err(cudf_to_df)?;
+        Ok(vec![casted_count, sum])
+    }
+
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if state_cols.len() != 2 {
+            return exec_err!(
+                "AVG merge expects 2 state columns, got {}",
+                state_cols.len()
+            );
+        }
+
+        let mut count_request = AggregationRequest::from_column_view(state_cols[0].clone());
+        count_request.add(AggregationOp::SUM.group_by());
+
+        let mut sum_request = AggregationRequest::from_column_view(state_cols[1].clone());
+        sum_request.add(AggregationOp::SUM.group_by());
+
+        Ok(vec![count_request, sum_request])
+    }
+
+    fn finalize(&self, state_cols: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if state_cols.len() != 2 {
+            return exec_err!(
+                "AVG finalize expects 2 state columns, got {}",
+                state_cols.len()
+            );
         }
 
         let result = cudf_binary_op(
-            libcudf_rs::CuDFColumnViewOrScalar::ColumnView(args[0].clone()),
-            libcudf_rs::CuDFColumnViewOrScalar::ColumnView(args[1].clone()),
+            CuDFColumnViewOrScalar::ColumnView(state_cols[1].clone()),
+            CuDFColumnViewOrScalar::ColumnView(state_cols[0].clone()),
             CuDFBinaryOp::Div,
             &DataType::Float64,
         )
         .map_err(cudf_to_df)?;
 
         match result {
-            libcudf_rs::CuDFColumnViewOrScalar::ColumnView(view) => Ok(view),
-            libcudf_rs::CuDFColumnViewOrScalar::Scalar(_) => {
-                exec_err!("AVG merge expects ColumnView, got Scalar")
+            CuDFColumnViewOrScalar::ColumnView(view) => Ok(view),
+            CuDFColumnViewOrScalar::Scalar(_) => {
+                exec_err!("AVG finalize: expected ColumnView from division, got Scalar")
             }
         }
     }

--- a/libcudf-datafusion/src/aggregate/op/count.rs
+++ b/libcudf-datafusion/src/aggregate/op/count.rs
@@ -1,14 +1,12 @@
 use crate::aggregate::op::udf::CuDFAggregateUDF;
 use crate::aggregate::CuDFAggregationOp;
 use crate::errors::cudf_to_df;
-use arrow::compute::cast;
 use arrow_schema::DataType;
 use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::count::Count;
 use datafusion_expr::AggregateUDF;
-use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
-use std::fmt::Debug;
+use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumn, CuDFColumnView};
 use std::sync::Arc;
 
 pub fn count() -> Arc<AggregateUDF> {
@@ -20,43 +18,49 @@ pub fn count() -> Arc<AggregateUDF> {
 pub struct CuDFCount;
 
 impl CuDFAggregationOp for CuDFCount {
+    fn num_state_columns(&self) -> usize {
+        1
+    }
+
     fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        // Partial: COUNT input values per batch
         if args.len() != 1 {
             return exec_err!("COUNT expects 1 argument, got {}", args.len());
         }
 
         let mut request = AggregationRequest::from_column_view(args[0].clone());
         request.add(AggregationOp::COUNT.group_by());
-
         Ok(vec![request])
     }
 
-    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        // Final: SUM the partial counts
-        if args.len() != 1 {
-            return exec_err!("COUNT final expects 1 argument, got {}", args.len());
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if state_cols.len() != 1 {
+            return exec_err!(
+                "COUNT merge expects 1 state column, got {}",
+                state_cols.len()
+            );
         }
 
-        let mut request = AggregationRequest::from_column_view(args[0].clone());
+        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
         request.add(AggregationOp::SUM.group_by());
-
         Ok(vec![request])
     }
 
-    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
-        if args.len() != 1 {
-            return exec_err!("COUNT merge expects 1 argument, got {}", args.len());
+    fn normalize_partial_state(&self, mut cols: Vec<CuDFColumn>) -> Result<Vec<CuDFColumn>> {
+        // cuDF COUNT returns Int32 -> cast to Int64 to match merge_requests (SUM) output type
+        let casted =
+            libcudf_rs::cast(&cols.remove(0).into_view(), &DataType::Int64).map_err(cudf_to_df)?;
+        Ok(vec![casted])
+    }
+
+    fn finalize(&self, state_cols: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if state_cols.len() != 1 {
+            return exec_err!(
+                "COUNT finalize expects 1 state column, got {}",
+                state_cols.len()
+            );
         }
-
-        // cuDF COUNT returns Int32, but DataFusion expects Int64
-        // Cast to Int64 to match DataFusion's expectation
-        let result_array = args[0].to_arrow_host().map_err(cudf_to_df)?;
-        let casted = cast(&result_array, &DataType::Int64)?;
-
-        // Convert back to CuDFColumn and return view
-        let column =
-            libcudf_rs::CuDFColumn::from_arrow_host(casted.as_ref()).map_err(cudf_to_df)?;
-        Ok(column.into_view())
+        // cuDF COUNT returns Int32, DataFusion expects Int64
+        let casted = libcudf_rs::cast(&state_cols[0], &DataType::Int64).map_err(cudf_to_df)?;
+        Ok(casted.into_view())
     }
 }

--- a/libcudf-datafusion/src/aggregate/op/max.rs
+++ b/libcudf-datafusion/src/aggregate/op/max.rs
@@ -5,7 +5,6 @@ use datafusion::error::Result;
 use datafusion::functions_aggregate::min_max::Max;
 use datafusion_expr::AggregateUDF;
 use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
-use std::fmt::Debug;
 use std::sync::Arc;
 
 pub fn max() -> Arc<AggregateUDF> {
@@ -17,26 +16,37 @@ pub fn max() -> Arc<AggregateUDF> {
 pub struct CuDFMax;
 
 impl CuDFAggregationOp for CuDFMax {
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        self.final_requests(args)
+    fn num_state_columns(&self) -> usize {
+        1
     }
 
-    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
         if args.len() != 1 {
             return exec_err!("MAX expects 1 argument, got {}", args.len());
         }
 
         let mut request = AggregationRequest::from_column_view(args[0].clone());
         request.add(AggregationOp::MAX.group_by());
-
         Ok(vec![request])
     }
 
-    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
-        if args.len() != 1 {
-            return exec_err!("MAX merge expects 1 argument, got {}", args.len());
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if state_cols.len() != 1 {
+            return exec_err!("MAX merge expects 1 state column, got {}", state_cols.len());
         }
 
-        Ok(args[0].clone())
+        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
+        request.add(AggregationOp::MAX.group_by());
+        Ok(vec![request])
+    }
+
+    fn finalize(&self, state_cols: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if state_cols.len() != 1 {
+            return exec_err!(
+                "MAX finalize expects 1 state column, got {}",
+                state_cols.len()
+            );
+        }
+        Ok(state_cols[0].clone())
     }
 }

--- a/libcudf-datafusion/src/aggregate/op/min.rs
+++ b/libcudf-datafusion/src/aggregate/op/min.rs
@@ -5,7 +5,6 @@ use datafusion::error::Result;
 use datafusion::functions_aggregate::min_max::Min;
 use datafusion_expr::AggregateUDF;
 use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
-use std::fmt::Debug;
 use std::sync::Arc;
 
 pub fn min() -> Arc<AggregateUDF> {
@@ -17,26 +16,37 @@ pub fn min() -> Arc<AggregateUDF> {
 pub struct CuDFMin;
 
 impl CuDFAggregationOp for CuDFMin {
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        self.final_requests(args)
+    fn num_state_columns(&self) -> usize {
+        1
     }
 
-    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
         if args.len() != 1 {
             return exec_err!("MIN expects 1 argument, got {}", args.len());
         }
 
         let mut request = AggregationRequest::from_column_view(args[0].clone());
         request.add(AggregationOp::MIN.group_by());
-
         Ok(vec![request])
     }
 
-    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
-        if args.len() != 1 {
-            return exec_err!("MIN merge expects 1 argument, got {}", args.len());
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if state_cols.len() != 1 {
+            return exec_err!("MIN merge expects 1 state column, got {}", state_cols.len());
         }
 
-        Ok(args[0].clone())
+        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
+        request.add(AggregationOp::MIN.group_by());
+        Ok(vec![request])
+    }
+
+    fn finalize(&self, state_cols: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if state_cols.len() != 1 {
+            return exec_err!(
+                "MIN finalize expects 1 state column, got {}",
+                state_cols.len()
+            );
+        }
+        Ok(state_cols[0].clone())
     }
 }

--- a/libcudf-datafusion/src/aggregate/op/mod.rs
+++ b/libcudf-datafusion/src/aggregate/op/mod.rs
@@ -1,5 +1,5 @@
 use datafusion::error::Result;
-use libcudf_rs::{AggregationRequest, CuDFColumnView};
+use libcudf_rs::{AggregationRequest, CuDFColumn, CuDFColumnView};
 use std::fmt::Debug;
 
 pub mod avg;
@@ -9,41 +9,39 @@ pub mod min;
 pub mod sum;
 pub mod udf;
 
-/// GPU aggregation operation trait for two-phase aggregation.
+/// GPU aggregation operation backed by cuDF.
 ///
-/// This trait defines the contract for aggregation operations that can be executed
-/// on the GPU using cuDF's group-by functionality. Aggregations follow a two-phase
-/// pattern to support distributed and streaming execution:
+/// Each implementation defines a three-phase lifecycle that mirrors DataFusion's
+/// Partial/Final model:
 ///
-/// 1. **Partial Phase**: Each input batch is aggregated independently, producing
-///    partial results (e.g., partial sums, counts).
+/// 1. **partial** — aggregate raw input rows into per-group intermediate state
+/// 2. **merge** — combine intermediate states (from multiple batches or partitions)
+/// 3. **finalize** — convert merged state into the final output column
 ///
-/// 2. **Final Phase**: Partial results are concatenated and re-aggregated to produce
-///    the final output. The `merge` function combines the final aggregation results
-///    into a single column.
-///
-/// # Example
-///
-/// For SUM aggregation:
-/// - `partial_requests`: Returns a SUM aggregation request for the input column
-/// - `final_requests`: Returns a SUM aggregation request for the partial sums
-/// - `merge`: Returns the single summed column (identity operation for SUM)
+/// Column ordering in `partial_requests` must match the DataFusion UDF's
+/// `state_fields()` order, since the Partial->Final schema contract is positional.
 pub trait CuDFAggregationOp: Debug + Send + Sync {
-    /// Creates cuDF aggregation requests for the partial phase.
-    ///
-    /// Takes the input columns and returns aggregation requests to compute
-    /// partial results for each input batch.
+    /// Number of intermediate state columns this op produces.
+    /// Must match the DataFusion UDF's `state_fields().len()`.
+    fn num_state_columns(&self) -> usize;
+
+    /// Build cuDF aggregation requests for raw input data.
     fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>>;
 
-    /// Creates cuDF aggregation requests for the final phase.
+    /// Normalize state columns produced by `partial_requests` so their types are
+    /// compatible with `merge_requests` for subsequent merge cycles, and match the
+    /// DataFusion UDF's `state_fields()` contract when emitting `Partial` mode output.
     ///
-    /// Takes the concatenated partial result columns and returns aggregation
-    /// requests to compute the final aggregation.
-    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>>;
+    /// Override when the cuDF operation used in `partial_requests` returns a narrower
+    /// type than the one used in `merge_requests` (e.g. COUNT → Int32, SUM → Int64).
+    /// Default is a no-op.
+    fn normalize_partial_state(&self, cols: Vec<CuDFColumn>) -> Result<Vec<CuDFColumn>> {
+        Ok(cols)
+    }
 
-    /// Merges the final aggregation result columns into a single output column.
-    ///
-    /// For most aggregations this is an identity operation (returning the single
-    /// result column), but some aggregations may need to combine multiple columns.
-    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView>;
+    /// Build cuDF aggregation requests that combine intermediate state columns.
+    fn merge_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>>;
+
+    /// Convert merged state columns into the final output column.
+    fn finalize(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView>;
 }

--- a/libcudf-datafusion/src/aggregate/op/sum.rs
+++ b/libcudf-datafusion/src/aggregate/op/sum.rs
@@ -17,26 +17,40 @@ pub fn sum() -> Arc<AggregateUDF> {
 pub struct CuDFSum;
 
 impl CuDFAggregationOp for CuDFSum {
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
-        self.final_requests(args)
+    fn num_state_columns(&self) -> usize {
+        1
     }
 
-    fn final_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
         if args.len() != 1 {
-            return exec_err!("SUM expects 1 argument, got {}", args.len());
+            return exec_err!("SUM expects 1 argument, received: {}", args.len());
         }
 
         let mut request = AggregationRequest::from_column_view(args[0].clone());
         request.add(AggregationOp::SUM.group_by());
-
         Ok(vec![request])
     }
 
-    fn merge(&self, args: &[CuDFColumnView]) -> Result<CuDFColumnView> {
-        if args.len() != 1 {
-            return exec_err!("SUM merge expects 1 argument, got {}", args.len());
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+        if state_cols.len() != 1 {
+            return exec_err!(
+                "SUM merge expects 1 state column, received: {}",
+                state_cols.len()
+            );
         }
 
-        Ok(args[0].clone())
+        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
+        request.add(AggregationOp::SUM.group_by());
+        Ok(vec![request])
+    }
+
+    fn finalize(&self, state_cols: &[CuDFColumnView]) -> Result<CuDFColumnView> {
+        if state_cols.len() != 1 {
+            return exec_err!(
+                "SUM finalize expects 1 state column, received: {}",
+                state_cols.len()
+            );
+        }
+        Ok(state_cols[0].clone())
     }
 }

--- a/libcudf-datafusion/src/aggregate/op/udf.rs
+++ b/libcudf-datafusion/src/aggregate/op/udf.rs
@@ -13,6 +13,11 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+/// Wraps a DataFusion CPU aggregate UDF with a GPU-backed [`CuDFAggregationOp`].
+///
+/// Delegates all DataFusion metadata (schema, `state_fields`, accumulator) to the
+/// original CPU UDF so that schema contracts are preserved. The `gpu()` accessor
+/// provides the cuDF implementation used at execution time.
 #[derive(Debug)]
 pub struct CuDFAggregateUDF {
     inner: Arc<dyn AggregateUDFImpl>,

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -1,13 +1,15 @@
 use crate::aggregate::op::udf::CuDFAggregateUDF;
 use crate::aggregate::CuDFAggregationOp;
 use crate::errors::cudf_to_df;
-use arrow::array::{ArrayRef, RecordBatch};
+use arrow::array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::SchemaRef;
 use datafusion::common::{exec_err, internal_err};
 use datafusion::error::Result;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream};
 use datafusion::physical_expr::PhysicalExpr;
-use datafusion_physical_plan::aggregates::{evaluate_group_by, evaluate_many, PhysicalGroupBy};
+use datafusion_physical_plan::aggregates::{
+    aggregate_expressions, evaluate_group_by, evaluate_many, AggregateMode, PhysicalGroupBy,
+};
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
 use futures::{ready, StreamExt};
 use libcudf_rs::{CuDFColumn, CuDFColumnView, CuDFGroupBy, CuDFTable, CuDFTableView};
@@ -15,73 +17,80 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-enum State {
-    ReceivingInput,
-    Final,
+/// Number of input batches to accumulate before running a single aggregate and merge cycle.
+const AGGREGATE_CHUNK_BATCHES: usize = 1024;
+
+enum StreamState {
+    ReadingInput,
+    ProducingOutput,
     Done,
 }
 
-/// Results from partial aggregations across batches: `batches -> result groups -> columns`
-/// - Outer Vec: Batches (one entry per input batch processed)
-/// - Middle Vec: Result groups (one per aggregation request sent to cuDF)
-/// - Inner Vec: Columns in that result group (typically 1, but >=2 for multi-column ops like AVG)
+/// Maps each aggregation op to its slice of the flat state_columns array.
 ///
-/// Use `column_mapping` to determine which result groups belong to which operation.
-type PartialResults = Vec<Vec<Vec<CuDFColumn>>>;
-
-/// Tracks which result groups belong to each aggregation operation.
-///
-/// Enables correct slicing of multi-column aggregations like AVG (uses sum and count).
+/// Built once at construction from `num_state_columns()`.
 ///
 /// Example for `[SUM, AVG, MAX]`:
 /// ```text
-/// column_mapping = [
-///   ColumnRange { start: 0, count: 1 }, -> SUM uses result group 0
-///   ColumnRange { start: 1, count: 2 }, -> AVG uses result groups 1-2
-///   ColumnRange { start: 3, count: 1 }, -> MAX uses result group 3
-/// ]
+///   SUM -> (0, 1), AVG -> (1, 2), MAX -> (3, 1)
 /// ```
-#[derive(Debug, Clone)]
-struct ColumnRange {
-    start: usize, // Starting index in result groups
-    count: usize, // Number of result groups this operation uses
+struct ColumnMapping {
+    ranges: Vec<(usize, usize)>, // (start, count) per op
 }
 
+/// Running O(G) state: unique group keys + intermediate state columns.
+struct RunningState {
+    keys: CuDFTable,
+    state_columns: Vec<CuDFColumn>, // flat, indexed via ColumnMapping
+}
+
+/// GPU-accelerated GROUP BY aggregation stream using chunked aggregation.
+///
+/// Input batches are accumulated into a pending buffer. Once the buffer reaches
+/// `AGGREGATE_CHUNK_BATCHES` batches (or input is exhausted), all pending batches
+/// are concatenated on the GPU into a single table and aggregated in one kernel call.
+/// The result (at most G rows, where G is the group cardinality) is merged into the
+/// running state using the standard partial-state merge.
+///
+/// After all input is consumed, a single output batch is produced by either
+/// finalizing the state (Single/Final modes) or emitting raw state columns
+/// (Partial mode).
 pub struct Stream {
     input: SendableRecordBatchStream,
     output_schema: SchemaRef,
-
+    mode: AggregateMode,
     group_by: PhysicalGroupBy,
-
+    /// DataFusion expressions -> used for schema metadata (e.g., `state_fields()`).
     aggregate_expr: Vec<Arc<AggregateFunctionExpr>>,
+    /// Physical expressions that extract each op's argument columns from a batch.
     aggregate_args: Vec<Vec<Arc<dyn PhysicalExpr>>>,
+    /// GPU aggregation implementations (one per aggregate function).
     aggregate_ops: Vec<Arc<dyn CuDFAggregationOp>>,
-
-    state: State,
-
-    keys: Vec<CuDFTable>,
-
-    results: PartialResults,
-
-    column_mapping: Vec<ColumnRange>,
+    column_mapping: ColumnMapping,
+    state: StreamState,
+    /// Batches accumulated since the last flush, cleared on each flush.
+    pending_batches: Vec<RecordBatch>,
+    /// Aggregated running state (at most G rows), updated after each flush.
+    running: Option<RunningState>,
 }
 
 impl Stream {
     pub fn new(
         input: SendableRecordBatchStream,
         output_schema: SchemaRef,
+        mode: AggregateMode,
         group_by: PhysicalGroupBy,
         aggregate_expr: Vec<Arc<AggregateFunctionExpr>>,
-    ) -> Self {
-        let aggregate_args = aggregate_expr
-            .iter()
-            .map(|x| x.expressions())
-            .collect::<Vec<_>>();
+    ) -> Result<Self> {
+        let aggregate_args = aggregate_expressions(&aggregate_expr, &mode, group_by.expr().len())?;
 
+        // Extract the GPU op from each CuDFAggregateUDF wrapper.
+        // Safe to unwrap: the optimizer only creates CuDFAggregateExec when all
+        // aggregate functions are backed by CuDFAggregateUDF.
         let aggregate_ops = aggregate_expr
             .iter()
-            .map(|x| {
-                x.fun()
+            .map(|expr| {
+                expr.fun()
                     .inner()
                     .as_any()
                     .downcast_ref::<CuDFAggregateUDF>()
@@ -91,131 +100,217 @@ impl Stream {
             })
             .collect::<Vec<_>>();
 
-        Self {
+        let column_mapping = {
+            let mut offset = 0;
+            let ranges = aggregate_ops
+                .iter()
+                .map(|op| {
+                    let count = op.num_state_columns();
+                    let start = offset;
+                    offset += count;
+                    (start, count)
+                })
+                .collect();
+            ColumnMapping { ranges }
+        };
+
+        Ok(Self {
             input,
             output_schema,
+            mode,
             group_by,
             aggregate_expr,
             aggregate_args,
             aggregate_ops,
-            state: State::ReceivingInput,
-            keys: vec![],
-            results: vec![],
-            column_mapping: vec![],
-        }
+            column_mapping,
+            state: StreamState::ReadingInput,
+            pending_batches: Vec::new(),
+            running: None,
+        })
     }
 
-    /// Concatenate unique group keys from all batches.
+    /// Aggregate all pending batches in one GPU kernel call and merge the result
+    /// into the running state.
     ///
-    /// Consumes `self.keys` and produces a single table containing all unique group keys that will
-    /// be used for the final aggregation phase.
-    fn concat_keys(&mut self) -> Result<CuDFTable> {
-        let mut keys = Vec::with_capacity(self.keys.len());
-        for table in std::mem::take(&mut self.keys) {
-            keys.push(table.into_view());
+    /// Clears `pending_batches` on return.
+    fn flush_pending(&mut self) -> Result<()> {
+        if self.pending_batches.is_empty() {
+            return Ok(());
         }
-        CuDFTable::concat(keys).map_err(cudf_to_df)
+
+        let chunk = concat_cudf_batches(&self.pending_batches)?;
+        self.pending_batches.clear();
+
+        let group_by = self.evaluate_batch_groups(&chunk)?;
+        let evaluated_args = self.evaluate_batch_arguments(&chunk)?;
+        let requests = self.build_batch_requests(evaluated_args)?;
+
+        let (chunk_keys, chunk_results) = group_by.aggregate(&requests).map_err(cudf_to_df)?;
+        let mut chunk_state_columns = chunk_results.into_iter().flatten().collect();
+
+        // Normalize partial state column types so they are compatible with merge_requests.
+        if !matches!(
+            self.mode,
+            AggregateMode::Final | AggregateMode::FinalPartitioned
+        ) {
+            chunk_state_columns = self.normalize_partial_state(chunk_state_columns)?;
+        }
+
+        self.merge_into_running(chunk_keys, chunk_state_columns)
     }
 
-    /// Concatenate partial aggregation results from all batches.
-    ///
-    /// This groups columns by their result group index (middle Vec in PartialResults),
-    /// concatenates across batches, then returns them in the same grouped structure.
-    ///
-    /// # Steps
-    /// 1. Group columns by result group index across all batches
-    /// 2. For each result group, concatenate columns from all batches
-    /// 3. Return concatenated results in same structure as input
-    ///
-    /// # Example
-    /// ```text
-    /// Input (3 batches, 2 result groups each):
-    /// [
-    ///   [[col_b1_g0], [col_b1_g1]], -> Batch 1
-    ///   [[col_b2_g0], [col_b2_g1]], -> Batch 2
-    ///   [[col_b3_g0], [col_b3_g1]]  -> Batch 3
-    /// ]
-    ///
-    /// Output (2 result groups, concatenated across batches):
-    /// [
-    ///   [concat(col_b1_g0, col_b2_g0, col_b3_g0)], -> Group 0
-    ///   [concat(col_b1_g1, col_b2_g1, col_b3_g1)]  -> Group 1
-    /// ]
-    /// ```
-    fn concat_partial_results(&mut self) -> Result<Vec<Vec<CuDFColumnView>>> {
-        // Infer structure from first batch
-        let first = self.results.first().expect("at least one result");
-        let mut partial_columns = Vec::with_capacity(first.len());
-        for agg_results in first {
-            partial_columns.push(vec![
-                Vec::with_capacity(self.results.len());
-                agg_results.len()
-            ])
+    /// Dispatch `normalize_partial_state` for each op over the flat state column vec.
+    fn normalize_partial_state(&self, cols: Vec<CuDFColumn>) -> Result<Vec<CuDFColumn>> {
+        let mut result = Vec::with_capacity(cols.len());
+        let mut col_iter = cols.into_iter();
+        for op_idx in 0..self.aggregate_ops.len() {
+            let (_, count) = self.column_mapping.ranges[op_idx];
+            let op_cols: Vec<CuDFColumn> = col_iter.by_ref().take(count).collect();
+            result.extend(self.aggregate_ops[op_idx].normalize_partial_state(op_cols)?);
         }
-
-        // Group columns by result group index across batches
-        for results in std::mem::take(&mut self.results) {
-            for (r_i, columns) in results.into_iter().enumerate() {
-                for (c_i, column) in columns.into_iter().enumerate() {
-                    partial_columns[r_i][c_i].push(column.into_view());
-                }
-            }
-        }
-
-        // Concatenate each group
-        partial_columns
-            .into_iter()
-            .map(|columns| {
-                columns
-                    .into_iter()
-                    .map(|views| Ok(CuDFColumn::concat(views).map_err(cudf_to_df)?.into_view()))
-                    .collect()
-            })
-            .collect()
+        Ok(result)
     }
 
-    /// Build the final output RecordBatch from aggregation results.
+    /// Build aggregation requests for a chunk based on mode.
     ///
-    /// Combines group keys with merged aggregation results into a single RecordBatch
-    /// matching the output schema.
-    ///
-    /// # Steps
-    /// 1. Add group key columns to output
-    /// 2. For each aggregation operation, extract its columns using column_mapping
-    /// 3. Call merge() to combine multi-column results (e.g., AVG: sum/count → average)
-    /// 4. Add merged result to output
-    fn build_final_batch(
+    /// - Single/Partial/SinglePartitioned: use `partial_requests` (input is raw data)
+    /// - Final/FinalPartitioned: use `merge_requests` (input is partial state)
+    fn build_batch_requests(
         &self,
-        keys: CuDFTable,
-        mut results: Vec<Vec<CuDFColumn>>,
-    ) -> Result<RecordBatch> {
-        let groups = keys.into_columns();
-        let mut arrays: Vec<ArrayRef> =
-            Vec::with_capacity(groups.len() + self.aggregate_expr.len());
-        for group in groups {
-            arrays.push(Arc::new(group.into_view()))
+        evaluated_args: Vec<Vec<CuDFColumnView>>,
+    ) -> Result<Vec<libcudf_rs::AggregationRequest>> {
+        let mut requests = Vec::new();
+
+        let use_merge = matches!(
+            self.mode,
+            AggregateMode::Final | AggregateMode::FinalPartitioned
+        );
+
+        for (op, args) in self.aggregate_ops.iter().zip(evaluated_args) {
+            let op_requests = if use_merge {
+                op.merge_requests(&args)?
+            } else {
+                op.partial_requests(&args)?
+            };
+            requests.extend(op_requests);
         }
 
-        for (aggr, mapping) in self.aggregate_ops.iter().zip(&self.column_mapping) {
-            // Use mapping to extract the correct columns for this operation
-            let range = mapping.start..(mapping.start + mapping.count);
-            let mut args: Vec<CuDFColumnView> = Vec::new();
-            for i in range {
-                for col in results[i].drain(..) {
-                    args.push(col.into_view());
-                }
-            }
-            let merged = aggr.merge(&args)?;
-            arrays.push(Arc::new(merged));
-        }
-
-        Ok(RecordBatch::try_new(self.output_schema.clone(), arrays)?)
+        Ok(requests)
     }
 
-    /// Evaluate group keys from a batch and create a CuDFGroupBy instance.
+    /// Merge new chunk results into the running state.
     ///
-    /// Extracts the group key columns from the input batch and prepares them
-    /// for use in GPU aggregation.
+    /// If no running state exists, stores the new results directly.
+    /// Otherwise, concatenates running + new, then re-aggregates with merge_requests.
+    fn merge_into_running(
+        &mut self,
+        new_keys: CuDFTable,
+        new_state_columns: Vec<CuDFColumn>,
+    ) -> Result<()> {
+        let Some(running) = self.running.take() else {
+            self.running = Some(RunningState {
+                keys: new_keys,
+                state_columns: new_state_columns,
+            });
+            return Ok(());
+        };
+
+        // Concat keys
+        let combined_keys = CuDFTable::concat(vec![running.keys.into_view(), new_keys.into_view()])
+            .map_err(cudf_to_df)?;
+
+        // Concat each state column pair
+        let mut combined_state_columns = Vec::with_capacity(running.state_columns.len());
+        for (run_col, new_col) in running
+            .state_columns
+            .into_iter()
+            .zip(new_state_columns.into_iter())
+        {
+            let combined = CuDFColumn::concat(vec![run_col.into_view(), new_col.into_view()])
+                .map_err(cudf_to_df)?;
+            combined_state_columns.push(combined);
+        }
+
+        // Convert to views for merge requests
+        let combined_views: Vec<CuDFColumnView> = combined_state_columns
+            .into_iter()
+            .map(|col| col.into_view())
+            .collect();
+
+        // Build merge requests
+        let mut requests = Vec::new();
+        for (op_idx, op) in self.aggregate_ops.iter().enumerate() {
+            let (start, count) = self.column_mapping.ranges[op_idx];
+            let state_views: Vec<CuDFColumnView> = combined_views[start..start + count].to_vec();
+            requests.extend(op.merge_requests(&state_views)?);
+        }
+
+        // Re-aggregate
+        let group_by = CuDFGroupBy::from_table_view(combined_keys.into_view());
+        let (merged_keys, merged_results) = group_by.aggregate(&requests).map_err(cudf_to_df)?;
+        let merged_state_columns = merged_results.into_iter().flatten().collect();
+
+        self.running = Some(RunningState {
+            keys: merged_keys,
+            state_columns: merged_state_columns,
+        });
+
+        Ok(())
+    }
+
+    /// Build the final output RecordBatch from the running state.
+    fn build_output(&mut self) -> Result<Option<RecordBatch>> {
+        let Some(running) = self.running.take() else {
+            return Ok(None);
+        };
+
+        let key_columns = running.keys.into_columns();
+        let mut arrays: Vec<ArrayRef> =
+            Vec::with_capacity(key_columns.len() + self.aggregate_expr.len());
+
+        for col in key_columns {
+            arrays.push(Arc::new(col.into_view()));
+        }
+
+        let state_views: Vec<CuDFColumnView> = running
+            .state_columns
+            .into_iter()
+            .map(|c| c.into_view())
+            .collect();
+
+        let is_partial = matches!(self.mode, AggregateMode::Partial);
+
+        for (op_idx, op) in self.aggregate_ops.iter().enumerate() {
+            let (start, count) = self.column_mapping.ranges[op_idx];
+            let state_views: Vec<CuDFColumnView> = state_views[start..start + count].to_vec();
+
+            if is_partial {
+                // Partial mode: emit raw state columns, cast to match state_fields schema
+                let state_fields = self.aggregate_expr[op_idx].state_fields()?;
+                for (col_idx, view) in state_views.into_iter().enumerate() {
+                    let target_type = state_fields[col_idx].data_type();
+                    if view.data_type() != target_type {
+                        let casted = libcudf_rs::cast(&view, target_type).map_err(cudf_to_df)?;
+                        arrays.push(Arc::new(casted.into_view()));
+                    } else {
+                        arrays.push(Arc::new(view));
+                    }
+                }
+            } else {
+                // Single/Final/FinalPartitioned/SinglePartitioned: finalize
+                let finalized = op.finalize(&state_views)?;
+                arrays.push(Arc::new(finalized));
+            }
+        }
+
+        Ok(Some(RecordBatch::try_new(
+            self.output_schema.clone(),
+            arrays,
+        )?))
+    }
+
+    /// Evaluate GROUP BY expressions on a batch and wrap the resulting key
+    /// columns into a [`CuDFGroupBy`] for GPU aggregation.
     fn evaluate_batch_groups(&self, batch: &RecordBatch) -> Result<CuDFGroupBy> {
         let grouping_sets = evaluate_group_by(&self.group_by, batch)?;
 
@@ -226,19 +321,21 @@ impl Stream {
         let group = &grouping_sets[0];
         let column_views = group
             .iter()
-            .map(|x| x.as_any().downcast_ref::<CuDFColumnView>().unwrap())
-            .cloned()
-            .collect::<Vec<_>>();
+            .map(|arr| {
+                let Some(view) = arr.as_any().downcast_ref::<CuDFColumnView>() else {
+                    return internal_err!("Expected Array to be of type CuDFColumnView");
+                };
+                Ok(view.clone())
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         let table_view = CuDFTableView::from_column_views(column_views).map_err(cudf_to_df)?;
 
         Ok(CuDFGroupBy::from_table_view(table_view))
     }
 
-    /// Evaluate aggregate function arguments from a batch.
-    ///
-    /// Extracts and validates the argument columns for each aggregation operation,
-    /// ensuring they are CuDFColumnViews suitable for GPU processing.
+    /// Evaluate each aggregate function's argument expressions on a batch,
+    /// returning GPU column views suitable for `partial_requests` / `merge_requests`.
     fn evaluate_batch_arguments(&self, batch: &RecordBatch) -> Result<Vec<Vec<CuDFColumnView>>> {
         let evaluated_arguments = evaluate_many(&self.aggregate_args, batch)?;
 
@@ -256,74 +353,29 @@ impl Stream {
             })
             .collect()
     }
+}
 
-    /// Build aggregation requests for partial phase.
-    ///
-    /// On first call, also computes and stores the column mapping that describes
-    /// which result groups belong to which operations. On subsequent calls, reuses
-    /// the existing mapping.
-    ///
-    /// Returns the list of aggregation requests to send to cuDF.
-    fn build_partial_requests(
-        &mut self,
-        evaluated_views: Vec<Vec<CuDFColumnView>>,
-    ) -> Result<Vec<libcudf_rs::AggregationRequest>> {
-        let mut requests = Vec::with_capacity(evaluated_views.len());
-
-        let is_first_batch = self.column_mapping.is_empty();
-
-        if is_first_batch {
-            // First batch: build mapping
-            let mut col_offset = 0;
-            let mut column_mapping = Vec::with_capacity(self.aggregate_ops.len());
-
-            for (agg, args) in self.aggregate_ops.iter().zip(evaluated_views) {
-                let op_requests = agg.partial_requests(&args)?;
-                let col_count = op_requests.len();
-
-                column_mapping.push(ColumnRange {
-                    start: col_offset,
-                    count: col_count,
-                });
-
-                col_offset += col_count;
-                requests.extend(op_requests);
-            }
-
-            self.column_mapping = column_mapping;
-        } else {
-            // Subsequent batches: reuse mapping
-            for (agg, args) in self.aggregate_ops.iter().zip(evaluated_views) {
-                requests.extend(agg.partial_requests(&args)?);
-            }
-        }
-
-        Ok(requests)
-    }
-
-    /// Build aggregation requests for final phase.
-    ///
-    /// Uses the column mapping to correctly slice concatenated partial results,
-    /// ensuring each operation receives all its columns (e.g., AVG gets both sum and count).
-    fn build_final_requests(
-        &self,
-        concatenated_columns: &[Vec<CuDFColumnView>],
-    ) -> Result<Vec<libcudf_rs::AggregationRequest>> {
-        let mut requests = Vec::with_capacity(self.aggregate_expr.len());
-
-        for (agg, mapping) in self.aggregate_ops.iter().zip(&self.column_mapping) {
-            // Slice to get columns for this operation
-            let range = mapping.start..(mapping.start + mapping.count);
-            let op_columns: Vec<CuDFColumnView> = concatenated_columns[range]
+/// Concatenate CuDF-backed record batches into a single batch by column.
+fn concat_cudf_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
+    let schema = batches[0].schema();
+    let cols = (0..schema.fields().len())
+        .map(|i| {
+            let views = batches
                 .iter()
-                .flat_map(|cols| cols.iter().cloned())
-                .collect();
-
-            requests.extend(agg.final_requests(&op_columns)?);
-        }
-
-        Ok(requests)
-    }
+                .map(|b| {
+                    let Some(view) = b.column(i).as_any().downcast_ref::<CuDFColumnView>() else {
+                        return internal_err!(
+                            "Expected Array to be of type CuDFColumnView after CuDFLoadExec"
+                        );
+                    };
+                    Ok(view.clone())
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let col = CuDFColumn::concat(views).map_err(cudf_to_df)?;
+            Ok(Arc::new(col.into_view()) as Arc<dyn Array>)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(RecordBatch::try_new(schema, cols)?)
 }
 
 impl futures::Stream for Stream {
@@ -332,44 +384,28 @@ impl futures::Stream for Stream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
             match &self.state {
-                State::ReceivingInput => {
-                    match ready!(self.input.poll_next_unpin(cx)) {
-                        None => {
-                            // finished
-                            self.state = State::Final;
-                        }
-                        Some(Err(err)) => return Poll::Ready(Some(Err(err))),
-                        Some(Ok(batch)) => {
-                            let group_by = self.evaluate_batch_groups(&batch)?;
-                            let evaluated_views = self.evaluate_batch_arguments(&batch)?;
-                            let requests = self.build_partial_requests(evaluated_views)?;
-
-                            let (keys, results) =
-                                group_by.aggregate(&requests).map_err(cudf_to_df)?;
-
-                            self.results.push(results);
-                            self.keys.push(keys);
+                StreamState::ReadingInput => match ready!(self.input.poll_next_unpin(cx)) {
+                    None => {
+                        self.state = StreamState::ProducingOutput;
+                    }
+                    Some(Err(e)) => return Poll::Ready(Some(Err(e))),
+                    Some(Ok(batch)) => {
+                        self.pending_batches.push(batch);
+                        if self.pending_batches.len() >= AGGREGATE_CHUNK_BATCHES {
+                            self.flush_pending()?;
                         }
                     }
+                },
+                StreamState::ProducingOutput => {
+                    self.flush_pending()?;
+                    let output = self.build_output()?;
+                    self.state = StreamState::Done;
+                    return match output {
+                        Some(batch) => Poll::Ready(Some(Ok(batch))),
+                        None => Poll::Ready(None),
+                    };
                 }
-                State::Final => {
-                    if self.results.is_empty() {
-                        return Poll::Ready(None);
-                    }
-
-                    let keys_table = self.concat_keys()?;
-                    let group_by = CuDFGroupBy::from_table_view(keys_table.into_view());
-
-                    let concatenated_columns = self.concat_partial_results()?;
-                    let requests = self.build_final_requests(&concatenated_columns)?;
-
-                    let (keys, results) = group_by.aggregate(&requests).map_err(cudf_to_df)?;
-                    let output = self.build_final_batch(keys, results)?;
-
-                    self.state = State::Done;
-                    return Poll::Ready(Some(Ok(output)));
-                }
-                State::Done => return Poll::Ready(None),
+                StreamState::Done => return Poll::Ready(None),
             }
         }
     }

--- a/libcudf-datafusion/src/optimizer/host_to_cudf.rs
+++ b/libcudf-datafusion/src/optimizer/host_to_cudf.rs
@@ -1,3 +1,4 @@
+use crate::aggregate::{CuDFAggregateExec, CuDFAggregateUDF};
 use crate::optimizer::CuDFConfig;
 use crate::physical::{
     is_cudf_plan, CuDFCoalesceBatchesExec, CuDFFilterExec, CuDFLoadExec, CuDFProjectionExec,
@@ -5,6 +6,7 @@ use crate::physical::{
 };
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
+use datafusion::error::Result;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion_physical_plan::aggregates::AggregateExec;
 use datafusion_physical_plan::coalesce_batches::CoalesceBatchesExec;
@@ -13,6 +15,50 @@ use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::sorts::sort::SortExec;
 use datafusion_physical_plan::ExecutionPlan;
 use std::sync::Arc;
+
+/// Try to convert an `AggregateExec` to a `CuDFAggregateExec`.
+///
+/// Returns `Ok(None)` (CPU fallback) if any unsupported feature is detected:
+/// - No GROUP BY columns (global aggregation requires synthetic key, not yet supported)
+/// - Non-single grouping sets (CUBE, ROLLUP)
+/// - DISTINCT or ORDER BY in any aggregate function
+/// - Any aggregate function not backed by `CuDFAggregateUDF`
+///
+/// Note: GROUP BY keys with Arrow `Utf8View` (StringView) type are handled transparently.
+/// `CuDFLoadExec` coerces `Utf8View → Utf8` in both schema and data, and `CuDFUnloadExec`
+/// casts back to `Utf8View` so upstream CPU nodes see the original type.
+fn try_as_cudf_aggregate(node: &AggregateExec) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+    // TODO: support global aggregation (no GROUP BY) by injecting a synthetic constant key.
+    if node.group_expr().expr().is_empty() {
+        return Ok(None);
+    }
+    // TODO: support CUBE and ROLLUP grouping sets.
+    if !node.group_expr().is_single() {
+        return Ok(None);
+    }
+    for expr in node.aggr_expr() {
+        // TODO: support DISTINCT aggregates (e.g. COUNT DISTINCT).
+        // TODO: support ORDER BY inside aggregate functions (e.g. ARRAY_AGG(x ORDER BY x)).
+        if expr.is_distinct() || !expr.order_bys().is_empty() {
+            return Ok(None);
+        }
+        if expr
+            .fun()
+            .inner()
+            .as_any()
+            .downcast_ref::<CuDFAggregateUDF>()
+            .is_none()
+        {
+            return Ok(None);
+        }
+    }
+    Ok(Some(Arc::new(CuDFAggregateExec::try_new(
+        node.input().clone(),
+        *node.mode(),
+        node.group_expr().clone(),
+        node.aggr_expr().to_vec(),
+    )?)))
+}
 
 #[derive(Debug)]
 pub struct HostToCuDFRule;
@@ -51,6 +97,10 @@ impl PhysicalOptimizerRule for HostToCuDFRule {
                         cudf_config.batch_size,
                     )));
                 }
+            }
+
+            if let Some(node) = plan.as_any().downcast_ref::<AggregateExec>() {
+                cudf_node = try_as_cudf_aggregate(node)?;
             }
 
             let mut changed = false;

--- a/libcudf-datafusion/src/test_utils/session_context.rs
+++ b/libcudf-datafusion/src/test_utils/session_context.rs
@@ -1,4 +1,6 @@
+use crate::aggregate::{avg, count, max, min, sum};
 use crate::optimizer::{CuDFConfig, HostToCuDFRule};
+use arrow::array::RecordBatch;
 use arrow::util::pretty::pretty_format_batches;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
@@ -24,6 +26,14 @@ impl TestFramework {
             .with_physical_optimizer_rule(Arc::new(HostToCuDFRule))
             .build();
         let ctx = SessionContext::from(state);
+
+        // Register GPU-backed aggregate UDFs so SQL queries route to the cuDF path.
+        ctx.register_udaf((*avg()).clone());
+        ctx.register_udaf((*count()).clone());
+        ctx.register_udaf((*max()).clone());
+        ctx.register_udaf((*min()).clone());
+        ctx.register_udaf((*sum()).clone());
+
         let mut base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         base.pop();
         ctx.register_parquet(
@@ -71,6 +81,7 @@ impl TestPlan {
         Ok(SqlResult {
             pretty_print: pretty_format_batches(&batches)?.to_string(),
             plan: self.display(),
+            batches,
         })
     }
 
@@ -82,4 +93,5 @@ impl TestPlan {
 pub struct SqlResult {
     pub pretty_print: String,
     pub plan: String,
+    pub batches: Vec<RecordBatch>,
 }


### PR DESCRIPTION
## Summary

Redesigns the DataFusion aggregate stream around explicit aggregate state columns, chunked input flushing, and final state materialization.

This PR builds on the basic aggregate execution PR and adds:

- a `CuDFAggregationOp` state lifecycle: partial, normalize, merge, finalize
- chunked aggregate execution over pending input batches
- running GPU aggregate state for grouped aggregates
- optimizer routing from supported DataFusion `AggregateExec` nodes into `CuDFAggregateExec`
- aggregate UDF registration in the test framework
- a Criterion aggregate benchmark

## Notes

- Unsupported aggregate shapes still fall back to CPU: global aggregation, grouping sets, distinct aggregates, aggregate order-by, and non-cuDF aggregate functions.
- `criterion` is added as a dev dependency for the new benchmark target.
- Full `cargo test -p libcudf-datafusion --locked` still has the previously identified unrelated snapshot nondeterminism from `LIMIT 1` weather parquet tests. I plan to keep that as a separate small follow-up PR.

## Validation

- `cargo fmt --all`
- `git diff --cached --check`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p libcudf-datafusion --locked`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-datafusion aggregate::test --lib --locked`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p libcudf-datafusion --benches --locked`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo bench -p libcudf-datafusion --bench aggregate --locked -- --sample-size 10 --warm-up-time 1 --measurement-time 2`

Focused aggregate tests pass: 5 passed, 20 filtered out.

## Benchmark Results

Bounded Criterion run, so treat these as directional rather than publication-grade.

| query | rows | CPU mean | GPU mean | GPU speedup |
|---|---:|---:|---:|---:|
| sum | 1M | 20.554 ms | 27.703 ms | 0.74x |
| sum | 5M | 80.074 ms | 59.296 ms | 1.35x |
| sum | 20M | 298.456 ms | 175.843 ms | 1.70x |
| count | 1M | 20.139 ms | 27.186 ms | 0.74x |
| count | 5M | 72.791 ms | 58.898 ms | 1.24x |
| count | 20M | 271.922 ms | 174.750 ms | 1.56x |
| avg | 1M | 22.339 ms | 35.060 ms | 0.64x |
| avg | 5M | 80.826 ms | 68.567 ms | 1.18x |
| avg | 20M | 298.184 ms | 187.718 ms | 1.59x |
| min/max | 1M | 22.343 ms | 34.828 ms | 0.64x |
| min/max | 5M | 84.070 ms | 68.122 ms | 1.23x |
| min/max | 20M | 314.923 ms | 190.208 ms | 1.66x |
| combined | 1M | 38.425 ms | 67.538 ms | 0.57x |
| combined | 5M | 137.476 ms | 104.954 ms | 1.31x |
| combined | 20M | 505.627 ms | 238.087 ms | 2.12x |
