### PR TITLE
Fix CuDFUnloadExec on zero-column batches

### DIFF
--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -266,6 +266,7 @@ impl Stream {
             return Ok(None);
         };
 
+        let num_rows = running.keys.num_rows();
         let key_columns = running.keys.into_columns();
         let mut arrays: Vec<ArrayRef> =
             Vec::with_capacity(key_columns.len() + self.aggregate_expr.len());
@@ -305,7 +306,11 @@ impl Stream {
             }
         }
 
-        Ok(Some(record_batch_with_schema(arrays, &self.output_schema)?))
+        Ok(Some(record_batch_with_schema(
+            arrays,
+            &self.output_schema,
+            num_rows,
+        )?))
     }
 
     /// Evaluate GROUP BY expressions on a batch and wrap the resulting key
@@ -362,6 +367,7 @@ impl Stream {
 /// Concatenate CuDF-backed record batches into a single batch by column.
 fn concat_cudf_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
     let schema = batches[0].schema();
+    let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     let cols = (0..schema.fields().len())
         .map(|i| {
             let views = batches
@@ -379,7 +385,7 @@ fn concat_cudf_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
             Ok(Arc::new(col.into_view()) as Arc<dyn Array>)
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(record_batch_with_schema(cols, &schema)?)
+    Ok(record_batch_with_schema(cols, &schema, num_rows)?)
 }
 
 impl futures::Stream for Stream {

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -1,6 +1,6 @@
 use crate::errors::cudf_to_df;
 use crate::optimizer::CuDFConfig;
-use arrow::array::{Array, RecordBatch};
+use arrow::array::{Array, RecordBatch, RecordBatchOptions};
 use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema, SchemaRef};
 use datafusion::common::{exec_err, plan_err, ScalarValue};
 use datafusion::error::DataFusionError;
@@ -118,12 +118,15 @@ impl ExecutionPlan for CuDFLoadExec {
             } else {
                 CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?
             };
+            let num_rows = table.num_rows();
             let cudf_cols: Vec<Arc<dyn Array>> = table
                 .into_columns()
                 .into_iter()
                 .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
                 .collect();
-            Ok(libcudf_rs::record_batch_with_schema(cudf_cols, &schema)?)
+            Ok(libcudf_rs::record_batch_with_schema(
+                cudf_cols, &schema, num_rows,
+            )?)
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
@@ -163,6 +166,7 @@ pub(crate) fn cast_to_target_schema(
     batch: RecordBatch,
     target_schema: SchemaRef,
 ) -> Result<RecordBatch, ArrowError> {
+    let num_rows = batch.num_rows();
     let columns = batch
         .columns()
         .iter()
@@ -170,5 +174,6 @@ pub(crate) fn cast_to_target_schema(
         .map(|(col, field)| arrow::compute::cast(col, field.data_type()))
         .collect::<Result<Vec<_>, _>>()?;
 
-    RecordBatch::try_new(target_schema, columns)
+    let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+    RecordBatch::try_new_with_options(target_schema, columns, &options)
 }

--- a/libcudf-datafusion/src/physical/cudf_unload.rs
+++ b/libcudf-datafusion/src/physical/cudf_unload.rs
@@ -1,5 +1,5 @@
 use crate::errors::cudf_to_df;
-use arrow::array::RecordBatch;
+use arrow::array::{RecordBatch, RecordBatchOptions};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use datafusion::common::{plan_err, DataFusionError};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -91,18 +91,22 @@ impl ExecutionPlan for CuDFUnloadExec {
 
             let view = CuDFTableView::from_record_batch(&batch).map_err(cudf_to_df)?;
             let host_batch = view.to_arrow_host().map_err(cudf_to_df)?;
+            let num_rows = host_batch.num_rows();
             let columns = host_batch
                 .columns()
                 .iter()
                 .zip(target_schema.fields())
                 .map(|(col, field)| arrow::compute::cast(col, field.data_type()))
                 .collect::<Result<Vec<_>, _>>()?;
-            RecordBatch::try_new(target_schema.clone(), columns).map_err(|err| {
-                DataFusionError::ArrowError(
-                    Box::new(err),
-                    Some("Error while unloading a RecordBatch from CuDF into host".to_string()),
-                )
-            })
+            let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+            RecordBatch::try_new_with_options(target_schema.clone(), columns, &options).map_err(
+                |err| {
+                    DataFusionError::ArrowError(
+                        Box::new(err),
+                        Some("Error while unloading a RecordBatch from CuDF into host".to_string()),
+                    )
+                },
+            )
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),

--- a/libcudf-datafusion/src/physical/filter.rs
+++ b/libcudf-datafusion/src/physical/filter.rs
@@ -195,6 +195,7 @@ fn filter_and_project(
 
     // Keep data on GPU by wrapping table in an Arc and creating column views that reference it
     let table_view = filtered_table.into_view();
+    let num_rows = table_view.num_rows();
     let num_cols = table_view.num_columns();
 
     let mut cudf_columns: Vec<Arc<dyn Array>> = Vec::with_capacity(num_cols);
@@ -215,6 +216,7 @@ fn filter_and_project(
     Ok(libcudf_rs::record_batch_with_schema(
         columns,
         output_schema,
+        num_rows,
     )?)
 }
 

--- a/libcudf-datafusion/src/physical/projection.rs
+++ b/libcudf-datafusion/src/physical/projection.rs
@@ -2,7 +2,6 @@ use crate::expr::expr_to_cudf_expr;
 use crate::physical::record_gpu_poll;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatchOptions;
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
@@ -167,14 +166,8 @@ impl CuDFProjectionStream {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if arrays.is_empty() {
-            let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-            RecordBatch::try_new_with_options(Arc::clone(&self.schema), arrays, &options)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-        } else {
-            libcudf_rs::record_batch_with_schema(arrays, &self.schema)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-        }
+        libcudf_rs::record_batch_with_schema(arrays, &self.schema, batch.num_rows())
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     }
 }
 

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -1,6 +1,6 @@
 use crate::cudf_reference::CuDFRef;
 use crate::{CuDFColumnView, CuDFError};
-use arrow::array::{Array, ArrayRef, RecordBatch, StructArray};
+use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
 use arrow::ffi::{from_ffi, FFI_ArrowArray};
 use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::{ArrowError, Schema, SchemaRef};
@@ -172,7 +172,15 @@ impl CuDFTableView {
         let array_data = unsafe { from_ffi(ffi_array, &ffi_schema)? };
         let struct_array = StructArray::from(array_data);
 
-        let batch = RecordBatch::try_new(schema, struct_array.columns().to_vec())?;
+        // Carry the row count explicitly so zero-column batches (e.g. produced by
+        // `FilterExec` with `projection=[]` for `COUNT(*) WHERE ...` plans) don't
+        // trip Arrow's "must either specify a row count or at least one column" check.
+        let options = RecordBatchOptions::new().with_row_count(Some(struct_array.len()));
+        let batch = RecordBatch::try_new_with_options(
+            schema,
+            struct_array.columns().to_vec(),
+            &options,
+        )?;
 
         Ok(batch)
     }
@@ -198,7 +206,12 @@ impl CuDFTableView {
             .map(|i| Arc::new(self.column(i as i32)) as _)
             .collect();
 
-        Ok(RecordBatch::try_new(Arc::new(self.schema()?), columns)?)
+        let options = RecordBatchOptions::new().with_row_count(Some(self.num_rows()));
+        Ok(RecordBatch::try_new_with_options(
+            Arc::new(self.schema()?),
+            columns,
+            &options,
+        )?)
     }
 
     /// Wrap GPU columns in a `RecordBatch` whose types match `schema`.
@@ -221,7 +234,7 @@ impl CuDFTableView {
         let columns: Vec<ArrayRef> = (0..self.num_columns())
             .map(|i| Arc::new(self.column(i as i32)) as _)
             .collect();
-        record_batch_with_schema(columns, schema).map_err(CuDFError::ArrowError)
+        record_batch_with_schema(columns, schema, self.num_rows()).map_err(CuDFError::ArrowError)
     }
 
     /// Create a table view from a RecordBatch containing CuDF arrays (GPU)
@@ -254,9 +267,13 @@ impl CuDFTableView {
 /// This function restores the declared precision so `RecordBatch::try_new` accepts it.
 /// All GPU `RecordBatch` creation should go through this function instead of calling
 /// `RecordBatch::try_new` directly.
+///
+/// `num_rows` is required so zero-column batches (e.g. produced by `FilterExec`
+/// with `projection=[]` for `COUNT(*) WHERE ...` plans) carry their row count.
 pub fn record_batch_with_schema(
     columns: Vec<ArrayRef>,
     schema: &SchemaRef,
+    num_rows: usize,
 ) -> Result<RecordBatch, ArrowError> {
     let relabeled: Vec<ArrayRef> = columns
         .into_iter()
@@ -270,7 +287,8 @@ pub fn record_batch_with_schema(
             col
         })
         .collect();
-    RecordBatch::try_new(Arc::clone(schema), relabeled)
+    let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+    RecordBatch::try_new_with_options(Arc::clone(schema), relabeled, &options)
 }
 
 impl Clone for CuDFTableView {


### PR DESCRIPTION
## Summary
- Fixes #39 — `Arrow error: Invalid argument error: must either specify a row count or at least one column` on the GPU path for plans where DataFusion produces a filter with `projection=[]` (e.g. `SELECT COUNT(*) FROM t WHERE ...`).
- Several `RecordBatch::try_new` callsites in `libcudf-rs` and `libcudf-datafusion` built batches without an explicit row count, which Arrow rejects when the column list is empty.
- Threads `num_rows` through every affected RecordBatch construction; all callers source it from data they already had (filter table view, projection input batch, aggregate running keys, concat'd batches).

### Affected sites
- `libcudf-rs::record_batch_with_schema` — signature now takes `num_rows: usize` and uses `try_new_with_options`. Internal API change; all in-tree callers updated.
- `CuDFTableView::to_arrow_host` and `to_record_batch` — switched to options-aware constructor.
- `CuDFLoadExec::cast_to_target_schema` — switched to options-aware constructor.
- `CuDFUnloadExec::execute` — switched to options-aware constructor.

## Test plan
- [x] `cargo test -p libcudf-rs` (135 tests, all pass)
- [x] `cargo test -p libcudf-datafusion` (43 tests, all pass)
- [x] `dfbench run --dataset clickbench_0-100 --query q1 --gpu --partitions 1 --batch-size 81920 --iterations 1` — previously failed every iteration; now returns 1 row in ~1.1 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)