### PR TITLE
[codex] enable benchmark GPU memory pools

### DIFF
--- a/libcudf-datafusion-benchmarks/src/run.rs
+++ b/libcudf-datafusion-benchmarks/src/run.rs
@@ -26,6 +26,7 @@ use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::*;
 use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
+use libcudf_datafusion::configure_default_pools;
 use libcudf_datafusion::{CuDFConfig, SessionStateBuilderExt};
 use libcudf_datafusion_benchmarks::datasets::{clickbench, register_tables, tpcds, tpch};
 use std::fs;
@@ -152,6 +153,10 @@ impl RunOpt {
     }
 
     async fn benchmark(&self) -> Result<BenchmarkRun> {
+        if self.gpu {
+            configure_default_pools();
+        }
+
         let mut state_builder = SessionStateBuilder::new()
             .with_default_features()
             .with_config(self.config()?);


### PR DESCRIPTION
## Summary

Enable the default libcudf/RMM memory pools for `dfbench run --gpu` and the GPU leg of `dfbench harness`.

This keeps CPU benchmark behavior unchanged, but makes GPU benchmark runs use the same pooled allocation path we expect for libcudf workloads instead of paying repeated CUDA allocation/free costs inside each query.

## Why

The profiled benchmark runs showed that unpooled GPU execution was dominated by CUDA allocation churn. Across the profiled TPC-H queries, Nsight showed hundreds of thousands of `cudaMalloc`/`cudaFree` runtime calls before pooling. After enabling pools, those calls collapse to a small number of setup/teardown calls per profiled subprocess.

## Benchmark Results

Both runs used:

```sh
target/release/dfbench harness \
  --dataset tpch_sf1 \
  --iterations 3 \
  --partitions 4 \
  --profile-query q1,q6,q10,q12,q15,q19,q21 \
  --run-id <run-id>
```

Artifacts are under:

- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/no_pool_profiled_20260505T172237Z/`
- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/pool_profiled_20260505T172627Z/`

Summary:

| Run | CPU total avg | GPU total avg | GPU speedup by total avg | Geomean speedup |
| --- | ---: | ---: | ---: | ---: |
| No pool | 4557.0 ms | 14449.5 ms | 0.32x | 0.37x |
| Pool | 4598.7 ms | 10076.8 ms | 0.46x | 0.50x |

GPU total average improved from `14449.5 ms` to `10076.8 ms`, about `43.4%` faster. CPU movement is noise from separate runs.

Largest GPU query improvements:

| Query | No pool GPU | Pool GPU | Improvement |
| --- | ---: | ---: | ---: |
| q6 | 971.5 ms | 546.1 ms | 77.9% faster |
| q12 | 1248.1 ms | 750.1 ms | 66.4% faster |
| q15 | 1009.8 ms | 618.3 ms | 63.3% faster |
| q19 | 2124.6 ms | 1317.9 ms | 61.2% faster |
| q14 | 502.2 ms | 328.0 ms | 53.1% faster |

All 22 TPC-H queries completed successfully in both harness runs.

## Profiling Notes

Across profiled queries `q1,q6,q10,q12,q15,q19,q21`, CUDA allocation/free runtime activity changed from:

| Run | cudaMalloc/cudaFree calls | Runtime in malloc/free |
| --- | ---: | ---: |
| No pool | 551,124 | 4554.4 ms |
| Pool | 172 | 33.3 ms |

That is a 99%+ reduction in both allocation/free call count and runtime overhead for the profiled query set.

Example from q19:

| Runtime function | No pool calls/time | Pool calls/time |
| --- | ---: | ---: |
| `cudaMalloc` | 83,169 / 494.6 ms | 1 / 0.2 ms |
| `cudaFree` | 83,169 / 463.7 ms | 1 / 0.4 ms |

After pooling, the dominant q19 runtime entries are no longer allocator churn. The expensive areas are `cudaMemcpyAsync`, stream synchronization, kernel launch volume, and a one-time `cudaHostAlloc` in the profiled subprocess. That points the next round of work toward reducing host/device movement, synchronization frequency, and tiny kernel/operator launch patterns rather than allocator setup.

## Validation

- `cargo fmt --all`
- `cargo check -p libcudf-datafusion-benchmarks`
- `cargo test -p libcudf-datafusion-benchmarks`
- `cargo build -p libcudf-datafusion-benchmarks --release`
- `git diff --check`
- Full `dfbench harness` runs with Nsight profiles before and after pooling
