### PR TITLE
Add GPU execution batch size benchmark override and fix batch sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 cargo run --example basic_usage
 ```
 
+### DataFusion Execution Batch Size
+
+For cuDF-backed DataFusion workloads, configure batch size through DataFusion's
+existing `execution.batch_size` setting. Start GPU runs at `65_536` rows and
+tune with benchmarks for the target workload and GPU:
+
+```rust
+use datafusion::execution::SessionStateBuilder;
+use datafusion::prelude::SessionConfig;
+use libcudf_datafusion::SessionStateBuilderExt;
+
+let config = SessionConfig::new().with_batch_size(65_536);
+let state = SessionStateBuilder::new()
+    .with_default_features()
+    .with_config(config)
+    .with_cudf_planner()
+    .build();
+```
+
+This is DataFusion's global execution batch size, not a cuDF-only operator
+limit. Some cuDF operators process one incoming `RecordBatch` at a time, while
+joins, full sorts, and aggregate chunks can materialize larger intermediate GPU
+tables.
+
 ## Architecture
 
 This project uses the `cxx` crate to provide safe interoperability between Rust and C++:

--- a/libcudf-datafusion-benchmarks/README.md
+++ b/libcudf-datafusion-benchmarks/README.md
@@ -106,7 +106,8 @@ That writes to:
 
 ## Harness Options
 
-Common options are forwarded to both CPU and GPU runs:
+Common options are forwarded to both CPU and GPU runs, except for execution
+batch size, which can be configured independently:
 
 ```bash
 target/release/dfbench harness \
@@ -119,11 +120,9 @@ target/release/dfbench harness \
 ```
 
 `--batch-size` sets DataFusion's `execution.batch_size`. The harness passes
-this value to both CPU and GPU runs. Use `--gpu-execution-batch-size` to
-override only the GPU run while leaving the CPU run at `--batch-size`, or at
-DataFusion's default when `--batch-size` is omitted. Use `65536` as the
-recommended starting point for GPU runs, then tune with benchmarks for the
-target workload and GPU.
+this value to the CPU run. GPU runs use `65536` by default; pass
+`--gpu-execution-batch-size` to override that value for the target workload and
+GPU.
 
 Capture physical plans for selected queries:
 

--- a/libcudf-datafusion-benchmarks/README.md
+++ b/libcudf-datafusion-benchmarks/README.md
@@ -118,6 +118,13 @@ target/release/dfbench harness \
   --warmup
 ```
 
+`--batch-size` sets DataFusion's `execution.batch_size`. The harness passes
+this value to both CPU and GPU runs. Use `--gpu-execution-batch-size` to
+override only the GPU run while leaving the CPU run at `--batch-size`, or at
+DataFusion's default when `--batch-size` is omitted. Use `65536` as the
+recommended starting point for GPU runs, then tune with benchmarks for the
+target workload and GPU.
+
 Capture physical plans for selected queries:
 
 ```bash

--- a/libcudf-datafusion-benchmarks/src/harness.rs
+++ b/libcudf-datafusion-benchmarks/src/harness.rs
@@ -8,6 +8,8 @@ use std::process::Command;
 use std::time::{Duration, SystemTime};
 use structopt::StructOpt;
 
+const DEFAULT_GPU_EXECUTION_BATCH_SIZE: usize = 65_536;
+
 /// Run paired CPU/GPU benchmarks and write a reproducible report.
 ///
 /// This is a thin harness around the existing `run` subcommand. It does not
@@ -31,11 +33,11 @@ pub struct HarnessOpt {
     #[structopt(short = "n", long = "partitions")]
     partitions: Option<usize>,
 
-    /// DataFusion execution batch size.
+    /// DataFusion execution batch size for the CPU run.
     #[structopt(short = "s", long = "batch-size")]
     batch_size: Option<usize>,
 
-    /// DataFusion execution batch size for the GPU run. Overrides `--batch-size`.
+    /// DataFusion execution batch size for the GPU run.
     #[structopt(long = "gpu-execution-batch-size")]
     gpu_execution_batch_size: Option<usize>,
 
@@ -262,7 +264,10 @@ impl HarnessOpt {
     }
 
     fn gpu_execution_batch_size(&self) -> Option<usize> {
-        self.gpu_execution_batch_size.or(self.batch_size)
+        Some(
+            self.gpu_execution_batch_size
+                .unwrap_or(DEFAULT_GPU_EXECUTION_BATCH_SIZE),
+        )
     }
 
     fn capture_plan_logs(&self, exe: &Path, run_dir: &Path) -> Result<()> {
@@ -790,7 +795,33 @@ mod tests {
             Some(Path::new("/tmp/gpu")),
             true,
         );
-        assert!(contains_arg_pair(&default_gpu_args, "--batch-size", "8192"));
+        assert!(contains_arg_pair(
+            &default_gpu_args,
+            "--batch-size",
+            "65536"
+        ));
+
+        let no_batch_opt = harness_opt(None, None);
+        let cpu_args = no_batch_opt.dfbench_run_args(
+            false,
+            no_batch_opt.cpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/cpu")),
+            true,
+        );
+        let gpu_args = no_batch_opt.dfbench_run_args(
+            true,
+            no_batch_opt.gpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/gpu")),
+            true,
+        );
+        assert!(!cpu_args.iter().any(|arg| arg == "--batch-size"));
+        assert!(contains_arg_pair(&gpu_args, "--batch-size", "65536"));
     }
 
     fn harness_opt(

--- a/libcudf-datafusion-benchmarks/src/harness.rs
+++ b/libcudf-datafusion-benchmarks/src/harness.rs
@@ -31,9 +31,13 @@ pub struct HarnessOpt {
     #[structopt(short = "n", long = "partitions")]
     partitions: Option<usize>,
 
-    /// DataFusion input batch size.
+    /// DataFusion execution batch size.
     #[structopt(short = "s", long = "batch-size")]
     batch_size: Option<usize>,
+
+    /// DataFusion execution batch size for the GPU run. Overrides `--batch-size`.
+    #[structopt(long = "gpu-execution-batch-size")]
+    gpu_execution_batch_size: Option<usize>,
 
     /// Run each query once before timed iterations.
     #[structopt(long)]
@@ -69,7 +73,8 @@ struct HarnessMetadata {
     queries: Vec<String>,
     iterations: usize,
     partitions: Option<usize>,
-    batch_size: Option<usize>,
+    cpu_execution_batch_size: Option<usize>,
+    gpu_execution_batch_size: Option<usize>,
     warmup: bool,
     plan_queries: Vec<String>,
     profile_queries: Vec<String>,
@@ -126,10 +131,26 @@ impl HarnessOpt {
         reset_dir(&cpu_dir)?;
         reset_dir(&gpu_dir)?;
 
-        let cpu_args =
-            self.dfbench_run_args(false, false, None, self.iterations, Some(&cpu_dir), true);
-        let gpu_args =
-            self.dfbench_run_args(true, false, None, self.iterations, Some(&gpu_dir), true);
+        let cpu_execution_batch_size = self.cpu_execution_batch_size();
+        let gpu_execution_batch_size = self.gpu_execution_batch_size();
+        let cpu_args = self.dfbench_run_args(
+            false,
+            cpu_execution_batch_size,
+            false,
+            None,
+            self.iterations,
+            Some(&cpu_dir),
+            true,
+        );
+        let gpu_args = self.dfbench_run_args(
+            true,
+            gpu_execution_batch_size,
+            false,
+            None,
+            self.iterations,
+            Some(&gpu_dir),
+            true,
+        );
 
         run_logged(&exe, &cpu_args, &logs_dir.join("cpu.log"))?;
 
@@ -144,7 +165,8 @@ impl HarnessOpt {
             queries: self.query.clone(),
             iterations: self.iterations,
             partitions: self.partitions,
-            batch_size: self.batch_size,
+            cpu_execution_batch_size,
+            gpu_execution_batch_size,
             warmup: self.warmup,
             plan_queries: self.plan_query.clone(),
             profile_queries: self.profile_query.clone(),
@@ -179,6 +201,7 @@ impl HarnessOpt {
     fn dfbench_run_args(
         &self,
         gpu: bool,
+        batch_size: Option<usize>,
         debug: bool,
         query: Option<&str>,
         iterations: usize,
@@ -197,7 +220,7 @@ impl HarnessOpt {
             args.push("--partitions".to_string());
             args.push(partitions.to_string());
         }
-        if let Some(batch_size) = self.batch_size {
+        if let Some(batch_size) = batch_size {
             args.push("--batch-size".to_string());
             args.push(batch_size.to_string());
         }
@@ -234,6 +257,14 @@ impl HarnessOpt {
         args
     }
 
+    fn cpu_execution_batch_size(&self) -> Option<usize> {
+        self.batch_size
+    }
+
+    fn gpu_execution_batch_size(&self) -> Option<usize> {
+        self.gpu_execution_batch_size.or(self.batch_size)
+    }
+
     fn capture_plan_logs(&self, exe: &Path, run_dir: &Path) -> Result<()> {
         if self.plan_query.is_empty() {
             return Ok(());
@@ -242,14 +273,30 @@ impl HarnessOpt {
         let plans_dir = run_dir.join("plans");
         fs::create_dir_all(&plans_dir)?;
         for query in &self.plan_query {
-            let cpu_args = self.dfbench_run_args(false, true, Some(query), 1, None, false);
+            let cpu_args = self.dfbench_run_args(
+                false,
+                self.cpu_execution_batch_size(),
+                true,
+                Some(query),
+                1,
+                None,
+                false,
+            );
             run_logged(
                 exe,
                 &cpu_args,
                 &plans_dir.join(format!("{query}_cpu_debug.log")),
             )?;
 
-            let gpu_args = self.dfbench_run_args(true, true, Some(query), 1, None, false);
+            let gpu_args = self.dfbench_run_args(
+                true,
+                self.gpu_execution_batch_size(),
+                true,
+                Some(query),
+                1,
+                None,
+                false,
+            );
             run_logged(
                 exe,
                 &gpu_args,
@@ -280,7 +327,15 @@ impl HarnessOpt {
                 profile_base.display().to_string(),
                 exe.display().to_string(),
             ];
-            args.extend(self.dfbench_run_args(true, false, Some(query), 1, None, false));
+            args.extend(self.dfbench_run_args(
+                true,
+                self.gpu_execution_batch_size(),
+                false,
+                Some(query),
+                1,
+                None,
+                false,
+            ));
             run_logged(
                 Path::new("nsys"),
                 &args,
@@ -344,7 +399,14 @@ fn write_report(run_dir: &Path, metadata: &HarnessMetadata) -> Result<()> {
     }
     report.push_str(&format!("- iterations: `{}`\n", metadata.iterations));
     report.push_str(&format!("- partitions: `{:?}`\n", metadata.partitions));
-    report.push_str(&format!("- batch size: `{:?}`\n", metadata.batch_size));
+    report.push_str(&format!(
+        "- cpu execution batch size: `{:?}`\n",
+        metadata.cpu_execution_batch_size
+    ));
+    report.push_str(&format!(
+        "- gpu execution batch size: `{:?}`\n",
+        metadata.gpu_execution_batch_size
+    ));
     report.push_str(&format!("- warmup: `{}`\n\n", metadata.warmup));
 
     report.push_str("## Commands\n\n");
@@ -690,5 +752,72 @@ mod tests {
         assert_eq!(dataset_path_component("tpch_sf1"), "tpch_sf1");
         assert_eq!(dataset_path_component("nested/tpch"), "nested_tpch");
         assert_eq!(dataset_path_component(r"nested\tpch"), "nested_tpch");
+    }
+
+    #[test]
+    fn gpu_execution_batch_size_overrides_shared_batch_size() {
+        let opt = harness_opt(Some(8192), Some(131072));
+
+        assert_eq!(opt.cpu_execution_batch_size(), Some(8192));
+        assert_eq!(opt.gpu_execution_batch_size(), Some(131072));
+    }
+
+    #[test]
+    fn gpu_execution_batch_size_defaults_to_shared_batch_size() {
+        let opt = harness_opt(Some(8192), None);
+
+        assert_eq!(opt.cpu_execution_batch_size(), Some(8192));
+        assert_eq!(opt.gpu_execution_batch_size(), Some(8192));
+    }
+
+    #[test]
+    fn run_args_use_gpu_execution_batch_size_override() {
+        let opt = harness_opt(Some(8192), Some(131072));
+
+        let cpu_args = opt.dfbench_run_args(
+            false,
+            opt.cpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/cpu")),
+            true,
+        );
+        let gpu_args = opt.dfbench_run_args(
+            true,
+            opt.gpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/gpu")),
+            true,
+        );
+
+        assert!(contains_arg_pair(&cpu_args, "--batch-size", "8192"));
+        assert!(contains_arg_pair(&gpu_args, "--batch-size", "131072"));
+    }
+
+    fn harness_opt(
+        batch_size: Option<usize>,
+        gpu_execution_batch_size: Option<usize>,
+    ) -> HarnessOpt {
+        HarnessOpt {
+            dataset: "tpch_sf1".to_string(),
+            query: Vec::new(),
+            iterations: 3,
+            partitions: Some(4),
+            batch_size,
+            gpu_execution_batch_size,
+            warmup: false,
+            output: PathBuf::from("/tmp/bench-results"),
+            run_id: None,
+            plan_query: Vec::new(),
+            profile_query: Vec::new(),
+        }
+    }
+
+    fn contains_arg_pair(args: &[String], key: &str, value: &str) -> bool {
+        args.windows(2)
+            .any(|pair| pair[0] == key && pair[1] == value)
     }
 }

--- a/libcudf-datafusion-benchmarks/src/harness.rs
+++ b/libcudf-datafusion-benchmarks/src/harness.rs
@@ -755,22 +755,6 @@ mod tests {
     }
 
     #[test]
-    fn gpu_execution_batch_size_overrides_shared_batch_size() {
-        let opt = harness_opt(Some(8192), Some(131072));
-
-        assert_eq!(opt.cpu_execution_batch_size(), Some(8192));
-        assert_eq!(opt.gpu_execution_batch_size(), Some(131072));
-    }
-
-    #[test]
-    fn gpu_execution_batch_size_defaults_to_shared_batch_size() {
-        let opt = harness_opt(Some(8192), None);
-
-        assert_eq!(opt.cpu_execution_batch_size(), Some(8192));
-        assert_eq!(opt.gpu_execution_batch_size(), Some(8192));
-    }
-
-    #[test]
     fn run_args_use_gpu_execution_batch_size_override() {
         let opt = harness_opt(Some(8192), Some(131072));
 
@@ -795,6 +779,18 @@ mod tests {
 
         assert!(contains_arg_pair(&cpu_args, "--batch-size", "8192"));
         assert!(contains_arg_pair(&gpu_args, "--batch-size", "131072"));
+
+        let default_opt = harness_opt(Some(8192), None);
+        let default_gpu_args = default_opt.dfbench_run_args(
+            true,
+            default_opt.gpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/gpu")),
+            true,
+        );
+        assert!(contains_arg_pair(&default_gpu_args, "--batch-size", "8192"));
     }
 
     fn harness_opt(

--- a/libcudf-datafusion/src/planner/config.rs
+++ b/libcudf-datafusion/src/planner/config.rs
@@ -5,8 +5,6 @@ extensions_options! {
     pub struct CuDFConfig {
         /// Enables CuDF optimizations.
         pub enable: bool, default = true
-        /// Batch size for moving data from CPU to GPU and vice-versa.
-        pub batch_size: usize, default = 8192 * 10
         /// Allocate record batches using pinned (page-locked) memory via `cudaMallocHost`
         /// instead of the default allocator for arrow arrays. Pinned-source `cudaMemcpyAsync`
         /// is fully asynchronous, allowing us to do H -> D copies much faster.

--- a/libcudf-datafusion/src/planner/session_state_builder_ext.rs
+++ b/libcudf-datafusion/src/planner/session_state_builder_ext.rs
@@ -6,13 +6,16 @@ use std::sync::Arc;
 
 /// Extension trait for [SessionStateBuilder].
 pub trait SessionStateBuilderExt {
+    /// Installs the cuDF physical optimizer rules.
     fn with_cudf_planner(self) -> Self;
 }
 
 impl SessionStateBuilderExt for SessionStateBuilder {
     fn with_cudf_planner(mut self) -> Self {
         let cfg = self.config().get_or_insert_default();
-        cfg.options_mut().extensions.insert(CuDFConfig::default());
+        if cfg.options().extensions.get::<CuDFConfig>().is_none() {
+            cfg.options_mut().extensions.insert(CuDFConfig::default());
+        }
 
         let target_partitions = cfg.options_mut().execution.target_partitions;
         // Assume only one GPU present, and therefore, force target_partitions == 1.


### PR DESCRIPTION
## Summary

- default harness GPU subprocesses to DataFusion `execution.batch_size = 65536`
- keep CPU harness behavior unchanged: `--batch-size` only applies to the CPU run when provided
- keep `--gpu-execution-batch-size` as the explicit GPU override for follow-up sweeps
- report CPU and GPU execution batch sizes separately in harness metadata/report output
- document production tuning as DataFusion's existing `SessionConfig::with_batch_size(65_536)`, not as a cuDF-specific batch-size config
- remove the unused `cudf.batch_size` field and preserve caller-provided `CuDFConfig` in `with_cudf_planner()`

## Why Change Batch Configuration

The old `cudf.batch_size` config field was misleading because no cuDF operator consumed it. The actual knob that changes batch shape is DataFusion's global `execution.batch_size`. That setting affects scan/coalescing behavior and determines the incoming `RecordBatch` sizes that many cuDF operators receive.

This PR keeps production behavior simple: applications should configure DataFusion directly:

```rust
let config = SessionConfig::new().with_batch_size(65_536);
```

The harness needs separate CPU and GPU batch handling because it runs CPU and GPU as separate subprocesses. CPU keeps DataFusion's default unless `--batch-size` is passed. GPU now defaults to the benchmarked recommended size, `65536`, and can still be changed with `--gpu-execution-batch-size` for sweeps.

Examples:

```text
# CPU: DataFusion default, GPU: 65536
target/release/dfbench harness --dataset tpch_sf1

# CPU: 8192, GPU: 65536
target/release/dfbench harness --dataset tpch_sf1 --batch-size 8192

# CPU: 8192, GPU: explicit override
target/release/dfbench harness --dataset tpch_sf1 --batch-size 8192 --gpu-execution-batch-size 131072
```

## TPC-H SF1 CPU vs GPU Runtime

Environment:

- GPU: Tesla T4, 15 GiB
- Dataset: `tpch_sf1`
- Iterations: 3
- Partitions: 4
- Baseline: main-style shared harness batch size, CPU/GPU `execution.batch_size = 8192`
- Candidate: this PR's GPU default/recommended value, CPU `execution.batch_size = 8192`, GPU `execution.batch_size = 65536`

Total average runtime across all 22 TPC-H SF1 queries:

| Configuration | CPU total avg | GPU total avg | GPU vs CPU | GPU change vs main-style |
|---|---:|---:|---:|---:|
| Main-style shared `8192` | 5034.6 ms | 10376.3 ms | 0.49x | baseline |
| PR GPU default `65536` | 4602.4 ms | 5931.3 ms | 0.78x | 1.75x faster / 42.8% lower |

The GPU path is still slower than CPU overall at SF1, but the larger GPU execution batch size closes a large part of the gap. It also moves more queries into the GPU-faster column: 7 of 22 queries are faster than CPU in the `65536` run.

Largest per-query GPU improvements from main-style `8192` to `65536`:

| Query | GPU 8192 ms | GPU 65536 ms | Speedup |
|---:|---:|---:|---:|
| q6 | 528.9 | 170.5 | 3.10x |
| q12 | 706.5 | 260.6 | 2.71x |
| q19 | 1409.9 | 524.6 | 2.69x |
| q20 | 477.9 | 177.5 | 2.69x |
| q14 | 333.3 | 145.3 | 2.29x |
| q1 | 1001.7 | 544.4 | 1.84x |

Local artifact paths:

- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/batch8192_sf1_profile_q1_pr/report.md`
- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/batch65536_sf1_profile_q1_pr/report.md`

These artifacts are ignored and are not committed.

## Nsight q1 Profile Comparison

Compared `q1` profiles from the same two runs:

| Metric | 8192 | 65536 | Change |
|---|---:|---:|---:|
| Runtime API calls | 110459 | 15147 | -86.3% |
| Runtime API time | 937.0 ms | 705.5 ms | -24.7% |
| Memcpy API calls | 24394 | 3142 | -87.1% |
| Memcpy API time | 143.3 ms | 30.6 ms | -78.7% |
| Kernel launch calls | 13361 | 1769 | -86.8% |
| Kernel launch API time | 194.1 ms | 101.9 ms | -47.5% |
| Memcpy activity bytes | 492.18 MiB | 491.63 MiB | -0.1% |

Interpretation: the larger execution batch moves essentially the same bytes, but it does so with far fewer transfers, kernel launches, and runtime API calls.

Profile comparison artifact:

- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/comparisons/batch8192_sf1_profile_q1_pr__batch65536_sf1_profile_q1_pr/profile-compare.md`

## Separate Follow-Up

SF10 OOM behavior is tracked separately in #50. This PR intentionally does not change the RMM pool cap or attempt to solve join/materialization peak memory.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p libcudf-datafusion-benchmarks`
- `cargo test -p libcudf-datafusion --lib`
- `cargo run -p libcudf-datafusion-benchmarks -- harness --help | rg -n "batch-size|gpu-execution"`
- `target/release/dfbench harness --dataset tpch_sf1 --iterations 3 --partitions 4 --batch-size 8192 --profile-query q1 --run-id batch8192_sf1_profile_q1_pr`
- `target/release/dfbench harness --dataset tpch_sf1 --iterations 3 --partitions 4 --batch-size 8192 --gpu-execution-batch-size 65536 --profile-query q1 --run-id batch65536_sf1_profile_q1_pr`
- `target/release/dfbench profile-compare --dataset tpch_sf1 --baseline-run-id batch8192_sf1_profile_q1_pr --candidate-run-id batch65536_sf1_profile_q1_pr --query q1 --top 8`
