### PR TITLE
Add --warmup flag to dfbench run

### DIFF
--- a/libcudf-datafusion-benchmarks/src/run.rs
+++ b/libcudf-datafusion-benchmarks/src/run.rs
@@ -66,6 +66,12 @@ pub struct RunOpt {
     #[structopt(short, long)]
     debug: bool,
 
+    /// Run each query once before starting timed iterations.
+    /// Useful to amortize one-shot costs (parquet metadata caching,
+    /// CUDA context init, JIT, etc.) before measurement begins.
+    #[structopt(long)]
+    warmup: bool,
+
     /// Use the GPU (cuDF) execution path. When unset, runs on the CPU
     /// using DataFusion's default operators.
     #[structopt(long)]
@@ -165,6 +171,18 @@ impl RunOpt {
             dataset: self.dataset.clone(),
             iterations: vec![],
         };
+
+        if self.warmup {
+            for query in sql.split(";").map(|v| v.trim()) {
+                if query.is_empty() {
+                    continue;
+                }
+                match self.execute_query(ctx, query).await {
+                    Ok(_) => println!("Query {id} warmup completed"),
+                    Err(err) => println!("Query {id} warmup failed: {err}"),
+                }
+            }
+        }
 
         'outer: for i in 0..self.iterations {
             let start = Instant::now();


### PR DESCRIPTION
## Summary
- New `--warmup` flag on `dfbench run`. When set, each query runs once before its timed iterations begin.
- Useful to amortize one-shot costs (parquet metadata caching, CUDA context init, JIT, etc.) out of the reported numbers.
- Warmup failures are logged but don't abort the run — the query still gets its real timed attempts.

## Test plan
- [x] `cargo build -p libcudf-datafusion-benchmarks --bin dfbench`
- [x] `dfbench run --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)