### PR TITLE
libcudf-sys: add cuda streams FFI API

### DIFF
--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ffi {
         include!("libcudf-sys/src/binaryop.h");
         include!("libcudf-sys/src/sorting.h");
         include!("libcudf-sys/src/join.h");
+        include!("libcudf-sys/src/stream.h");
 
         /// A set of cuDF columns of the same size
         ///
@@ -78,6 +79,22 @@ pub mod ffi {
         /// The groupby object is constructed with a set of key columns and can perform
         /// various aggregations on value columns based on those keys.
         type GroupBy;
+
+        /// Opaque owning wrapper for an RMM CUDA stream.
+        type CudaStream;
+
+        /// Return whether this wrapper still owns an underlying CUDA stream.
+        ///
+        /// In C++, you could do something like
+        /// ```ignore
+        /// CudaStream a = CudaStream();
+        /// CudaStream b(std::move(a));
+        /// ```
+        /// This would transfer ownership of the stream from `a` to `b`, making `a` invalid.
+        ///
+        /// However, there's no ffi API available right now to do this via rust, so there's no
+        /// need to worry about invalidating a stream at the moment.
+        fn is_valid(self: &CudaStream) -> bool;
 
         // GroupBy methods - direct cuDF class methods
 
@@ -605,6 +622,12 @@ pub mod ffi {
         /// Allocations at or below `threshold_bytes` use pinned memory. Larger
         /// allocations remain pageable.
         fn set_host_pinned_threshold(threshold_bytes: usize);
+
+        /// Create a CUDA stream using the default creation flag.
+        fn cuda_stream_create() -> UniquePtr<CudaStream>;
+
+        /// Create a CUDA stream with explicit creation flags.
+        fn cuda_stream_create_with_flags(flags: u32) -> UniquePtr<CudaStream>;
     }
 }
 
@@ -957,6 +980,12 @@ unsafe impl Send for ffi::GroupByResult {}
 /// SAFETY: GroupByResult can be accessed from multiple threads.
 unsafe impl Sync for ffi::GroupByResult {}
 
+/// SAFETY: CUDA stream handles can be transferred between threads.
+unsafe impl Send for ffi::CudaStream {}
+
+/// SAFETY: Shared references to the opaque stream wrapper are safe.
+unsafe impl Sync for ffi::CudaStream {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -968,6 +997,10 @@ mod tests {
     use arrow_schema::{ArrowError, DataType};
     use insta::assert_snapshot;
     use std::fmt::Display;
+    use std::sync::Arc;
+
+    const CUDA_STREAM_FLAG_BLOCKING: u32 = 1;
+    const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
 
     // Sorting tests
     #[test]
@@ -1310,6 +1343,35 @@ mod tests {
         ");
 
         Ok(())
+    }
+
+    // CUDA Stream tests
+
+    // Test the various methods of creating streams. Assert that each method yields a valid stream.
+    #[test]
+    fn test_cuda_stream_create() {
+        let stream = ffi::cuda_stream_create();
+        assert!(stream.is_valid());
+
+        let stream = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_BLOCKING);
+        assert!(stream.is_valid());
+
+        let stream = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING);
+        assert!(stream.is_valid());
+    }
+
+    // Test that streams are Send and Sync.
+    #[test]
+    fn test_cuda_stream_send_sync() {
+        let stream = Arc::new(ffi::cuda_stream_create());
+
+        let handle = std::thread::spawn({
+            let stream = Arc::clone(&stream);
+            move || stream.is_valid()
+        });
+
+        assert!(handle.join().expect("moved stream should be valid"));
+        assert!(stream.is_valid());
     }
 
     fn pretty_table(table_view: &ffi::TableView) -> Result<impl Display + use<>, ArrowError> {

--- a/libcudf-sys/src/stream.cpp
+++ b/libcudf-sys/src/stream.cpp
@@ -1,0 +1,52 @@
+#include "stream.h"
+
+#include <stdexcept>
+
+namespace libcudf_bridge {
+    namespace {
+        constexpr uint32_t kCudaStreamFlagSyncDefault = 0;
+        constexpr uint32_t kCudaStreamFlagNonBlocking = 1;
+
+        // Map our flags to [`rmm::cuda_stream::flags`].
+        [[nodiscard]] rmm::cuda_stream::flags to_rmm_flags(const uint32_t flags) {
+            switch (flags) {
+                case kCudaStreamFlagSyncDefault:
+                    return rmm::cuda_stream::flags::sync_default;
+                case kCudaStreamFlagNonBlocking:
+                    return rmm::cuda_stream::flags::non_blocking;
+            }
+
+            throw std::invalid_argument("Unsupported CUDA stream flags");
+        }
+    } // namespace
+
+    /// By default, create a stream that synchronizes with the default stream
+    /// (ie. this uses [`rmm::cuda_stream::flags::sync_default`]).
+    CudaStream::CudaStream() : inner(std::make_unique<rmm::cuda_stream>()) {}
+
+    CudaStream::CudaStream(const uint32_t flags)
+        : inner(std::make_unique<rmm::cuda_stream>(to_rmm_flags(flags))) {}
+
+    CudaStream::~CudaStream() = default;
+
+    // A wrapper is valid as long as it still owns an underlying RMM stream.
+    bool CudaStream::is_valid() const {
+        return inner && inner->is_valid();
+    }
+
+    rmm::cuda_stream_view CudaStream::view() const {
+        // In case `inner` gets moved by assigning one `CudaStream` to another.
+        if (!inner) {
+            throw std::runtime_error("Cannot get view of null CUDA stream");
+        }
+        return inner->view();
+    }
+
+    std::unique_ptr<CudaStream> cuda_stream_create() {
+        return std::make_unique<CudaStream>();
+    }
+
+    std::unique_ptr<CudaStream> cuda_stream_create_with_flags(const uint32_t flags) {
+        return std::make_unique<CudaStream>(flags);
+    }
+} // namespace libcudf_bridge

--- a/libcudf-sys/src/stream.h
+++ b/libcudf-sys/src/stream.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+
+namespace libcudf_bridge {
+    /// Owning wrapper for an RMM CUDA stream.
+    struct CudaStream {
+        std::unique_ptr<rmm::cuda_stream> inner;
+
+        /// Construct a stream using RMM's sync-default stream creation flag.
+        CudaStream();
+
+        /// Construct a stream with an explicit raw flag value.
+        explicit CudaStream(uint32_t flags);
+
+        ~CudaStream();
+
+        /// Return whether this wrapper still owns a live CUDA stream.
+        ///
+        /// This becomes `false` if the wrapper has been moved-from and no longer
+        /// owns its underlying `rmm::cuda_stream`.
+        [[nodiscard]] bool is_valid() const;
+
+        /// Return a non-owning stream view for passing into cuDF APIs.
+        [[nodiscard]] rmm::cuda_stream_view view() const;
+    };
+
+    /// Create a CUDA stream using the default sync-default creation flag.
+    std::unique_ptr<CudaStream> cuda_stream_create();
+
+    /// Create a CUDA stream with an explicit raw flag value.
+    std::unique_ptr<CudaStream> cuda_stream_create_with_flags(uint32_t flags);
+} // namespace libcudf_bridge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod operations;
 mod pinned_pool;
 mod scalar;
 mod sort;
+mod stream;
 mod table;
 mod table_view;
 
@@ -47,6 +48,7 @@ pub use operations::{apply_boolean_mask, cast, gather, slice_column};
 pub use pinned_pool::PinnedPoolConfig;
 pub use scalar::CuDFScalar;
 pub use sort::{sort, sort_by_all, stable_sorted_order, SortOrder};
+pub use stream::{CuDFStream, CuDFStreamFlags};
 pub use table::*;
 pub use table_view::*;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,61 @@
+use cxx::UniquePtr;
+
+/// Stream creation flags for CUDA stream-backed cuDF execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CuDFStreamFlags {
+    /// Create a stream that synchronizes with the default stream.
+    SyncDefault,
+    /// Create a non-blocking stream that does not synchronize with the default stream.
+    NonBlocking,
+}
+
+const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
+const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
+
+impl From<CuDFStreamFlags> for u32 {
+    fn from(value: CuDFStreamFlags) -> Self {
+        match value {
+            CuDFStreamFlags::SyncDefault => CUDA_STREAM_FLAG_SYNC_DEFAULT,
+            CuDFStreamFlags::NonBlocking => CUDA_STREAM_FLAG_NON_BLOCKING,
+        }
+    }
+}
+
+/// Owning Rust wrapper for a CUDA stream used by cuDF operations.
+///
+/// This type owns an opaque C++ `rmm::cuda_stream`. Dropping `CuDFStream`
+/// destroys that underlying stream.
+///
+/// The handle may be shared across host threads. Work enqueued onto the same
+/// stream executes in order; sharing the handle does not by itself synchronize
+/// access to GPU memory used by those operations.
+pub struct CuDFStream {
+    inner: UniquePtr<libcudf_sys::ffi::CudaStream>,
+}
+
+impl CuDFStream {
+    /// Create a stream using the sync-default creation flag.
+    pub fn new() -> Self {
+        Self {
+            inner: libcudf_sys::ffi::cuda_stream_create(),
+        }
+    }
+
+    /// Create a stream with explicit creation flags.
+    pub fn with_flags(flags: CuDFStreamFlags) -> Self {
+        Self {
+            inner: libcudf_sys::ffi::cuda_stream_create_with_flags(flags.into()),
+        }
+    }
+
+    /// Get a reference to the underlying FFI stream handle.
+    pub(crate) fn inner(&self) -> &libcudf_sys::ffi::CudaStream {
+        self.inner.as_ref().expect("CudaStream should not be null")
+    }
+}
+
+impl Default for CuDFStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This change adds cuda steam times in cpp and the corresponding FFI API / wrappers in rust. This APIs can be used to create streams (see https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#cuda-streams).

Streams two types which can be configured via a flag:
- Sync/Blocking: This stream synchronizes with the default stream, defined below:
```
This default stream, which was shared amongst all host threads, is a blocking stream. When an operation is launched into this default stream, it will synchronize with all other blocking streams, in other words it will wait for all other blocking streams to complete before it can execute.
```
- Nonblocking: This stream does not synchronize with the default stream, meaning two streams can do work (run a kernel, copy from host to device, copy from device to host) in parallel.

This project currently uses the default stream for all operations, so we lose some potential parallelism.

Future work:
Determine the stream model/design in libcudf-rs (ex. should we use a stream per partition, per core, per tokio executor thread etc.)
- Are streams thread safe (even though they are serialized queues of instructions, they don' seem to be safe for concurrent usage) - how do we share them across tasks in rust safely?
- What is the overhead in creating a stream?
- Should different concurrent queries share streams or should we create new ones each time?