### PR TITLE
Handle aggregate edge cases

### DIFF
--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -572,15 +572,14 @@ mod integration {
           CuDFProjectionExec: expr=[RainToday@0 as RainToday, sum(weather.Rainfall)@1 as total]
             CuDFAggregateExec: mode=FinalPartitioned, group_by=[RainToday@RainToday@0], aggr_expr=[sum(weather.Rainfall)]
               CuDFLoadExec
-                CoalesceBatchesExec: target_batch_size=8192
-                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
-                    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
-                      CuDFUnloadExec
-                        CuDFCoalesceBatchesExec: target_batch_size=81920
-                          CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[sum(weather.Rainfall)]
-                            CuDFLoadExec
-                              CoalesceBatchesExec: target_batch_size=81920
-                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Rainfall, RainToday], file_type=parquet
+                CoalesceBatchesExec: target_batch_size=81920
+                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=3
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[sum(weather.Rainfall)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Rainfall, RainToday], file_type=parquet
         ");
         Ok(())
     }
@@ -594,15 +593,14 @@ mod integration {
           CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as n]
             CuDFAggregateExec: mode=FinalPartitioned, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
               CuDFLoadExec
-                CoalesceBatchesExec: target_batch_size=8192
-                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
-                    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
-                      CuDFUnloadExec
-                        CuDFCoalesceBatchesExec: target_batch_size=81920
-                          CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
-                            CuDFLoadExec
-                              CoalesceBatchesExec: target_batch_size=81920
-                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+                CoalesceBatchesExec: target_batch_size=81920
+                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=3
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
         ");
         Ok(())
     }
@@ -628,15 +626,14 @@ mod integration {
           CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as n, sum(weather.Rainfall)@2 as total, avg(weather.MaxTemp)@3 as avg_max, min(weather.MinTemp)@4 as lo, max(weather.MaxTemp)@5 as hi]
             CuDFAggregateExec: mode=FinalPartitioned, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1)), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
               CuDFLoadExec
-                CoalesceBatchesExec: target_batch_size=8192
-                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
-                    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
-                      CuDFUnloadExec
-                        CuDFCoalesceBatchesExec: target_batch_size=81920
-                          CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@3], aggr_expr=[count(Int64(1)), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
-                            CuDFLoadExec
-                              CoalesceBatchesExec: target_batch_size=81920
-                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, Rainfall, RainToday], file_type=parquet
+                CoalesceBatchesExec: target_batch_size=81920
+                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=3
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@3], aggr_expr=[count(Int64(1)), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, Rainfall, RainToday], file_type=parquet
         ");
         Ok(())
     }

--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -184,13 +184,16 @@ mod test {
     use crate::physical::{CuDFLoadExec, CuDFUnloadExec};
     use arrow::array::record_batch;
     use arrow::util::pretty::pretty_format_batches;
+    use arrow_schema::SchemaRef;
+    use datafusion::common::ScalarValue;
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
     use datafusion_expr::AggregateUDF;
     use datafusion_physical_plan::aggregates::{AggregateMode, PhysicalGroupBy};
-    use datafusion_physical_plan::expressions::col;
+    use datafusion_physical_plan::expressions::{col, Literal};
     use datafusion_physical_plan::test::TestMemoryExec;
     use datafusion_physical_plan::ExecutionPlan;
+    use datafusion_physical_plan::PhysicalExpr;
     use futures_util::TryStreamExt;
     use std::error::Error;
     use std::sync::Arc;
@@ -199,10 +202,11 @@ mod test {
     /// TestMemoryExec -> CuDFLoadExec -> CuDFAggregateExec -> CuDFUnloadExec.
     ///
     /// Sends 3 identical batches (to exercise cross-batch rolling merge) and
-    /// groups by column "c".
+    /// groups by column "c". `build_args` receives the batch schema and returns
+    /// the argument expressions for the aggregate function.
     async fn run_group_by_test(
         agg_fn: Arc<AggregateUDF>,
-        agg_column: &str,
+        build_args: impl FnOnce(&SchemaRef) -> datafusion::error::Result<Vec<Arc<dyn PhysicalExpr>>>,
         agg_alias: &str,
     ) -> Result<String, Box<dyn Error>> {
         let batch = record_batch!(
@@ -224,7 +228,7 @@ mod test {
 
         let group_by = PhysicalGroupBy::new_single(vec![(col("c", &schema)?, "c".to_string())]);
 
-        let agg = AggregateExprBuilder::new(agg_fn, vec![col(agg_column, &schema)?])
+        let agg = AggregateExprBuilder::new(agg_fn, build_args(&schema)?)
             .schema(schema)
             .alias(agg_alias)
             .build()?;
@@ -249,7 +253,7 @@ mod test {
 
     #[tokio::test]
     async fn test_group_by_sum() -> Result<(), Box<dyn Error>> {
-        let output = run_group_by_test(sum(), "a", "SUM(a)").await?;
+        let output = run_group_by_test(sum(), |s| Ok(vec![col("a", s)?]), "SUM(a)").await?;
 
         // Note: cuDF's SUM always returns Int64 for integer inputs
         assert_snapshot!(output, @r"
@@ -266,7 +270,7 @@ mod test {
 
     #[tokio::test]
     async fn test_group_by_min() -> Result<(), Box<dyn Error>> {
-        let output = run_group_by_test(min(), "a", "MIN(a)").await?;
+        let output = run_group_by_test(min(), |s| Ok(vec![col("a", s)?]), "MIN(a)").await?;
 
         assert_snapshot!(output, @r"
         +-------+--------+
@@ -282,7 +286,7 @@ mod test {
 
     #[tokio::test]
     async fn test_group_by_max() -> Result<(), Box<dyn Error>> {
-        let output = run_group_by_test(max(), "a", "MAX(a)").await?;
+        let output = run_group_by_test(max(), |s| Ok(vec![col("a", s)?]), "MAX(a)").await?;
 
         assert_snapshot!(output, @r"
         +-------+--------+
@@ -298,7 +302,7 @@ mod test {
 
     #[tokio::test]
     async fn test_group_by_count() -> Result<(), Box<dyn Error>> {
-        let output = run_group_by_test(count(), "a", "COUNT(a)").await?;
+        let output = run_group_by_test(count(), |s| Ok(vec![col("a", s)?]), "COUNT(a)").await?;
 
         assert_snapshot!(output, @r"
         +-------+----------+
@@ -312,9 +316,27 @@ mod test {
         Ok(())
     }
 
+    /// COUNT with a literal argument — the exact code path hit by COUNT(*) = COUNT(lit(1)).
+    #[tokio::test]
+    async fn test_group_by_count_literal_arg() -> Result<(), Box<dyn Error>> {
+        let lit_one: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int32(Some(1))));
+        let output = run_group_by_test(count(), |_| Ok(vec![lit_one.clone()]), "COUNT(*)").await?;
+
+        assert_snapshot!(output, @r"
+        +-------+----------+
+        | c     | COUNT(*) |
+        +-------+----------+
+        | world | 3        |
+        | hello | 6        |
+        +-------+----------+
+        ");
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_group_by_avg() -> Result<(), Box<dyn Error>> {
-        let output = run_group_by_test(avg(), "a", "AVG(a)").await?;
+        let output = run_group_by_test(avg(), |s| Ok(vec![col("a", s)?]), "AVG(a)").await?;
 
         assert_snapshot!(output, @r"
         +-------+--------+
@@ -452,5 +474,52 @@ mod integration {
         "#,
         )
         .await
+    }
+
+    #[tokio::test]
+    async fn test_count_star() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday", COUNT(*) as n
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_count_star_mixed() -> Result<(), Box<dyn Error>> {
+        check(
+            r#"
+            SELECT "RainToday", COUNT(*) as n, SUM("Rainfall") as total
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#,
+        )
+        .await
+    }
+
+    /// Aggregates with unsupported functions (non-CuDFAggregateUDF) must fall back to CPU.
+    #[tokio::test]
+    async fn test_unsupported_agg_falls_back_to_cpu() -> Result<(), Box<dyn Error>> {
+        let tf = TestFramework::new().await;
+        // BOOL_OR is not a CuDFAggregateUDF, so the aggregate must run on CPU.
+        let sql = r#"
+            SELECT "RainToday", BOOL_OR("RainTomorrow" = 'Yes') as any_rain
+            FROM weather
+            GROUP BY "RainToday"
+            ORDER BY "RainToday"
+        "#;
+        let cudf = tf.execute(&format!("SET cudf.enable=true; {sql}")).await?;
+        let cpu = tf.execute(sql).await?;
+        assert!(
+            !cudf.plan.contains("CuDFAggregateExec"),
+            "expected CPU fallback"
+        );
+        assert_eq!(cpu.pretty_print, cudf.pretty_print);
+        Ok(())
     }
 }

--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -353,22 +353,18 @@ mod test {
 
 /// Integration tests: full SQL pipeline through TestFramework against real weather data.
 ///
-/// Each test runs the same query on CPU and GPU, asserts the plan uses `CuDFAggregateExec`,
-/// and verifies GPU results match CPU results exactly (ORDER BY ensures stable row ordering).
+/// Tests using `check_query_results` omit ORDER BY — the helper sorts rows before
+/// comparing, keeping plans free of sort operators. Float tests (AVG, mixed aggregates)
+/// keep ORDER BY and use `assert_batches_approx_eq` to absorb last-ULP differences.
 #[cfg(test)]
 mod integration {
-    use crate::test_utils::TestFramework;
+    use crate::assert_snapshot;
+    use crate::test_utils::{check_query_results, sort_batches, TestFramework};
     use arrow::array::{Array, Float64Array, RecordBatch};
-    use datafusion::common::assert_contains;
     use std::error::Error;
 
-    /// Compare two sets of record batches, rounding Float64 values to `decimals`
-    /// decimal places before comparing.
-    ///
-    /// This absorbs last-ULP differences between cuDF's GPU arithmetic and
-    /// DataFusion's CPU arithmetic (e.g. `19.243023255813952` vs `...956`).
-    /// Non-float columns are compared for exact equality.
-    /// Rows are expected to already be in the same order.
+    /// Absorbs last-ULP differences between cuDF and DataFusion float arithmetic.
+    /// Used only for tests that produce Float64 results (AVG, mixed aggregates).
     fn assert_batches_approx_eq(gpu: &[RecordBatch], cpu: &[RecordBatch], decimals: u32) {
         let factor = 10f64.powi(decimals as i32);
         assert_eq!(gpu.len(), cpu.len(), "batch count mismatch");
@@ -394,132 +390,240 @@ mod integration {
         }
     }
 
-    async fn check(sql: &str) -> Result<(), Box<dyn Error>> {
-        let tf = TestFramework::new().await;
-        let cudf_sql = format!("SET cudf.enable=true; {sql}");
-
-        let cudf = tf.execute(&cudf_sql).await?;
-        let cpu = tf.execute(sql).await?;
-
-        assert_contains!(&cudf.plan, "CuDFAggregateExec");
-        assert_batches_approx_eq(&cudf.batches, &cpu.batches, 10);
+    #[tokio::test]
+    async fn test_sum() -> Result<(), Box<dyn Error>> {
+        let sql = r#"SELECT "RainToday", SUM("Rainfall") as total_rain FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 1).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, sum(weather.Rainfall)@1 as total_rain]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[sum(weather.Rainfall)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[sum(weather.Rainfall)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Rainfall, RainToday], file_type=parquet
+        ");
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_sum() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday", SUM("Rainfall") as total_rain
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
-    }
-
-    #[tokio::test]
     async fn test_count() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday", COUNT("Rainfall") as n
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
+        let sql = r#"SELECT "RainToday", COUNT("Rainfall") as n FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 1).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(weather.Rainfall)@1 as n]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[count(weather.Rainfall)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[count(weather.Rainfall)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Rainfall, RainToday], file_type=parquet
+        ");
+        Ok(())
     }
 
+    /// AVG produces Float64 — uses assert_batches_approx_eq to handle last-ULP differences.
     #[tokio::test]
     async fn test_avg() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday", AVG("MinTemp") as avg_min
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
+        let sql = r#"SELECT "RainToday", AVG("MinTemp") as avg_min FROM weather GROUP BY "RainToday""#;
+        let tf = TestFramework::new().await;
+        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
+        assert_snapshot!(gpu.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, avg(weather.MinTemp)@1 as avg_min]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[avg(weather.MinTemp)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[avg(weather.MinTemp)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, RainToday], file_type=parquet
+        ");
+        Ok(())
     }
 
     #[tokio::test]
     async fn test_min_max() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday", MIN("MinTemp") as lo, MAX("MaxTemp") as hi
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
+        let sql = r#"SELECT "RainToday", MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 1).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, min(weather.MinTemp)@1 as lo, max(weather.MaxTemp)@2 as hi]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[min(weather.MinTemp), max(weather.MaxTemp)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@2], aggr_expr=[min(weather.MinTemp), max(weather.MaxTemp)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, RainToday], file_type=parquet
+        ");
+        Ok(())
     }
 
+    /// Contains AVG — uses assert_batches_approx_eq to handle last-ULP differences.
     #[tokio::test]
     async fn test_multiple_aggregates() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday",
-                   COUNT("Rainfall") as n,
-                   SUM("Rainfall") as total,
-                   AVG("MaxTemp") as avg_max,
-                   MIN("MinTemp") as lo,
-                   MAX("MaxTemp") as hi
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
+        let sql = r#"SELECT "RainToday", COUNT("Rainfall") as n, SUM("Rainfall") as total, AVG("MaxTemp") as avg_max, MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
+        let tf = TestFramework::new().await;
+        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
+        assert_snapshot!(gpu.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(weather.Rainfall)@1 as n, sum(weather.Rainfall)@2 as total, avg(weather.MaxTemp)@3 as avg_max, min(weather.MinTemp)@4 as lo, max(weather.MaxTemp)@5 as hi]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[count(weather.Rainfall), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@3], aggr_expr=[count(weather.Rainfall), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, Rainfall, RainToday], file_type=parquet
+        ");
+        Ok(())
     }
 
     #[tokio::test]
     async fn test_count_star() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday", COUNT(*) as n
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
+        let sql = r#"SELECT "RainToday", COUNT(*) as n FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 1).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as n]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+        ");
+        Ok(())
     }
 
     #[tokio::test]
     async fn test_count_star_mixed() -> Result<(), Box<dyn Error>> {
-        check(
-            r#"
-            SELECT "RainToday", COUNT(*) as n, SUM("Rainfall") as total
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#,
-        )
-        .await
+        let sql = r#"SELECT "RainToday", COUNT(*) as n, SUM("Rainfall") as total FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 1).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as n, sum(weather.Rainfall)@2 as total]
+            CuDFAggregateExec: mode=Final, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1)), sum(weather.Rainfall)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=81920
+                  CoalescePartitionsExec
+                    CuDFUnloadExec
+                      CuDFCoalesceBatchesExec: target_batch_size=81920
+                        CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[count(Int64(1)), sum(weather.Rainfall)]
+                          CuDFLoadExec
+                            CoalesceBatchesExec: target_batch_size=81920
+                              DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Rainfall, RainToday], file_type=parquet
+        ");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_partition_sum() -> Result<(), Box<dyn Error>> {
+        let sql = r#"SELECT "RainToday", SUM("Rainfall") as total FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 4).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, sum(weather.Rainfall)@1 as total]
+            CuDFAggregateExec: mode=FinalPartitioned, group_by=[RainToday@RainToday@0], aggr_expr=[sum(weather.Rainfall)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=8192
+                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
+                    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+                      CuDFUnloadExec
+                        CuDFCoalesceBatchesExec: target_batch_size=81920
+                          CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@1], aggr_expr=[sum(weather.Rainfall)]
+                            CuDFLoadExec
+                              CoalesceBatchesExec: target_batch_size=81920
+                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[Rainfall, RainToday], file_type=parquet
+        ");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_partition_count_star() -> Result<(), Box<dyn Error>> {
+        let sql = r#"SELECT "RainToday", COUNT(*) as n FROM weather GROUP BY "RainToday""#;
+        let result = check_query_results(sql, 4).await?;
+        assert_snapshot!(result.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as n]
+            CuDFAggregateExec: mode=FinalPartitioned, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=8192
+                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
+                    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+                      CuDFUnloadExec
+                        CuDFCoalesceBatchesExec: target_batch_size=81920
+                          CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1))]
+                            CuDFLoadExec
+                              CoalesceBatchesExec: target_batch_size=81920
+                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+        ");
+        Ok(())
+    }
+
+    /// Contains AVG — uses assert_batches_approx_eq to handle last-ULP differences.
+    #[tokio::test]
+    async fn test_multi_partition_multiple_aggs() -> Result<(), Box<dyn Error>> {
+        let sql = r#"SELECT "RainToday", COUNT(*) as n, SUM("Rainfall") as total, AVG("MaxTemp") as avg_max, MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
+        let tf = TestFramework::new().await;
+        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=4; {sql}")).await?;
+        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=4; {sql}")).await?;
+        assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
+        assert_snapshot!(gpu.plan, @"
+        CuDFUnloadExec
+          CuDFProjectionExec: expr=[RainToday@0 as RainToday, count(Int64(1))@1 as n, sum(weather.Rainfall)@2 as total, avg(weather.MaxTemp)@3 as avg_max, min(weather.MinTemp)@4 as lo, max(weather.MaxTemp)@5 as hi]
+            CuDFAggregateExec: mode=FinalPartitioned, group_by=[RainToday@RainToday@0], aggr_expr=[count(Int64(1)), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
+              CuDFLoadExec
+                CoalesceBatchesExec: target_batch_size=8192
+                  RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=4
+                    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+                      CuDFUnloadExec
+                        CuDFCoalesceBatchesExec: target_batch_size=81920
+                          CuDFAggregateExec: mode=Partial, group_by=[RainToday@RainToday@3], aggr_expr=[count(Int64(1)), sum(weather.Rainfall), avg(weather.MaxTemp), min(weather.MinTemp), max(weather.MaxTemp)]
+                            CuDFLoadExec
+                              CoalesceBatchesExec: target_batch_size=81920
+                                DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, Rainfall, RainToday], file_type=parquet
+        ");
+        Ok(())
     }
 
     /// Aggregates with unsupported functions (non-CuDFAggregateUDF) must fall back to CPU.
     #[tokio::test]
     async fn test_unsupported_agg_falls_back_to_cpu() -> Result<(), Box<dyn Error>> {
         let tf = TestFramework::new().await;
-        // BOOL_OR is not a CuDFAggregateUDF, so the aggregate must run on CPU.
-        let sql = r#"
-            SELECT "RainToday", BOOL_OR("RainTomorrow" = 'Yes') as any_rain
-            FROM weather
-            GROUP BY "RainToday"
-            ORDER BY "RainToday"
-        "#;
-        let cudf = tf.execute(&format!("SET cudf.enable=true; {sql}")).await?;
+        let sql = r#"SELECT "RainToday", BOOL_OR("RainTomorrow" = 'Yes') as any_rain FROM weather GROUP BY "RainToday""#;
+        let gpu = tf.execute(&format!("SET cudf.enable=true; {sql}")).await?;
         let cpu = tf.execute(sql).await?;
-        assert!(
-            !cudf.plan.contains("CuDFAggregateExec"),
-            "expected CPU fallback"
-        );
-        assert_eq!(cpu.pretty_print, cudf.pretty_print);
+        assert!(!gpu.plan.contains("CuDFAggregateExec"), "expected CPU fallback");
+        assert_eq!(cpu.pretty_print, gpu.pretty_print);
         Ok(())
     }
 }

--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -435,10 +435,19 @@ mod integration {
     /// AVG produces Float64 — uses assert_batches_approx_eq to handle last-ULP differences.
     #[tokio::test]
     async fn test_avg() -> Result<(), Box<dyn Error>> {
-        let sql = r#"SELECT "RainToday", AVG("MinTemp") as avg_min FROM weather GROUP BY "RainToday""#;
+        let sql =
+            r#"SELECT "RainToday", AVG("MinTemp") as avg_min FROM weather GROUP BY "RainToday""#;
         let tf = TestFramework::new().await;
-        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}")).await?;
-        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        let gpu = tf
+            .execute(&format!(
+                "SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
+        let cpu = tf
+            .execute(&format!(
+                "SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
         assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
         assert_snapshot!(gpu.plan, @"
         CuDFUnloadExec
@@ -483,8 +492,16 @@ mod integration {
     async fn test_multiple_aggregates() -> Result<(), Box<dyn Error>> {
         let sql = r#"SELECT "RainToday", COUNT("Rainfall") as n, SUM("Rainfall") as total, AVG("MaxTemp") as avg_max, MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
         let tf = TestFramework::new().await;
-        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}")).await?;
-        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        let gpu = tf
+            .execute(&format!(
+                "SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
+        let cpu = tf
+            .execute(&format!(
+                "SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
         assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
         assert_snapshot!(gpu.plan, @"
         CuDFUnloadExec
@@ -547,7 +564,8 @@ mod integration {
 
     #[tokio::test]
     async fn test_multi_partition_sum() -> Result<(), Box<dyn Error>> {
-        let sql = r#"SELECT "RainToday", SUM("Rainfall") as total FROM weather GROUP BY "RainToday""#;
+        let sql =
+            r#"SELECT "RainToday", SUM("Rainfall") as total FROM weather GROUP BY "RainToday""#;
         let result = check_query_results(sql, 4).await?;
         assert_snapshot!(result.plan, @"
         CuDFUnloadExec
@@ -594,8 +612,16 @@ mod integration {
     async fn test_multi_partition_multiple_aggs() -> Result<(), Box<dyn Error>> {
         let sql = r#"SELECT "RainToday", COUNT(*) as n, SUM("Rainfall") as total, AVG("MaxTemp") as avg_max, MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
         let tf = TestFramework::new().await;
-        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=4; {sql}")).await?;
-        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=4; {sql}")).await?;
+        let gpu = tf
+            .execute(&format!(
+                "SET cudf.enable=true; SET datafusion.execution.target_partitions=4; {sql}"
+            ))
+            .await?;
+        let cpu = tf
+            .execute(&format!(
+                "SET datafusion.execution.target_partitions=4; {sql}"
+            ))
+            .await?;
         assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
         assert_snapshot!(gpu.plan, @"
         CuDFUnloadExec
@@ -622,7 +648,10 @@ mod integration {
         let sql = r#"SELECT "RainToday", BOOL_OR("RainTomorrow" = 'Yes') as any_rain FROM weather GROUP BY "RainToday""#;
         let gpu = tf.execute(&format!("SET cudf.enable=true; {sql}")).await?;
         let cpu = tf.execute(sql).await?;
-        assert!(!gpu.plan.contains("CuDFAggregateExec"), "expected CPU fallback");
+        assert!(
+            !gpu.plan.contains("CuDFAggregateExec"),
+            "expected CPU fallback"
+        );
         assert_eq!(cpu.pretty_print, gpu.pretty_print);
         Ok(())
     }

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -12,7 +12,9 @@ use datafusion_physical_plan::aggregates::{
 };
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
 use futures::{ready, StreamExt};
-use libcudf_rs::{CuDFColumn, CuDFColumnView, CuDFGroupBy, CuDFTable, CuDFTableView};
+use libcudf_rs::{
+    record_batch_with_schema, CuDFColumn, CuDFColumnView, CuDFGroupBy, CuDFTable, CuDFTableView,
+};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -303,10 +305,7 @@ impl Stream {
             }
         }
 
-        Ok(Some(RecordBatch::try_new(
-            self.output_schema.clone(),
-            arrays,
-        )?))
+        Ok(Some(record_batch_with_schema(arrays, &self.output_schema)?))
     }
 
     /// Evaluate GROUP BY expressions on a batch and wrap the resulting key
@@ -386,7 +385,7 @@ fn concat_cudf_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
             Ok(Arc::new(col.into_view()) as Arc<dyn Array>)
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(RecordBatch::try_new(schema, cols)?)
+    Ok(record_batch_with_schema(cols, &schema)?)
 }
 
 impl futures::Stream for Stream {

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -336,6 +336,15 @@ impl Stream {
 
     /// Evaluate each aggregate function's argument expressions on a batch,
     /// returning GPU column views suitable for `partial_requests` / `merge_requests`.
+    ///
+    /// `aggregate_args` holds raw DataFusion expressions (not cuDF-wrapped ones), so
+    /// `evaluate_many` can return plain Arrow arrays. Non-GPU arrays are uploaded at this
+    /// boundary.
+    ///
+    /// TODO: A cleaner design would store cuDF expressions in `aggregate_args` (mirroring how
+    /// `CuDFFilterExec` stores a `CuDFExpr`), but requires `cudf::make_column_from_scalar`
+    /// in `libcudf-sys` to broadcast `CuDFScalar` literals to full column length. The boundary
+    /// upload here is equivalent work and avoids adding that FFI surface for now.
     fn evaluate_batch_arguments(&self, batch: &RecordBatch) -> Result<Vec<Vec<CuDFColumnView>>> {
         let evaluated_arguments = evaluate_many(&self.aggregate_args, batch)?;
 
@@ -344,10 +353,12 @@ impl Stream {
             .map(|args| {
                 args.iter()
                     .map(|arg| {
-                        let Some(view) = arg.as_any().downcast_ref::<CuDFColumnView>() else {
-                            return internal_err!("Expected Array to be of type CuDFColumnView");
-                        };
-                        Ok(view.clone())
+                        if let Some(view) = arg.as_any().downcast_ref::<CuDFColumnView>() {
+                            return Ok(view.clone());
+                        }
+                        CuDFColumn::from_arrow_host(arg.as_ref())
+                            .map(|col| col.into_view())
+                            .map_err(cudf_to_df)
                     })
                     .collect()
             })

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -336,14 +336,8 @@ impl Stream {
     /// Evaluate each aggregate function's argument expressions on a batch,
     /// returning GPU column views suitable for `partial_requests` / `merge_requests`.
     ///
-    /// `aggregate_args` holds raw DataFusion expressions (not cuDF-wrapped ones), so
-    /// `evaluate_many` can return plain Arrow arrays. Non-GPU arrays are uploaded at this
-    /// boundary.
-    ///
-    /// TODO: A cleaner design would store cuDF expressions in `aggregate_args` (mirroring how
-    /// `CuDFFilterExec` stores a `CuDFExpr`), but requires `cudf::make_column_from_scalar`
-    /// in `libcudf-sys` to broadcast `CuDFScalar` literals to full column length. The boundary
-    /// upload here is equivalent work and avoids adding that FFI surface for now.
+    /// Literal aggregate args, such as `COUNT(*)`, can evaluate to host Arrow arrays.
+    /// Upload them here so aggregate requests always receive cuDF column views.
     fn evaluate_batch_arguments(&self, batch: &RecordBatch) -> Result<Vec<Vec<CuDFColumnView>>> {
         let evaluated_arguments = evaluate_many(&self.aggregate_args, batch)?;
 

--- a/libcudf-datafusion/src/expr/binary.rs
+++ b/libcudf-datafusion/src/expr/binary.rs
@@ -1,6 +1,6 @@
 use crate::errors::cudf_to_df;
 use crate::expr::{columnar_value_to_cudf, cudf_to_columnar_value, expr_to_cudf_expr};
-use arrow::array::{AsArray, RecordBatch};
+use arrow::array::RecordBatch;
 use arrow_schema::{DataType, FieldRef, Schema};
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::ColumnarValue;
@@ -67,49 +67,21 @@ impl PhysicalExpr for CuDFBinaryExpr {
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> datafusion::common::Result<ColumnarValue> {
-        // Get BOTH the expected output type (from host) AND the CuDF output type (normalized precision)
-        let expected_output_type = self.data_type(batch.schema_ref())?;
+        let expected = self.data_type(batch.schema_ref())?;
 
-        // For CuDF binary op, use normalized decimal precision (38)
-        let cudf_output_type = match &expected_output_type {
+        // cuDF requires max precision for decimal output types.
+        let cudf_output_type = match &expected {
             DataType::Decimal128(_, scale) => DataType::Decimal128(38, *scale),
             DataType::Decimal32(_, scale) => DataType::Decimal32(9, *scale),
             DataType::Decimal64(_, scale) => DataType::Decimal64(18, *scale),
-            _ => expected_output_type.clone(),
+            _ => expected.clone(),
         };
 
-        let lhs = self.left.evaluate(batch)?;
-        let lhs = columnar_value_to_cudf(lhs)?;
-        let rhs = self.right.evaluate(batch)?;
-        let rhs = columnar_value_to_cudf(rhs)?;
+        let lhs = columnar_value_to_cudf(self.left.evaluate(batch)?)?;
+        let rhs = columnar_value_to_cudf(self.right.evaluate(batch)?)?;
 
         let result = cudf_binary_op(lhs, rhs, self.op, &cudf_output_type).map_err(cudf_to_df)?;
-        let mut result = cudf_to_columnar_value(result);
-
-        // CuDF returns decimals with maximum precision (38), but DataFusion may expect a different precision.
-        // Cast the result if needed to match the expected output type.
-        if let ColumnarValue::Array(arr) = &result {
-            if arr.data_type() != &expected_output_type {
-                if let (
-                    DataType::Decimal128(_, result_scale),
-                    DataType::Decimal128(_expected_prec, expected_scale),
-                ) = (arr.data_type(), &expected_output_type)
-                {
-                    if result_scale == expected_scale {
-                        // Same scale, just different precision. Arrow's cast doesn't handle this,
-                        // so we manually change the precision metadata while keeping the same i128 values.
-                        let decimal_array = arr.as_primitive::<arrow::datatypes::Decimal128Type>();
-                        let casted = decimal_array
-                            .clone()
-                            .with_precision_and_scale(*_expected_prec, *expected_scale)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                        result = ColumnarValue::Array(Arc::new(casted));
-                    }
-                }
-            }
-        }
-
-        Ok(result)
+        Ok(cudf_to_columnar_value(result))
     }
 
     fn with_new_children(

--- a/libcudf-datafusion/src/physical/coalesce_batches.rs
+++ b/libcudf-datafusion/src/physical/coalesce_batches.rs
@@ -387,7 +387,9 @@ impl CuDFBatchCoalescer {
 
         // Convert back to record batch
         let concat_view = concat_table.into_view();
-        let concat_batch = concat_view.to_record_batch().map_err(cudf_to_df)?;
+        let concat_batch = concat_view
+            .to_record_batch_with_schema(&self.schema)
+            .map_err(cudf_to_df)?;
 
         // Split at target_batch_size
         let output_batch = concat_batch.slice(0, self.target_batch_size);
@@ -434,7 +436,9 @@ impl CuDFBatchCoalescer {
 
         let concat_table = CuDFTable::concat(table_views).map_err(cudf_to_df)?;
         let concat_view = concat_table.into_view();
-        let concat_batch = concat_view.to_record_batch().map_err(cudf_to_df)?;
+        let concat_batch = concat_view
+            .to_record_batch_with_schema(&self.schema)
+            .map_err(cudf_to_df)?;
 
         self.completed.push(concat_batch);
         self.buffered_batches.clear();

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -104,11 +104,7 @@ impl ExecutionPlan for CuDFLoadExec {
     }
 }
 
-/// Maps an Arrow schema to the types cuDF will actually produce.
-///
-/// - `Utf8View -> Utf8`: cuDF's `TYPE_STRING` has no view variant.
-/// - `Decimal{32,64,128}(p, s) -> Decimal{32,64,128}(max_p, s)`: cuDF uses fixed precision
-///   based on storage width (9/18/38). Scale is preserved.
+/// Maps an Arrow schema to cuDF-compatible types (`Utf8View -> Utf8`).
 pub(crate) fn cudf_schema_compatibility_map(schema: SchemaRef) -> SchemaRef {
     let mut new_fields = Vec::with_capacity(schema.fields.len());
 
@@ -117,21 +113,6 @@ pub(crate) fn cudf_schema_compatibility_map(schema: SchemaRef) -> SchemaRef {
             DataType::Utf8View => FieldRef::new(Field::new(
                 field.name(),
                 DataType::Utf8,
-                field.is_nullable(),
-            )),
-            DataType::Decimal32(_, s) => FieldRef::new(Field::new(
-                field.name(),
-                DataType::Decimal32(9, *s), // max precision for 32-bit
-                field.is_nullable(),
-            )),
-            DataType::Decimal64(_, s) => FieldRef::new(Field::new(
-                field.name(),
-                DataType::Decimal64(18, *s), // max precision for 64-bit
-                field.is_nullable(),
-            )),
-            DataType::Decimal128(_, s) => FieldRef::new(Field::new(
-                field.name(),
-                DataType::Decimal128(38, *s), // max precision for 128-bit
                 field.is_nullable(),
             )),
             _ => Arc::clone(field),

--- a/libcudf-datafusion/src/physical/filter.rs
+++ b/libcudf-datafusion/src/physical/filter.rs
@@ -204,21 +204,18 @@ fn filter_and_project(
     }
 
     // Apply projection if needed
-    if let Some(projection) = projection {
-        let projected_columns: Vec<Arc<dyn Array>> = projection
+    let columns = if let Some(projection) = projection {
+        projection
             .iter()
             .map(|i| Arc::clone(&cudf_columns[*i]))
-            .collect();
-        Ok(RecordBatch::try_new(
-            Arc::clone(output_schema),
-            projected_columns,
-        )?)
+            .collect()
     } else {
-        Ok(libcudf_rs::record_batch_with_schema(
-            cudf_columns,
-            output_schema,
-        )?)
-    }
+        cudf_columns
+    };
+    Ok(libcudf_rs::record_batch_with_schema(
+        columns,
+        output_schema,
+    )?)
 }
 
 // Implementation pretty much copied from `datafusion/core/src/physical_plan/filter.rs`

--- a/libcudf-datafusion/src/physical/sort.rs
+++ b/libcudf-datafusion/src/physical/sort.rs
@@ -1,5 +1,6 @@
 use crate::errors::cudf_to_df;
-use arrow::array::{Array, RecordBatch};
+use arrow::array::RecordBatch;
+use arrow_schema::SchemaRef;
 use datafusion::common::Statistics;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -71,9 +72,11 @@ impl ExecutionPlan for CuDFSortExec {
             execute_stream(Arc::clone(self.inner.input()), context)?
         };
 
+        let schema = self.schema();
         let ordered_stream = if let Some(limit) = self.fetch() {
             CuDFTopKStream {
                 input,
+                schema,
                 limit,
                 ordering: self.inner.expr().clone(),
                 result: None,
@@ -83,6 +86,7 @@ impl ExecutionPlan for CuDFSortExec {
         } else {
             CuDFSortStream {
                 input,
+                schema,
                 ordering: self.inner.expr().clone(),
                 views: vec![],
                 finished: false,
@@ -109,6 +113,7 @@ impl ExecutionPlan for CuDFSortExec {
 
 struct CuDFSortStream {
     input: SendableRecordBatchStream,
+    schema: SchemaRef,
     ordering: LexOrdering,
     views: Vec<CuDFTableView>,
     finished: bool,
@@ -143,9 +148,12 @@ impl Stream for CuDFSortStream {
                 let (key_columns, sort_orders) = extract_sort_params(&self.ordering);
                 let sorted = sort(&table_view, &key_columns, &sort_orders).map_err(cudf_to_df)?;
 
-                let result = sorted.into_view().to_record_batch().map_err(cudf_to_df);
+                let result = sorted
+                    .into_view()
+                    .to_record_batch_with_schema(&self.schema)
+                    .map_err(cudf_to_df)?;
 
-                Poll::Ready(Some(result))
+                Poll::Ready(Some(Ok(result)))
             }
         }
     }
@@ -162,6 +170,7 @@ impl Stream for CuDFSortStream {
 /// This reduces memory usage and improves performance for large inputs.
 struct CuDFTopKStream {
     input: SendableRecordBatchStream,
+    schema: SchemaRef,
     ordering: LexOrdering,
     limit: usize,
     result: Option<CuDFTableView>,
@@ -232,7 +241,7 @@ impl Stream for CuDFTopKStream {
 
                 let batch = sorted_result
                     .into_view()
-                    .to_record_batch()
+                    .to_record_batch_with_schema(&self.schema)
                     .map_err(cudf_to_df)?;
                 Poll::Ready(Some(Ok(batch)))
             }

--- a/libcudf-datafusion/src/test_utils/mod.rs
+++ b/libcudf-datafusion/src/test_utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod insta;
+#[cfg(test)]
 mod session_context;
 pub mod tpch;
 
-pub(crate) use session_context::{check_query_results, sort_batches, SqlResult, TestFramework};
+#[cfg(test)]
+pub(crate) use session_context::{check_query_results, sort_batches, TestFramework};

--- a/libcudf-datafusion/src/test_utils/mod.rs
+++ b/libcudf-datafusion/src/test_utils/mod.rs
@@ -2,4 +2,4 @@ pub mod insta;
 mod session_context;
 pub mod tpch;
 
-pub(crate) use session_context::{SqlResult, TestFramework};
+pub(crate) use session_context::{check_query_results, sort_batches, SqlResult, TestFramework};

--- a/libcudf-datafusion/src/test_utils/session_context.rs
+++ b/libcudf-datafusion/src/test_utils/session_context.rs
@@ -95,3 +95,42 @@ pub struct SqlResult {
     pub plan: String,
     pub batches: Vec<RecordBatch>,
 }
+
+/// Run `sql` on both GPU and CPU with `partitions` target partitions, assert results match,
+/// and return the GPU [`SqlResult`].
+pub(crate) async fn check_query_results(
+    sql: &str,
+    partitions: usize,
+) -> Result<SqlResult, DataFusionError> {
+    let tf = TestFramework::new().await;
+    let cudf_sql = format!(
+        "SET cudf.enable=true; SET datafusion.execution.target_partitions={partitions}; {sql}"
+    );
+    let cpu_sql = format!("SET datafusion.execution.target_partitions={partitions}; {sql}");
+    let gpu = tf.execute(&cudf_sql).await?;
+    let cpu = tf.execute(&cpu_sql).await?;
+    let gpu_pp = pretty_format_batches(&sort_batches(&gpu.batches))?.to_string();
+    let cpu_pp = pretty_format_batches(&sort_batches(&cpu.batches))?.to_string();
+    assert_eq!(gpu_pp, cpu_pp);
+    Ok(gpu)
+}
+
+/// Concatenate `batches` into one and sort rows by the first column.
+pub(crate) fn sort_batches(batches: &[RecordBatch]) -> Vec<RecordBatch> {
+    if batches.is_empty() {
+        return vec![];
+    }
+    let schema = batches[0].schema();
+    let combined = arrow::compute::concat_batches(&schema, batches).expect("concat_batches failed");
+    if combined.num_rows() == 0 {
+        return vec![combined];
+    }
+    let indices =
+        arrow::compute::sort_to_indices(combined.column(0), None, None).expect("sort failed");
+    let columns: Vec<_> = combined
+        .columns()
+        .iter()
+        .map(|c| arrow::compute::take(c.as_ref(), &indices, None).expect("take failed"))
+        .collect();
+    vec![RecordBatch::try_new(schema, columns).expect("RecordBatch::try_new failed")]
+}

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -54,10 +54,9 @@ impl CuDFColumnView {
         self.inner
     }
 
-    /// Create a view with a different Arrow `DataType` label, sharing the same GPU memory.
-    ///
-    /// The caller must ensure the raw GPU values are correct for the new type.
-    /// Safe to use when the view is only unloaded to host, not chained into further GPU arithmetic.
+    /// Relabel this view's Arrow `DataType` without touching GPU memory.
+    /// Used by [`record_batch_with_schema`](crate::record_batch_with_schema) to
+    /// reconcile cuDF's max-precision decimals with declared schema types.
     pub fn with_data_type(self, dt: DataType) -> Self {
         Self {
             _ref: self._ref,


### PR DESCRIPTION
## Summary

Updates the DataFusion aggregate path for edge cases that were still missing after the main aggregate redesign:

- support aggregate arguments that evaluate to host Arrow arrays, including `COUNT(*)`
- preserve declared schemas when aggregate/coalesce/filter/sort paths rebuild cuDF-backed `RecordBatch` values
- keep decimal output precision aligned with the DataFusion schema while still asking cuDF for max-precision decimal arithmetic
- add aggregate plan and correctness coverage for `COUNT(*)`, mixed aggregates, multi-partition aggregation, and CPU fallback for unsupported aggregates

## Validation

- `cargo fmt --all --check`
- `git diff --check upstream/main...HEAD`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-datafusion aggregate --lib --locked`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p libcudf-datafusion --lib --locked`

The full DataFusion lib suite passed: 46 passed, 0 failed.
