### PR TITLE
Use data/ dir for tpch_pipeline benchmark

### DIFF
--- a/libcudf-datafusion/.gitignore
+++ b/libcudf-datafusion/.gitignore
@@ -1,2 +1,1 @@
 data/
-testdata/

--- a/libcudf-datafusion/benches/tpch_pipeline.rs
+++ b/libcudf-datafusion/benches/tpch_pipeline.rs
@@ -27,7 +27,7 @@
 //!
 //! ## Data
 //!
-//! TPC-H Parquet files from `testdata/tpch/correctness_sf{scale}/`.
+//! TPC-H Parquet files from `data/tpch/correctness_sf{scale}/`.
 //! The benchmark defaults to SF=1. Set `LIBCUDF_TPCH_SCALE_FACTOR` to run
 //! another generated scale factor:
 //!
@@ -77,7 +77,7 @@ fn tpch_scale_factor() -> String {
 
 fn tpch_data_dir(scale_factor: &str) -> PathBuf {
     let data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(format!("testdata/tpch/correctness_sf{scale_factor}"));
+        .join(format!("data/tpch/correctness_sf{scale_factor}"));
     if !data_dir.exists() {
         panic!(
             "TPC-H SF={scale_factor} data not found at {}",


### PR DESCRIPTION
## Summary
- Points the `tpch_pipeline` criterion bench at `data/tpch/correctness_sf{N}/` (where `gen-tpch.sh` and the integration tests already write) instead of the old `testdata/tpch/correctness_sf{N}/` location.
- Drops the now-unused `testdata/` entry from `libcudf-datafusion/.gitignore`.

## Test plan
- [x] `cargo build --release --bench tpch_pipeline` compiles
- [x] `cargo bench -p libcudf-datafusion --bench tpch_pipeline` after running `gen-tpch.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)