### PR TITLE
Add GPU metrics, memory pools, and benchmarks

### DIFF
--- a/libcudf-datafusion/Cargo.toml
+++ b/libcudf-datafusion/Cargo.toml
@@ -69,6 +69,14 @@ harness = false
 name = "join"
 harness = false
 
+[[bench]]
+name = "load_unload"
+harness = false
+
+[[bench]]
+name = "tpch_pipeline"
+harness = false
+
 [[bin]]
 name = "cli"
 path = "bin/cli.rs"

--- a/libcudf-datafusion/benches/aggregate.rs
+++ b/libcudf-datafusion/benches/aggregate.rs
@@ -8,7 +8,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_physical_plan::{execute_stream, ExecutionPlan};
 use futures_util::TryStreamExt;
 use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-use libcudf_datafusion::{CuDFConfig, HostToCuDFRule};
+use libcudf_datafusion::{configure_default_pools, CuDFConfig, HostToCuDFRule};
 use std::hint::black_box;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -84,6 +84,7 @@ async fn build_plan(ctx: &SessionContext, sql: &str) -> Arc<dyn ExecutionPlan> {
 }
 
 fn bench_group(c: &mut Criterion, group_name: &str, sql: &str) {
+    configure_default_pools();
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group(group_name);
 

--- a/libcudf-datafusion/benches/join.rs
+++ b/libcudf-datafusion/benches/join.rs
@@ -2,7 +2,9 @@ use arrow::array::{Int32Array, Int64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use libcudf_rs::{inner_join, left_join, left_semi_join, CuDFTable, CuDFTableView};
+use libcudf_rs::{
+    configure_default_pools, inner_join, left_join, left_semi_join, CuDFTable, CuDFTableView,
+};
 use std::hint::black_box;
 use std::sync::Arc;
 
@@ -51,6 +53,7 @@ fn gpu_views(left_n: usize, right_m: usize) -> (CuDFTableView, CuDFTableView) {
 }
 
 fn bench_inner_join(c: &mut Criterion) {
+    configure_default_pools();
     let mut group = c.benchmark_group("join/inner");
 
     for &(left_n, right_m) in SIZES {

--- a/libcudf-datafusion/benches/load_unload.rs
+++ b/libcudf-datafusion/benches/load_unload.rs
@@ -1,0 +1,194 @@
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use datafusion::execution::TaskContext;
+use datafusion_physical_plan::test::TestMemoryExec;
+use datafusion_physical_plan::{execute_stream, ExecutionPlan};
+use futures_util::TryStreamExt;
+use libcudf_datafusion::{configure_default_pools, CuDFLoadExec, CuDFUnloadExec};
+use std::hint::black_box;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+const SIZES: &[usize] = &[100_000, 1_000_000, 10_000_000];
+
+fn make_cpu_batches(total_rows: usize) -> Vec<RecordBatch> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("orderkey", DataType::Int64, false),
+        Field::new("custkey", DataType::Int64, false),
+        Field::new("orderstatus", DataType::Utf8, false),
+        Field::new("totalprice", DataType::Float64, false),
+        Field::new("orderdate", DataType::Int32, false),
+        Field::new("orderpriority", DataType::Utf8, false),
+        Field::new("clerk", DataType::Utf8, false),
+        Field::new("shippriority", DataType::Int32, false),
+        Field::new("comment", DataType::Utf8, false),
+    ]));
+    let batch_size = 8192;
+    let mut batches = Vec::new();
+    let mut offset = 0;
+    while offset < total_rows {
+        let len = batch_size.min(total_rows - offset);
+        batches.push(
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from_iter_values(0..len as i64)),
+                    Arc::new(Int64Array::from_iter_values(0..len as i64)),
+                    Arc::new(StringArray::from(vec!["O"; len])),
+                    Arc::new(Float64Array::from_iter_values((0..len).map(|i| i as f64))),
+                    Arc::new(Int32Array::from_iter_values(0..len as i32)),
+                    Arc::new(StringArray::from(vec!["3-MEDIUM"; len])),
+                    Arc::new(StringArray::from(vec!["Clerk#000000001"; len])),
+                    Arc::new(Int32Array::from_iter_values(vec![0i32; len])),
+                    Arc::new(StringArray::from(vec!["comment"; len])),
+                ],
+            )
+            .unwrap(),
+        );
+        offset += len;
+    }
+    batches
+}
+
+fn load_plan(batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {
+    let schema = batches[0].schema();
+    let mem = Arc::new(TestMemoryExec::try_new(&[batches], schema, None).unwrap());
+    Arc::new(CuDFLoadExec::try_new(mem).unwrap())
+}
+
+fn unload_plan(gpu_batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {
+    let schema = gpu_batches[0].schema();
+    let mem = Arc::new(TestMemoryExec::try_new(&[gpu_batches], schema, None).unwrap());
+    Arc::new(CuDFUnloadExec::new(mem))
+}
+
+async fn drain(plan: Arc<dyn ExecutionPlan>) {
+    let ctx = Arc::new(TaskContext::default());
+    black_box(
+        execute_stream(plan, ctx)
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+    );
+}
+
+fn gpu_batches(rt: &Runtime, total_rows: usize) -> Vec<RecordBatch> {
+    rt.block_on(async {
+        let ctx = Arc::new(TaskContext::default());
+        execute_stream(load_plan(make_cpu_batches(total_rows)), ctx)
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap()
+    })
+}
+
+// Unpooled benchmarks must run first, pools are one-time global state.
+
+fn bench_load_unpooled(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("load");
+    for &total_rows in SIZES {
+        let batches = make_cpu_batches(total_rows);
+        let bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("unpooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || load_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_unload_unpooled(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("unload");
+    for &total_rows in SIZES {
+        let batches = gpu_batches(&rt, total_rows);
+        let bytes: usize = make_cpu_batches(total_rows)
+            .iter()
+            .map(|b| b.get_array_memory_size())
+            .sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("unpooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || unload_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_load_pooled(c: &mut Criterion) {
+    configure_default_pools();
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("load");
+    for &total_rows in SIZES {
+        let batches = make_cpu_batches(total_rows);
+        let bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("pooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || load_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_unload_pooled(c: &mut Criterion) {
+    // pools already configured by bench_load_pooled
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("unload");
+    for &total_rows in SIZES {
+        let batches = gpu_batches(&rt, total_rows);
+        let bytes: usize = make_cpu_batches(total_rows)
+            .iter()
+            .map(|b| b.get_array_memory_size())
+            .sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("pooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || unload_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_load_unpooled,
+    bench_unload_unpooled,
+    bench_load_pooled,
+    bench_unload_pooled
+);
+criterion_main!(benches);

--- a/libcudf-datafusion/benches/tpch_pipeline.rs
+++ b/libcudf-datafusion/benches/tpch_pipeline.rs
@@ -1,0 +1,226 @@
+//! # TPC-H Pipeline Benchmark
+//!
+//! ## What this benchmark measures
+//!
+//! End-to-end wall-clock latency for a TPC-H Q5-style pipeline:
+//! Parquet scan -> hash join -> aggregate. Both CPU and GPU paths read the same
+//! files from disk; the GPU path uploads the raw input once over PCIe, runs
+//! the join and aggregate entirely on-device, then downloads only the 25-row
+//! result.
+//!
+//! This is an integration benchmark, not a microbenchmark. It measures query
+//! latency as a user would observe it. It does not isolate individual operators;
+//! use `nsys` or `ncu` for per-kernel attribution.
+//!
+//! ## Per-operator GPU profiling
+//!
+//! To attribute time between `CuDFLoadExec`, `CuDFHashJoinExec`, and
+//! `CuDFAggregateExec`, profile the benchmark binary directly:
+//!
+//! ```sh
+//! cargo build --release --bench tpch_pipeline
+//! nsys profile --stats=true \
+//!     ./target/release/deps/tpch_pipeline-* \
+//!     --bench --profile-time 5
+//! nsys stats last_report.nsys-rep
+//! ```
+//!
+//! ## Data
+//!
+//! TPC-H Parquet files from `testdata/tpch/correctness_sf{scale}/`.
+//! The benchmark defaults to SF=1. Set `LIBCUDF_TPCH_SCALE_FACTOR` to run
+//! another generated scale factor:
+//!
+//! ```sh
+//! LIBCUDF_TPCH_SCALE_FACTOR=10 cargo bench -p libcudf-datafusion --bench tpch_pipeline
+//! ```
+//!
+//! Row counts below are for SF=1.
+//!
+//! | Table    | Rows    | Role               |
+//! |----------|---------|--------------------|
+//! | orders   | ~1.5 M  | probe (fact) side  |
+//! | customer | ~150 K  | build (dim) side   |
+//! | result   | 25 rows | one per nation     |
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use datafusion::execution::SessionStateBuilder;
+use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
+use datafusion_physical_plan::{execute_stream, ExecutionPlan};
+use futures_util::TryStreamExt;
+use libcudf_datafusion::aggregate::count;
+use libcudf_datafusion::{configure_default_pools, CuDFConfig, HostToCuDFRule};
+use std::env;
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+const TPCH_SCALE_FACTOR_ENV: &str = "LIBCUDF_TPCH_SCALE_FACTOR";
+
+fn tpch_scale_factor() -> String {
+    let raw = env::var(TPCH_SCALE_FACTOR_ENV).unwrap_or_else(|_| "1".to_string());
+    let scale_factor = raw.trim().parse::<f64>().unwrap_or_else(|err| {
+        panic!("invalid {TPCH_SCALE_FACTOR_ENV} value {raw:?}: {err}");
+    });
+
+    if !scale_factor.is_finite() || scale_factor <= 0.0 {
+        panic!("{TPCH_SCALE_FACTOR_ENV} must be a positive finite number");
+    }
+
+    if scale_factor.fract() == 0.0 {
+        format!("{scale_factor:.0}")
+    } else {
+        scale_factor.to_string()
+    }
+}
+
+fn tpch_data_dir(scale_factor: &str) -> PathBuf {
+    let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(format!("testdata/tpch/correctness_sf{scale_factor}"));
+    if !data_dir.exists() {
+        panic!(
+            "TPC-H SF={scale_factor} data not found at {}",
+            data_dir.display()
+        );
+    }
+    data_dir
+}
+
+const PIPELINE_SQL: &str = "
+    SELECT c.c_nationkey, COUNT(c.c_custkey) AS cnt
+    FROM orders o
+    JOIN customer c ON o.o_custkey = c.c_custkey
+    GROUP BY c.c_nationkey
+";
+
+async fn cpu_ctx(base: PathBuf) -> SessionContext {
+    let ctx = SessionContext::new();
+    ctx.register_parquet(
+        "orders",
+        base.join("orders").to_str().unwrap(),
+        ParquetReadOptions::new(),
+    )
+    .await
+    .unwrap();
+    ctx.register_parquet(
+        "customer",
+        base.join("customer").to_str().unwrap(),
+        ParquetReadOptions::new(),
+    )
+    .await
+    .unwrap();
+    ctx
+}
+
+async fn gpu_ctx(base: PathBuf) -> SessionContext {
+    let mut cudf_config = CuDFConfig::default();
+    cudf_config.enable = true;
+    // Single partition: DataFusion plans AggregateMode::Single instead of
+    // Partial -> RepartitionExec -> Final. The two-phase path sends partial-state
+    // batches through a CPU RepartitionExec, which strips CuDFColumnView wrappers.
+    let config = SessionConfig::new()
+        .with_target_partitions(1)
+        .with_option_extension(cudf_config);
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_config(config)
+        .with_physical_optimizer_rule(Arc::new(HostToCuDFRule))
+        .build();
+    let ctx = SessionContext::from(state);
+    ctx.register_udaf((*count()).clone());
+    ctx.register_parquet(
+        "orders",
+        base.join("orders").to_str().unwrap(),
+        ParquetReadOptions::new(),
+    )
+    .await
+    .unwrap();
+    ctx.register_parquet(
+        "customer",
+        base.join("customer").to_str().unwrap(),
+        ParquetReadOptions::new(),
+    )
+    .await
+    .unwrap();
+    ctx
+}
+
+async fn build_plan(ctx: &SessionContext, sql: &str) -> Arc<dyn ExecutionPlan> {
+    ctx.sql(sql)
+        .await
+        .unwrap()
+        .create_physical_plan()
+        .await
+        .unwrap()
+}
+
+fn bench_tpch_pipeline(c: &mut Criterion) {
+    configure_default_pools();
+    let rt = Runtime::new().unwrap();
+    let scale_factor = tpch_scale_factor();
+    let data_dir = tpch_data_dir(&scale_factor);
+    let mut group = c.benchmark_group(format!("tpch_pipeline/orders_x_customer/sf{scale_factor}"));
+
+    let cpu = rt.block_on(cpu_ctx(data_dir.clone()));
+    let gpu = rt.block_on(gpu_ctx(data_dir));
+    let cpu_task_ctx = cpu.task_ctx();
+    let gpu_task_ctx = gpu.task_ctx();
+
+    // Warm the OS page cache so Parquet I/O does not appear in timed iterations.
+    rt.block_on(async {
+        let plan = build_plan(&cpu, PIPELINE_SQL).await;
+        execute_stream(plan, cpu_task_ctx.clone())
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let plan = build_plan(&gpu, PIPELINE_SQL).await;
+        execute_stream(plan, gpu_task_ctx.clone())
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+    });
+
+    group.bench_function("cpu", |b| {
+        b.iter_batched(
+            || rt.block_on(build_plan(&cpu, PIPELINE_SQL)),
+            |plan| {
+                rt.block_on(async {
+                    black_box(
+                        execute_stream(plan, cpu_task_ctx.clone())
+                            .unwrap()
+                            .try_collect::<Vec<_>>()
+                            .await
+                            .unwrap(),
+                    );
+                })
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("gpu", |b| {
+        b.iter_batched(
+            || rt.block_on(build_plan(&gpu, PIPELINE_SQL)),
+            |plan| {
+                rt.block_on(async {
+                    black_box(
+                        execute_stream(plan, gpu_task_ctx.clone())
+                            .unwrap()
+                            .try_collect::<Vec<_>>()
+                            .await
+                            .unwrap(),
+                    );
+                })
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_tpch_pipeline);
+criterion_main!(benches);

--- a/libcudf-datafusion/src/lib.rs
+++ b/libcudf-datafusion/src/lib.rs
@@ -12,4 +12,8 @@ mod physical;
 #[cfg(any(feature = "integration", test))]
 pub mod test_utils;
 
+pub use libcudf_rs::configure_default_pools;
+pub use libcudf_rs::DevicePoolConfig;
+pub use libcudf_rs::PinnedPoolConfig;
 pub use optimizer::{CuDFConfig, HostToCuDFRule};
+pub use physical::{CuDFLoadExec, CuDFUnloadExec};

--- a/libcudf-datafusion/src/physical/coalesce_batches.rs
+++ b/libcudf-datafusion/src/physical/coalesce_batches.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)]
 
 use crate::errors::cudf_to_df;
+use crate::physical::record_gpu_poll;
 use arrow::array::RecordBatch;
 use arrow_schema::SchemaRef;
 use datafusion::common::{internal_err, Statistics};
@@ -127,7 +128,7 @@ impl Stream for CoalesceBatchesStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let poll = self.poll_next_inner(cx);
-        self.baseline_metrics.record_poll(poll)
+        record_gpu_poll(&self.baseline_metrics, poll)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -8,7 +8,7 @@ use datafusion::physical_expr::EquivalenceProperties;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures_util::stream::StreamExt;
-use libcudf_rs::{is_cudf_array, CuDFColumn};
+use libcudf_rs::{is_cudf_array, CuDFTable};
 use std::any::Any;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -83,19 +83,19 @@ impl ExecutionPlan for CuDFLoadExec {
                 Err(err) => return Err(err),
             };
 
-            let original_cols = batch.columns();
-            let mut cudf_cols: Vec<Arc<dyn Array>> = Vec::with_capacity(original_cols.len());
-            for original_col in original_cols {
-                if is_cudf_array(original_col) {
-                    return exec_err!(
-                        "Cannot move RecordBatch from host to CuDF: a column is already a CuDF array"
-                    );
-                }
-                let col = CuDFColumn::from_arrow_host(original_col).map_err(cudf_to_df)?;
-                cudf_cols.push(Arc::new(col.into_view()));
+            if batch.columns().iter().any(|c| is_cudf_array(c)) {
+                return exec_err!(
+                    "Cannot move RecordBatch from host to CuDF: a column is already a CuDF array"
+                );
             }
-
-            Ok(RecordBatch::try_new(batch.schema(), cudf_cols)?)
+            let schema = batch.schema();
+            let table = CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?;
+            let cudf_cols: Vec<Arc<dyn Array>> = table
+                .into_columns()
+                .into_iter()
+                .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
+                .collect();
+            Ok(libcudf_rs::record_batch_with_schema(cudf_cols, &schema)?)
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),

--- a/libcudf-datafusion/src/physical/cudf_unload.rs
+++ b/libcudf-datafusion/src/physical/cudf_unload.rs
@@ -1,13 +1,13 @@
 use crate::errors::cudf_to_df;
 use arrow::array::RecordBatch;
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
-use datafusion::common::{exec_err, internal_datafusion_err, plan_err, DataFusionError};
+use datafusion::common::{plan_err, DataFusionError};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures_util::StreamExt;
-use libcudf_rs::CuDFColumnView;
+use libcudf_rs::CuDFTableView;
 use std::any::Any;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -89,24 +89,15 @@ impl ExecutionPlan for CuDFUnloadExec {
                 Err(err) => return Err(err),
             };
 
-            let original_cols = batch.columns();
-            let mut host_cols = Vec::with_capacity(original_cols.len());
-            for (i, original_col) in original_cols.iter().enumerate() {
-                let Some(cudf_col) = original_col.as_any().downcast_ref::<CuDFColumnView>() else {
-                    return exec_err!(
-                        "Cannot move RecordBatch from CuDF to host: a column is not a CuDF array"
-                    );
-                };
-                let arr = cudf_col.to_arrow_host().map_err(cudf_to_df)?;
-                let target_field = target_schema
-                    .fields
-                    .get(i)
-                    .ok_or_else(|| internal_datafusion_err!("Could not find field {i}"))?;
-
-                let arr = arrow::compute::cast(&arr, target_field.data_type())?;
-                host_cols.push((target_field.name(), arr))
-            }
-            RecordBatch::try_from_iter(host_cols).map_err(|err| {
+            let view = CuDFTableView::from_record_batch(&batch).map_err(cudf_to_df)?;
+            let host_batch = view.to_arrow_host().map_err(cudf_to_df)?;
+            let columns = host_batch
+                .columns()
+                .iter()
+                .zip(target_schema.fields())
+                .map(|(col, field)| arrow::compute::cast(col, field.data_type()))
+                .collect::<Result<Vec<_>, _>>()?;
+            RecordBatch::try_new(target_schema.clone(), columns).map_err(|err| {
                 DataFusionError::ArrowError(
                     Box::new(err),
                     Some("Error while unloading a RecordBatch from CuDF into host".to_string()),

--- a/libcudf-datafusion/src/physical/filter.rs
+++ b/libcudf-datafusion/src/physical/filter.rs
@@ -1,5 +1,6 @@
 use crate::errors::cudf_to_df;
 use crate::expr::{columnar_value_to_cudf, expr_to_cudf_expr};
+use crate::physical::record_gpu_poll;
 use arrow::array::{Array, RecordBatch};
 use arrow_schema::{DataType, SchemaRef};
 use datafusion::common::{exec_err, internal_err, Statistics};
@@ -254,7 +255,7 @@ impl Stream for CuDFFilterExecStream {
                 }
             }
         }
-        self.metrics.baseline_metrics.record_poll(poll)
+        record_gpu_poll(&self.metrics.baseline_metrics, poll)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/libcudf-datafusion/src/physical/mod.rs
+++ b/libcudf-datafusion/src/physical/mod.rs
@@ -1,5 +1,9 @@
 use crate::aggregate::CuDFAggregateExec;
+use arrow::array::RecordBatch;
+use datafusion::error::DataFusionError;
+use datafusion_physical_plan::metrics::BaselineMetrics;
 use datafusion_physical_plan::ExecutionPlan;
+use std::task::Poll;
 
 mod coalesce_batches;
 mod cudf_load;
@@ -16,6 +20,22 @@ pub use filter::CuDFFilterExec;
 pub use hash_join::{try_as_cudf_hash_join, CuDFHashJoinExec};
 pub use projection::CuDFProjectionExec;
 pub use sort::CuDFSortExec;
+
+/// GPU-safe replacement for [`BaselineMetrics::record_poll`].
+///
+/// `record_poll` internally calls `get_record_batch_memory_size` -> `Array::to_data()`,
+/// which for `CuDFColumnView` triggers a full GPU->CPU copy just to measure spill size.
+/// GPU data is never subject to DataFusion's host spill mechanism, so only the row
+/// count is recorded.
+pub(crate) fn record_gpu_poll(
+    metrics: &BaselineMetrics,
+    poll: Poll<Option<Result<RecordBatch, DataFusionError>>>,
+) -> Poll<Option<Result<RecordBatch, DataFusionError>>> {
+    if let Poll::Ready(Some(Ok(ref batch))) = poll {
+        metrics.output_rows().add(batch.num_rows());
+    }
+    poll
+}
 
 pub fn is_cudf_plan(plan: &dyn ExecutionPlan) -> bool {
     let any = plan.as_any();

--- a/libcudf-datafusion/src/physical/projection.rs
+++ b/libcudf-datafusion/src/physical/projection.rs
@@ -1,4 +1,5 @@
 use crate::expr::expr_to_cudf_expr;
+use crate::physical::record_gpu_poll;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchOptions;
@@ -186,7 +187,7 @@ impl Stream for CuDFProjectionStream {
             other => other,
         });
 
-        self.baseline_metrics.record_poll(poll)
+        record_gpu_poll(&self.baseline_metrics, poll)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/libcudf-sys/build.rs
+++ b/libcudf-sys/build.rs
@@ -55,6 +55,7 @@ fn main() {
         .include(OUT_DIR.join("libcudf").join("include").join("rapids"))
         .include(OUT_DIR.join("librmm").join("include"))
         .include(OUT_DIR.join("librmm").join("include").join("rapids"))
+        .include(OUT_DIR.join("rapids_logger").join("include"))
         .include(OUT_DIR.join("libkvikio").join("include"))
         // Include shared libraries from the CUDA installation present in the system
         .include(CUDA_ROOT.join("include"))
@@ -243,6 +244,7 @@ fn setup_library_paths(lib_dir: &Path, project_root: &Path) {
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=rmm");
     println!("cargo:rustc-link-lib=dylib=kvikio");
+    println!("cargo:rustc-link-lib=dylib=rapids_logger");
 
     // Set rpath
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -583,6 +583,28 @@ pub mod ffi {
 
         /// Get the version of the cuDF library
         fn get_cudf_version() -> String;
+
+        /// Configure the global RMM device-memory pool.
+        ///
+        /// Reserves `initial_bytes` of GPU VRAM via `cudaMalloc` once at startup so that
+        /// `rmm::device_buffer` allocations (every cuDF column buffer) are served from the
+        /// pool instead of calling `cudaMalloc` per allocation. Returns `true` if the pool
+        /// was configured, `false` if already set by a previous call.
+        fn config_device_memory_pool(initial_bytes: usize, max_bytes: usize) -> bool;
+
+        /// Configure the global cuDF pinned-memory pool.
+        ///
+        /// Reserves `pool_size_bytes` of page-locked host RAM via `cudaMallocHost`
+        /// once so eligible pinned host allocations can be served from a reusable
+        /// pool. Returns `true` if the pool was configured, `false` if it was
+        /// already set up by a previous call.
+        fn config_pinned_memory_resource(pool_size_bytes: usize) -> bool;
+
+        /// Set the maximum allocation size that will be served from the pinned pool.
+        ///
+        /// Allocations at or below `threshold_bytes` use pinned memory. Larger
+        /// allocations remain pageable.
+        fn set_host_pinned_threshold(threshold_bytes: usize);
     }
 }
 

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -7,7 +7,12 @@
 #include <cudf/copying.hpp>
 #include <cudf/interop.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/version_config.hpp>
+
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include <nanoarrow/nanoarrow.h>
 
@@ -115,6 +120,25 @@ namespace libcudf_bridge {
                 << CUDF_VERSION_MINOR << "."
                 << CUDF_VERSION_PATCH;
         return {version.str()};
+    }
+
+    bool config_device_memory_pool(size_t initial_bytes, size_t max_bytes) {
+        static std::unique_ptr<rmm::mr::cuda_memory_resource> base_mr;
+        static std::unique_ptr<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>> pool_mr;
+        if (pool_mr) return false;
+        base_mr = std::make_unique<rmm::mr::cuda_memory_resource>();
+        pool_mr = std::make_unique<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(
+            base_mr.get(), initial_bytes, max_bytes);
+        rmm::mr::set_current_device_resource(pool_mr.get());
+        return true;
+    }
+
+    bool config_pinned_memory_resource(size_t pool_size_bytes) {
+        return cudf::config_default_pinned_memory_resource({.pool_size = pool_size_bytes});
+    }
+
+    void set_host_pinned_threshold(size_t threshold_bytes) {
+        cudf::set_allocate_host_as_pinned_threshold(threshold_bytes);
     }
 
     // Arrow interop - convert Arrow data to cuDF table

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -32,4 +32,11 @@ namespace libcudf_bridge {
 
     // Utility functions
     rust::String get_cudf_version();
+
+    // Pinned-memory pool configuration
+    bool config_pinned_memory_resource(size_t pool_size_bytes);
+    void set_host_pinned_threshold(size_t threshold_bytes);
+
+    // Device-memory pool configuration
+    bool config_device_memory_pool(size_t initial_bytes, size_t max_bytes);
 } // namespace libcudf_bridge

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -142,7 +142,16 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn to_data(&self) -> ArrayData {
-        // WARNING: This performs a full GPU to CPU data transfer.
+        // In debug/test builds this panics so implicit GPU->CPU copies are easily
+        // caught.
+        //
+        // Call to_arrow_host() explicitly rather than this method to separate
+        // implicit and explicit transfers.
+        debug_assert!(
+            false,
+            "CuDFColumnView::to_data(), implicit GPU->CPU copy detected. \
+             Call to_arrow_host() explicitly."
+        );
         self.to_arrow_host()
             .expect("Failed to convert GPU column to host Arrow")
             .to_data()
@@ -178,7 +187,6 @@ unsafe impl Array for CuDFColumnView {
                 if self.null_count() == 0 {
                     return None;
                 }
-
                 let null_bytes = self.inner().get_null_buffer();
                 let offset = self.inner().offset() as usize;
                 let length = self.inner().size();

--- a/src/device_pool.rs
+++ b/src/device_pool.rs
@@ -1,0 +1,88 @@
+/// Configuration for the process-wide RMM GPU device-memory pool.
+///
+/// Configure this before any cuDF operation to serve device allocations from a
+/// reusable pool rather than calling `cudaMalloc`/`cudaFree` for every buffer.
+/// See [`configure_default_pools`](crate::configure_default_pools) for default
+/// values.
+///
+/// ## Without a device pool
+///
+/// Device buffers are allocated from CUDA directly. Workloads that create many
+/// batches can pay a driver allocation/free cost for each column buffer.
+///
+/// ```text
+/// batch N:
+///   col 0  [cudaMalloc] [copy/compute ----------------] [cudaFree]
+///   col 1               [cudaMalloc] [copy/compute ---] [cudaFree]
+///   col 2                            [cudaMalloc] [---] [cudaFree]
+/// ```
+///
+/// ## With a device pool
+///
+/// The pool reserves `initial_size` once. Allocations are then served from
+/// reusable pool blocks. If the pool needs more memory, it can grow until
+/// `max_size`.
+///
+/// ```text
+/// startup:
+///   [cudaMalloc initial pool ------------------------------------------]
+///
+/// batch N:
+///   [pool alloc col0] [pool alloc col1] [pool alloc col2]
+///   [copy/compute -----------------------------------------------------]
+///   [pool free col0]  [pool free col1]  [pool free col2]
+///
+/// batch N+1:
+///   [reuse pool blocks -----------------------------------------------]
+/// ```
+///
+/// This is most useful for repeated GPU pipelines where allocation churn is a
+/// measurable part of runtime. Size the pool conservatively on shared GPUs.
+pub struct DevicePoolConfig {
+    /// Bytes of GPU VRAM to reserve upfront via a single `cudaMalloc`.
+    ///
+    /// The pool pre-allocates this slab when [`DevicePoolConfig::apply`] is called.
+    /// If the slab fills up, it grows until [`DevicePoolConfig::max_size`] is reached.
+    ///
+    /// Set to at least your pipeline's peak working set (the sum of all live column
+    /// buffers across concurrent batches). Sizing below this causes growth pauses during
+    /// warm-up.
+    pub initial_size: usize,
+
+    /// Hard cap in bytes on total pool VRAM.
+    ///
+    /// The pool will not grow beyond this. If an allocation would exceed it,
+    /// cuDF throws `std::bad_alloc`. Set this to leave headroom for other GPU
+    /// workloads sharing the same device.
+    ///
+    /// Must be at least `initial_size`.
+    pub max_size: usize,
+}
+
+impl Default for DevicePoolConfig {
+    /// Conservative defaults suitable for GPU analytics workloads.
+    ///
+    /// - `initial_size`: 512 MB
+    /// - `max_size`: 4 GB
+    ///
+    /// Override `initial_size` upward if your pipeline's peak working set exceeds
+    /// 512 MB to avoid growth pauses during warm-up.
+    fn default() -> Self {
+        Self {
+            initial_size: 512 * 1024 * 1024,  // 512 MB
+            max_size: 4 * 1024 * 1024 * 1024, //   4 GB
+        }
+    }
+}
+
+impl DevicePoolConfig {
+    /// Apply this configuration globally for the current process.
+    ///
+    /// Must be called before any cuDF operations run.
+    ///
+    /// Returns `true` if the pool was configured, `false` if already set by
+    /// a previous call.
+    pub fn apply(&self) -> bool {
+        libcudf_sys::ffi::config_device_memory_pool(self.initial_size, self.max_size)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,12 @@ mod column_view;
 mod cudf_array;
 mod cudf_reference;
 mod data_type;
+mod device_pool;
 mod errors;
 mod group_by;
 mod join;
 mod operations;
+mod pinned_pool;
 mod scalar;
 mod sort;
 mod table;
@@ -37,14 +39,26 @@ pub use column::CuDFColumn;
 pub use column_view::CuDFColumnView;
 pub use cudf_array::*;
 pub use cudf_reference::CuDFRef;
+pub use device_pool::DevicePoolConfig;
 pub use errors::{CuDFError, Result};
 pub use group_by::*;
 pub use join::{cross_join, full_join, inner_join, left_anti_join, left_join, left_semi_join};
 pub use operations::{apply_boolean_mask, cast, gather, slice_column};
+pub use pinned_pool::PinnedPoolConfig;
 pub use scalar::CuDFScalar;
 pub use sort::{sort, sort_by_all, stable_sorted_order, SortOrder};
 pub use table::*;
 pub use table_view::*;
+
+/// Configure default memory pools for GPU-accelerated workloads.
+///
+/// Equivalent to calling [`PinnedPoolConfig::default().apply()`] and
+/// [`DevicePoolConfig::default().apply()`]. Call once before executing
+/// any GPU operations. See each config type to override pool sizes.
+pub fn configure_default_pools() {
+    PinnedPoolConfig::default().apply();
+    DevicePoolConfig::default().apply();
+}
 
 /// Get cuDF version information
 ///

--- a/src/pinned_pool.rs
+++ b/src/pinned_pool.rs
@@ -1,0 +1,98 @@
+/// Configuration for cuDF's process-wide pinned host-memory pool.
+///
+/// Configure this before any cuDF operation to let eligible cuDF host
+/// allocations come from a reusable page-locked pool. See
+/// [`configure_default_pools`](crate::configure_default_pools) for default
+/// values.
+///
+/// cuDF uses `threshold` as a maximum allocation size for pinned host memory:
+/// allocations at or below the threshold use pinned memory, while larger
+/// allocations use pageable memory. The pool backs those eligible pinned
+/// allocations.
+///
+/// ## Pageable host allocation
+///
+/// Pageable host memory may require CUDA to stage data through temporary pinned
+/// memory before DMA can proceed.
+///
+/// ```text
+/// CPU pageable buffer
+///   [stage chunk] [wait] [stage chunk] [wait] [stage chunk] [wait]
+///
+/// CUDA DMA
+///                 [copy]              [copy]              [copy]
+/// ```
+///
+/// ## Pinned host allocation
+///
+/// Eligible cuDF host allocations are page-locked and can be used directly for
+/// transfer. The exact copy path still depends on the cuDF operation and source
+/// or destination buffers, but the allocation itself comes from the reusable
+/// pinned pool.
+///
+/// ```text
+/// startup:
+///   [cudaMallocHost pinned pool ---------------------------------------]
+///
+/// cuDF host allocation <= threshold:
+///   [pool alloc] [DMA-capable host buffer -----------------------------]
+///   [pool free]
+///
+/// cuDF host allocation > threshold:
+///   [pageable allocation ---------------------------------------------]
+/// ```
+///
+/// This primarily helps paths where cuDF owns internal host buffers, such as
+/// GPU-to-host conversion and staging work. It does not pin user-owned Arrow
+/// input buffers automatically.
+pub struct PinnedPoolConfig {
+    /// Bytes of page-locked host RAM to reserve upfront.
+    ///
+    /// The pool is fixed-size, both the initial and maximum capacity are set to this
+    /// value. If exhausted, cuDF falls back to a non-pooled pinned allocation rather
+    /// than growing or erroring.
+    ///
+    /// Paid once at [`PinnedPoolConfig::apply`] time. Eligible cuDF internal host
+    /// allocations draw from this slab.
+    ///
+    /// Pinned memory is page-locked and cannot be swapped, so it reduces the
+    /// pageable RAM available to the rest of the system. Size conservatively on
+    /// shared or memory-constrained hosts.
+    pub pool_size: usize,
+
+    /// Largest allocation size, in bytes, that uses pinned host memory.
+    ///
+    /// cuDF's built-in default is 0. Allocations larger than this threshold use
+    /// pageable memory.
+    pub threshold: usize,
+}
+
+impl Default for PinnedPoolConfig {
+    /// Conservative defaults suitable for GPU analytics workloads.
+    ///
+    /// - `pool_size`: 512 MB
+    /// - `threshold`: 1 MB
+    ///
+    /// Override `pool_size` upward if your batches regularly exceed 256 MB per column,
+    /// or downward on memory-constrained hosts.
+    fn default() -> Self {
+        Self {
+            pool_size: 512 * 1024 * 1024, // 512 MB
+            threshold: 1 * 1024 * 1024,   //   1 MB
+        }
+    }
+}
+
+impl PinnedPoolConfig {
+    /// Apply this configuration globally for the current process.
+    ///
+    /// Must be called before any cuDF operations run.
+    ///
+    /// Returns `true` if the pool was configured, `false` if already set by
+    /// a previous call (the threshold is still updated).
+    pub fn apply(&self) -> bool {
+        let configured = libcudf_sys::ffi::config_pinned_memory_resource(self.pool_size);
+        libcudf_sys::ffi::set_host_pinned_threshold(self.threshold);
+        configured
+    }
+}


### PR DESCRIPTION
## Summary

This PR ports the next performance slice from the fork:

- avoids DataFusion metric polling from implicitly copying `CuDFColumnView` data back to host
- adds process-wide device and pinned memory pool configuration APIs
- uses table-level host/GPU load and unload in the DataFusion boundary
- enables default pool setup in the DataFusion aggregate and join benchmarks
- adds `load_unload` and `tpch_pipeline` benchmarks

The TPC-H pipeline benchmark defaults to SF=1 and keeps scale-factor selection in this PR via:

```sh
LIBCUDF_TPCH_SCALE_FACTOR=10 cargo bench -p libcudf-datafusion --bench tpch_pipeline
```

## Validation

```sh
cargo fmt --all
git diff --cached --check
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p libcudf-datafusion --benches --locked
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-datafusion --lib --locked
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-rs --lib --locked
```

Results:

- `cargo check -p libcudf-datafusion --benches --locked`: passed
- `cargo test -p libcudf-datafusion --lib --locked`: 39 passed
- `cargo test -p libcudf-rs --lib --locked`: 100 passed

## Benchmarks

All benchmark runs used:

```sh
--sample-size 10 --warm-up-time 1 --measurement-time 2
```

Criterion HTML reports are available under `target/criterion/`.

Commands:

```sh
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo bench -p libcudf-datafusion --bench load_unload --locked -- --sample-size 10 --warm-up-time 1 --measurement-time 2
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo bench -p libcudf-datafusion --bench tpch_pipeline --locked -- --sample-size 10 --warm-up-time 1 --measurement-time 2
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo bench -p libcudf-datafusion --bench join --locked -- --sample-size 10 --warm-up-time 1 --measurement-time 2
CARGO_NET_GIT_FETCH_WITH_CLI=true cargo bench -p libcudf-datafusion --bench aggregate --locked -- --sample-size 10 --warm-up-time 1 --measurement-time 2
```

### TPC-H Pipeline

| Benchmark | Median |
|---|---:|
| `tpch_pipeline/orders_x_customer/sf1/cpu` | 32.695 ms |
| `tpch_pipeline/orders_x_customer/sf1/gpu` | 23.337 ms |

### Load / Unload

| Benchmark | Median | Throughput |
|---|---:|---:|
| `load/unpooled/100000` | 4.5010 ms | 1.6817 GiB/s |
| `load/pooled/100000` | 2.8087 ms | 2.6949 GiB/s |
| `load/unpooled/1000000` | 47.869 ms | 1.5790 GiB/s |
| `load/pooled/1000000` | 29.358 ms | 2.5746 GiB/s |
| `load/unpooled/10000000` | 534.19 ms | 1.4149 GiB/s |
| `load/pooled/10000000` | 310.77 ms | 2.4321 GiB/s |
| `unload/unpooled/100000` | 7.1314 ms | 1.0614 GiB/s |
| `unload/pooled/100000` | 7.6720 ms | 1010.3 MiB/s |
| `unload/unpooled/1000000` | 80.272 ms | 964.23 MiB/s |
| `unload/pooled/1000000` | 83.306 ms | 929.11 MiB/s |
| `unload/unpooled/10000000` | 823.97 ms | 939.32 MiB/s |
| `unload/pooled/10000000` | 842.48 ms | 918.68 MiB/s |

### Join With Pools

| Benchmark | Median | Throughput |
|---|---:|---:|
| `join/inner/all_cols/100000x50000` | 206.21 us | 484.94 Melem/s |
| `join/inner/projected_1col/100000x50000` | 197.29 us | 506.87 Melem/s |
| `join/inner/all_cols/1000000x150000` | 1.4211 ms | 703.70 Melem/s |
| `join/inner/projected_1col/1000000x150000` | 1.1977 ms | 834.93 Melem/s |
| `join/inner/all_cols/5000000x150000` | 6.5984 ms | 757.75 Melem/s |
| `join/inner/projected_1col/5000000x150000` | 5.5533 ms | 900.37 Melem/s |
| `join/left/100000x50000` | 279.61 us | 357.64 Melem/s |
| `join/left/1000000x150000` | 1.6000 ms | 624.99 Melem/s |
| `join/left/5000000x150000` | 7.3015 ms | 684.79 Melem/s |
| `join/semi/100000x50000` | 123.72 us | 808.28 Melem/s |
| `join/semi/1000000x150000` | 527.31 us | 1.8964 Gelem/s |
| `join/semi/5000000x150000` | 2.1962 ms | 2.2767 Gelem/s |

### Aggregate With Pools

| Benchmark | CPU Median | GPU Median |
|---|---:|---:|
| `sum/1000000` | 20.184 ms | 14.980 ms |
| `sum/5000000` | 79.352 ms | 37.525 ms |
| `sum/20000000` | 298.67 ms | 120.93 ms |
| `count/1000000` | 19.346 ms | 15.164 ms |
| `count/5000000` | 71.394 ms | 37.136 ms |
| `count/20000000` | 265.78 ms | 120.41 ms |
| `avg/1000000` | 22.842 ms | 18.690 ms |
| `avg/5000000` | 80.618 ms | 41.196 ms |
| `avg/20000000` | 295.31 ms | 125.74 ms |
| `min_max/1000000` | 23.643 ms | 19.268 ms |
| `min_max/5000000` | 84.463 ms | 41.973 ms |
| `min_max/20000000` | 312.69 ms | 127.42 ms |
| `combined/1000000` | 40.509 ms | 41.768 ms |
| `combined/5000000` | 135.20 ms | 63.718 ms |
| `combined/20000000` | 489.08 ms | 147.71 ms |

