### PR TITLE
[codex] Ignore generated DataFusion testdata

### DIFF
--- a/libcudf-datafusion/.gitignore
+++ b/libcudf-datafusion/.gitignore
@@ -1,1 +1,2 @@
 data/
+testdata/


### PR DESCRIPTION
## Summary

Adds `libcudf-datafusion/testdata/` to the crate-local `.gitignore` so generated TPC-H parquet data does not show up as untracked repository state after running correctness tests.

## Validation

- `git diff --check`
- `git check-ignore -v libcudf-datafusion/testdata/tpch/correctness_sf10/customer/1.parquet`
