### PR TITLE
[codex] Chunk cuDF aggregates by input bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 cargo run --example basic_usage
 ```
 
-### DataFusion Execution Batch Size
+### DataFusion GPU Sizing
 
 For cuDF-backed DataFusion workloads, configure batch size through DataFusion's
 existing `execution.batch_size` setting. Start GPU runs at `65_536` rows and
@@ -104,6 +104,17 @@ This is DataFusion's global execution batch size, not a cuDF-only operator
 limit. Some cuDF operators process one incoming `RecordBatch` at a time, while
 joins, full sorts, and aggregate chunks can materialize larger intermediate GPU
 tables.
+
+cuDF aggregate chunks are bounded by input bytes, not row count. The default
+target is derived from the configured device pool cap:
+
+```text
+clamp(cudf.device_pool_max_bytes / 16, 64 MiB, 1 GiB)
+```
+
+With the default 4 GiB device pool cap, this gives a 256 MiB aggregate chunk
+target. Set `cudf.aggregate_chunk_target_bytes` only when you need an explicit
+override for benchmarking or deployment tuning.
 
 ## Architecture
 

--- a/libcudf-datafusion-benchmarks/README.md
+++ b/libcudf-datafusion-benchmarks/README.md
@@ -124,6 +124,12 @@ this value to the CPU run. GPU runs use `65536` by default; pass
 `--gpu-execution-batch-size` to override that value for the target workload and
 GPU.
 
+`--cudf-device-pool-max-bytes` sets the RMM device-memory pool cap for GPU
+runs. cuDF aggregate chunks derive their default target from that cap:
+`clamp(pool_max / 16, 64 MiB, 1 GiB)`. Use
+`--cudf-aggregate-chunk-target-bytes` only when testing an explicit aggregate
+chunk budget.
+
 Capture physical plans for selected queries:
 
 ```bash

--- a/libcudf-datafusion-benchmarks/src/harness.rs
+++ b/libcudf-datafusion-benchmarks/src/harness.rs
@@ -41,6 +41,14 @@ pub struct HarnessOpt {
     #[structopt(long = "gpu-execution-batch-size")]
     gpu_execution_batch_size: Option<usize>,
 
+    /// Target input bytes accumulated by each cuDF aggregate chunk before flushing.
+    #[structopt(long = "cudf-aggregate-chunk-target-bytes")]
+    aggregate_chunk_target_bytes: Option<usize>,
+
+    /// Maximum RMM device-memory pool size for GPU runs.
+    #[structopt(long = "cudf-device-pool-max-bytes")]
+    device_pool_max_bytes: Option<usize>,
+
     /// Run each query once before timed iterations.
     #[structopt(long)]
     warmup: bool,
@@ -77,6 +85,8 @@ struct HarnessMetadata {
     partitions: Option<usize>,
     cpu_execution_batch_size: Option<usize>,
     gpu_execution_batch_size: Option<usize>,
+    device_pool_max_bytes: Option<usize>,
+    aggregate_chunk_target_bytes: Option<usize>,
     warmup: bool,
     plan_queries: Vec<String>,
     profile_queries: Vec<String>,
@@ -169,6 +179,8 @@ impl HarnessOpt {
             partitions: self.partitions,
             cpu_execution_batch_size,
             gpu_execution_batch_size,
+            device_pool_max_bytes: self.device_pool_max_bytes,
+            aggregate_chunk_target_bytes: self.aggregate_chunk_target_bytes,
             warmup: self.warmup,
             plan_queries: self.plan_query.clone(),
             profile_queries: self.profile_query.clone(),
@@ -231,6 +243,14 @@ impl HarnessOpt {
         }
         if gpu {
             args.push("--gpu".to_string());
+            if let Some(bytes) = self.device_pool_max_bytes {
+                args.push("--cudf-device-pool-max-bytes".to_string());
+                args.push(bytes.to_string());
+            }
+            if let Some(bytes) = self.aggregate_chunk_target_bytes {
+                args.push("--cudf-aggregate-chunk-target-bytes".to_string());
+                args.push(bytes.to_string());
+            }
         }
         if debug {
             args.push("--debug".to_string());
@@ -411,6 +431,14 @@ fn write_report(run_dir: &Path, metadata: &HarnessMetadata) -> Result<()> {
     report.push_str(&format!(
         "- gpu execution batch size: `{:?}`\n",
         metadata.gpu_execution_batch_size
+    ));
+    report.push_str(&format!(
+        "- cuDF device pool max bytes: `{:?}`\n",
+        metadata.device_pool_max_bytes
+    ));
+    report.push_str(&format!(
+        "- cuDF aggregate chunk target bytes: `{:?}`\n",
+        metadata.aggregate_chunk_target_bytes
     ));
     report.push_str(&format!("- warmup: `{}`\n\n", metadata.warmup));
 
@@ -835,6 +863,8 @@ mod tests {
             partitions: Some(4),
             batch_size,
             gpu_execution_batch_size,
+            device_pool_max_bytes: None,
+            aggregate_chunk_target_bytes: None,
             warmup: false,
             output: PathBuf::from("/tmp/bench-results"),
             run_id: None,

--- a/libcudf-datafusion-benchmarks/src/run.rs
+++ b/libcudf-datafusion-benchmarks/src/run.rs
@@ -26,8 +26,7 @@ use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::*;
 use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-use libcudf_datafusion::configure_default_pools;
-use libcudf_datafusion::{CuDFConfig, SessionStateBuilderExt};
+use libcudf_datafusion::{CuDFConfig, DevicePoolConfig, PinnedPoolConfig, SessionStateBuilderExt};
 use libcudf_datafusion_benchmarks::datasets::{clickbench, register_tables, tpcds, tpch};
 use std::fs;
 use std::path::PathBuf;
@@ -61,6 +60,14 @@ pub struct RunOpt {
     /// Batch size when reading CSV or Parquet files
     #[structopt(short = "s", long = "batch-size")]
     batch_size: Option<usize>,
+
+    /// Target input bytes accumulated by each cuDF aggregate chunk before flushing.
+    #[structopt(long = "cudf-aggregate-chunk-target-bytes")]
+    aggregate_chunk_target_bytes: Option<usize>,
+
+    /// Maximum RMM device-memory pool size for GPU runs.
+    #[structopt(long = "cudf-device-pool-max-bytes")]
+    device_pool_max_bytes: Option<usize>,
 
     /// Activate debug mode to see more details
     #[structopt(short, long)]
@@ -120,9 +127,33 @@ impl RunOpt {
         if self.gpu {
             let mut cudf_config = CuDFConfig::default();
             cudf_config.enable = true;
+            if let Some(bytes) = self.aggregate_chunk_target_bytes {
+                cudf_config.aggregate_chunk_target_bytes = Some(bytes);
+            }
+            if let Some(bytes) = self.device_pool_max_bytes {
+                cudf_config.device_pool_max_bytes = Some(bytes);
+            }
             config = config.with_option_extension(cudf_config);
         }
         Ok(config)
+    }
+
+    fn device_pool_config(&self) -> Result<DevicePoolConfig> {
+        let mut config = DevicePoolConfig::default();
+        if let Some(max_size) = self.device_pool_max_bytes {
+            if max_size == 0 {
+                return exec_err!("--cudf-device-pool-max-bytes must be greater than zero");
+            }
+            config.max_size = max_size;
+            config.initial_size = config.initial_size.min(max_size);
+        }
+        Ok(config)
+    }
+
+    fn configure_gpu_pools(&self) -> Result<()> {
+        PinnedPoolConfig::default().apply();
+        self.device_pool_config()?.apply();
+        Ok(())
     }
 
     pub fn run(self) -> Result<()> {
@@ -154,7 +185,7 @@ impl RunOpt {
 
     async fn benchmark(&self) -> Result<BenchmarkRun> {
         if self.gpu {
-            configure_default_pools();
+            self.configure_gpu_pools()?;
         }
 
         let mut state_builder = SessionStateBuilder::new()

--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -1,4 +1,5 @@
 use crate::expr::expr_to_cudf_expr;
+use crate::planner::CuDFConfig;
 use arrow_schema::{DataType, Schema, SchemaRef};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -193,8 +194,22 @@ impl ExecutionPlan for CuDFAggregateExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        let aggregate_chunk_target_bytes = context
+            .session_config()
+            .options()
+            .extensions
+            .get::<CuDFConfig>()
+            .map_or_else(
+                || CuDFConfig::default().resolved_aggregate_chunk_target_bytes(),
+                CuDFConfig::resolved_aggregate_chunk_target_bytes,
+            );
         let input = self.input.execute(partition, context)?;
-        let stream = stream::Stream::new(input, self.schema(), self.prepared.clone())?;
+        let stream = stream::Stream::new(
+            input,
+            self.schema(),
+            self.prepared.clone(),
+            aggregate_chunk_target_bytes,
+        )?;
         Ok(Box::pin(stream))
     }
 }
@@ -333,12 +348,16 @@ mod test {
     use crate::aggregate::CuDFAggregateExec;
     use crate::assert_snapshot;
     use crate::physical::{CuDFLoadExec, CuDFUnloadExec};
-    use arrow::array::record_batch;
+    use crate::CuDFConfig;
+    use arrow::array::{record_batch, Array, Int64Array, StringArray, StringViewArray};
+    use arrow::record_batch::RecordBatch;
     use arrow::util::pretty::pretty_format_batches;
     use arrow_schema::SchemaRef;
     use datafusion::common::ScalarValue;
+    use datafusion::execution::runtime_env::RuntimeEnv;
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
+    use datafusion::prelude::SessionConfig;
     use datafusion_expr::AggregateUDF;
     use datafusion_physical_plan::aggregates::{AggregateMode, PhysicalGroupBy};
     use datafusion_physical_plan::expressions::{col, Literal};
@@ -346,20 +365,33 @@ mod test {
     use datafusion_physical_plan::ExecutionPlan;
     use datafusion_physical_plan::PhysicalExpr;
     use futures_util::TryStreamExt;
+    use std::collections::HashMap;
     use std::error::Error;
     use std::sync::Arc;
 
-    /// Run a GROUP BY aggregation through the full GPU pipeline:
-    /// TestMemoryExec -> CuDFLoadExec -> CuDFAggregateExec -> CuDFUnloadExec.
-    ///
-    /// Sends 3 identical batches (to exercise cross-batch rolling merge) and
-    /// groups by column "c". `build_args` receives the batch schema and returns
-    /// the argument expressions for the aggregate function.
     async fn run_group_by_test(
         agg_fn: Arc<AggregateUDF>,
         build_args: impl FnOnce(&SchemaRef) -> datafusion::error::Result<Vec<Arc<dyn PhysicalExpr>>>,
         agg_alias: &str,
     ) -> Result<String, Box<dyn Error>> {
+        let batches = collect_group_by_test(
+            agg_fn,
+            build_args,
+            agg_alias,
+            Arc::new(TaskContext::default()),
+        )
+        .await?;
+
+        let output = pretty_format_batches(&batches)?.to_string();
+        Ok(output)
+    }
+
+    async fn collect_group_by_test(
+        agg_fn: Arc<AggregateUDF>,
+        build_args: impl FnOnce(&SchemaRef) -> datafusion::error::Result<Vec<Arc<dyn PhysicalExpr>>>,
+        agg_alias: &str,
+        task: Arc<TaskContext>,
+    ) -> Result<Vec<RecordBatch>, Box<dyn Error>> {
         let batch = record_batch!(
             ("a", Int64, [1, 4, 3]),
             ("b", Float64, [Some(4.0), None, Some(5.0)]),
@@ -393,13 +425,10 @@ mod test {
 
         let unload = CuDFUnloadExec::new(Arc::new(aggregate));
 
-        let task = Arc::new(TaskContext::default());
-
         let result = unload.execute(0, task)?;
         let batches = result.try_collect::<Vec<_>>().await?;
 
-        let output = pretty_format_batches(&batches)?.to_string();
-        Ok(output)
+        Ok(batches)
     }
 
     #[tokio::test]
@@ -415,6 +444,26 @@ mod test {
         | hello | 15     |
         +-------+--------+
         ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_group_by_sum_with_tiny_aggregate_chunk() -> Result<(), Box<dyn Error>> {
+        let batches = collect_group_by_test(
+            sum(),
+            |s| Ok(vec![col("a", s)?]),
+            "SUM(a)",
+            task_ctx_with_aggregate_chunk_target_bytes(1),
+        )
+        .await?;
+
+        let mut rows = grouped_i64_rows(&batches);
+        rows.sort();
+        assert_eq!(
+            rows,
+            vec![("hello".to_string(), 15), ("world".to_string(), 9)]
+        );
 
         Ok(())
     }
@@ -499,6 +548,46 @@ mod test {
         ");
 
         Ok(())
+    }
+
+    fn task_ctx_with_aggregate_chunk_target_bytes(bytes: usize) -> Arc<TaskContext> {
+        let mut cudf_config = CuDFConfig::default();
+        cudf_config.aggregate_chunk_target_bytes = Some(bytes);
+        let session_config = SessionConfig::new().with_option_extension(cudf_config);
+
+        Arc::new(TaskContext::new(
+            None,
+            "aggregate-test".to_string(),
+            session_config,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            Arc::new(RuntimeEnv::default()),
+        ))
+    }
+
+    fn grouped_i64_rows(batches: &[RecordBatch]) -> Vec<(String, i64)> {
+        assert_eq!(batches.len(), 1, "expected one aggregate output batch");
+        let batch = &batches[0];
+        let sums = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("expected int64 sums");
+
+        (0..batch.num_rows())
+            .map(|i| (string_value(batch.column(0).as_ref(), i), sums.value(i)))
+            .collect()
+    }
+
+    fn string_value(array: &dyn Array, row: usize) -> String {
+        if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+            return array.value(row).to_string();
+        }
+        if let Some(array) = array.as_any().downcast_ref::<StringViewArray>() {
+            return array.value(row).to_string();
+        }
+        panic!("expected string group keys, got {}", array.data_type());
     }
 }
 

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -15,9 +15,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-/// Number of input batches to accumulate before running a single aggregate and merge cycle.
-const AGGREGATE_CHUNK_BATCHES: usize = 1024;
-
 enum StreamState {
     ReadingInput,
     ProducingOutput,
@@ -45,10 +42,10 @@ struct RunningState {
 /// GPU-accelerated GROUP BY aggregation stream using chunked aggregation.
 ///
 /// Input batches are accumulated into a pending buffer. Once the buffer reaches
-/// `AGGREGATE_CHUNK_BATCHES` batches (or input is exhausted), all pending batches
-/// are concatenated on the GPU into a single table and aggregated in one kernel call.
-/// The result (at most G rows, where G is the group cardinality) is merged into the
-/// running state using the standard partial-state merge.
+/// the configured byte budget (or input is exhausted), pending batches are
+/// concatenated on the GPU into a single table and aggregated in one kernel
+/// call. The result (at most G rows, where G is the group cardinality) is merged
+/// into the running state using the standard partial-state merge.
 ///
 /// After all input is consumed, a single output batch is produced by either
 /// finalizing the state (Single/Final modes) or emitting raw state columns
@@ -63,6 +60,10 @@ pub struct Stream {
     state: StreamState,
     /// Batches accumulated since the last flush, cleared on each flush.
     pending_batches: Vec<RecordBatch>,
+    /// Estimated GPU memory held by `pending_batches`.
+    pending_bytes: usize,
+    /// Target input bytes accumulated before running an aggregate/merge cycle.
+    chunk_target_bytes: usize,
     /// Aggregated running state (at most G rows), updated after each flush.
     running: Option<RunningState>,
 }
@@ -72,6 +73,7 @@ impl Stream {
         input: SendableRecordBatchStream,
         output_schema: SchemaRef,
         prepared: PreparedCuDFAggregate,
+        chunk_target_bytes: usize,
     ) -> Result<Self> {
         let aggregate_args = prepared
             .aggs
@@ -102,6 +104,8 @@ impl Stream {
             column_mapping,
             state: StreamState::ReadingInput,
             pending_batches: Vec::new(),
+            pending_bytes: 0,
+            chunk_target_bytes: chunk_target_bytes.max(1),
             running: None,
         })
     }
@@ -117,6 +121,7 @@ impl Stream {
 
         let chunk = concat_cudf_batches(&self.pending_batches)?;
         self.pending_batches.clear();
+        self.pending_bytes = 0;
 
         let group_by = self.evaluate_batch_groups(&chunk)?;
         let evaluated_args = self.evaluate_batch_arguments(&chunk)?;
@@ -379,8 +384,11 @@ impl futures::Stream for Stream {
                     }
                     Some(Err(e)) => return Poll::Ready(Some(Err(e))),
                     Some(Ok(batch)) => {
+                        self.pending_bytes = self
+                            .pending_bytes
+                            .saturating_add(batch.get_array_memory_size());
                         self.pending_batches.push(batch);
-                        if self.pending_batches.len() >= AGGREGATE_CHUNK_BATCHES {
+                        if self.pending_bytes >= self.chunk_target_bytes {
                             self.flush_pending()?;
                         }
                     }

--- a/libcudf-datafusion/src/planner/config.rs
+++ b/libcudf-datafusion/src/planner/config.rs
@@ -1,5 +1,10 @@
 use datafusion::common::{extensions_options, plan_err, DataFusionError};
 use datafusion::config::{ConfigExtension, ConfigOptions};
+use libcudf_rs::DevicePoolConfig;
+
+const AGGREGATE_CHUNK_POOL_FRACTION: usize = 16;
+const MIN_AGGREGATE_CHUNK_TARGET_BYTES: usize = 64 * 1024 * 1024;
+const MAX_AGGREGATE_CHUNK_TARGET_BYTES: usize = 1024 * 1024 * 1024;
 
 extensions_options! {
     pub struct CuDFConfig {
@@ -9,6 +14,10 @@ extensions_options! {
         /// instead of the default allocator for arrow arrays. Pinned-source `cudaMemcpyAsync`
         /// is fully asynchronous, allowing us to do H -> D copies much faster.
         pub pinned_input: bool, default = true
+        /// Configured RMM device-memory pool cap used to derive operator memory budgets.
+        pub device_pool_max_bytes: Option<usize>, default = None
+        /// Target input bytes accumulated by each cuDF aggregate chunk before flushing.
+        pub aggregate_chunk_target_bytes: Option<usize>, default = None
     }
 }
 
@@ -17,6 +26,27 @@ impl ConfigExtension for CuDFConfig {
 }
 
 impl CuDFConfig {
+    /// Derive the default cuDF aggregate input chunk budget from a device-pool cap.
+    pub fn derive_aggregate_chunk_target_bytes(device_pool_max_bytes: usize) -> usize {
+        (device_pool_max_bytes / AGGREGATE_CHUNK_POOL_FRACTION).clamp(
+            MIN_AGGREGATE_CHUNK_TARGET_BYTES,
+            MAX_AGGREGATE_CHUNK_TARGET_BYTES,
+        )
+    }
+
+    /// Resolve the configured device-pool cap, falling back to the default pool config.
+    pub fn resolved_device_pool_max_bytes(&self) -> usize {
+        self.device_pool_max_bytes
+            .unwrap_or_else(|| DevicePoolConfig::default().max_size)
+    }
+
+    /// Resolve the cuDF aggregate input chunk budget.
+    pub fn resolved_aggregate_chunk_target_bytes(&self) -> usize {
+        self.aggregate_chunk_target_bytes.unwrap_or_else(|| {
+            Self::derive_aggregate_chunk_target_bytes(self.resolved_device_pool_max_bytes())
+        })
+    }
+
     /// Gets the [CuDFConfig] from the [ConfigOptions]'s extensions.
     pub fn from_config_options(cfg: &ConfigOptions) -> Result<&Self, DataFusionError> {
         let Some(distributed_cfg) = cfg.extensions.get::<CuDFConfig>() else {
@@ -31,5 +61,43 @@ impl CuDFConfig {
             return plan_err!("CuDFConfig is not in ConfigOptions.extensions");
         };
         Ok(distributed_cfg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CuDFConfig;
+
+    #[test]
+    fn aggregate_chunk_target_resolves_from_override_or_pool_cap() {
+        assert_eq!(
+            CuDFConfig::default().resolved_aggregate_chunk_target_bytes(),
+            256 * 1024 * 1024
+        );
+        assert_eq!(
+            CuDFConfig::derive_aggregate_chunk_target_bytes(4 * 1024 * 1024 * 1024),
+            256 * 1024 * 1024
+        );
+        assert_eq!(
+            CuDFConfig {
+                device_pool_max_bytes: Some(12 * 1024 * 1024 * 1024),
+                ..Default::default()
+            }
+            .resolved_aggregate_chunk_target_bytes(),
+            768 * 1024 * 1024,
+        );
+        assert_eq!(
+            CuDFConfig::derive_aggregate_chunk_target_bytes(128 * 1024 * 1024 * 1024),
+            1024 * 1024 * 1024
+        );
+        assert_eq!(
+            CuDFConfig {
+                device_pool_max_bytes: Some(12 * 1024 * 1024 * 1024),
+                aggregate_chunk_target_bytes: Some(1234),
+                ..Default::default()
+            }
+            .resolved_aggregate_chunk_target_bytes(),
+            1234,
+        );
     }
 }

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -12,6 +12,9 @@
 #include <cudf/interop.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <memory>
 #include <nanoarrow/nanoarrow.h>
@@ -96,17 +99,18 @@ namespace libcudf_bridge {
 
     // Helper functions for memory size calculations
     size_t calculate_buffer_memory_size(const cudf::column_view& view) {
-        // Calculate size based on data type
-        size_t data_size = cudf::size_of(view.type()) * view.size();
-
-        // For strings add offset buffer size
-        if (view.type().id() == cudf::type_id::STRING) {
-            data_size += (view.size() + 1) * sizeof(int32_t);
-        }
-
-        // For nested types recursively add child buffer sizes
-        for (cudf::size_type i = 0; i < view.num_children(); ++i) {
-            data_size += calculate_buffer_memory_size(view.child(i));
+        size_t data_size = 0;
+        if (cudf::is_fixed_width(view.type())) {
+            data_size = cudf::size_of(view.type()) * view.size();
+        } else if (view.type().id() == cudf::type_id::STRING) {
+            auto const strings = cudf::strings_column_view(view);
+            data_size = ((view.size() + 1) * sizeof(cudf::size_type)) +
+                        static_cast<size_t>(strings.chars_size(cudf::get_default_stream()));
+        } else {
+            // For nested types recursively add child buffer sizes.
+            for (cudf::size_type i = 0; i < view.num_children(); ++i) {
+                data_size += calculate_buffer_memory_size(view.child(i));
+            }
         }
 
         return data_size;

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -242,7 +242,7 @@ unsafe impl Array for CuDFColumnView {
 mod tests {
     use super::*;
     use crate::CuDFColumn;
-    use arrow::array::Int32Array;
+    use arrow::array::{Int32Array, StringArray};
 
     #[test]
     fn test_column_view_clone() -> Result<(), Box<dyn std::error::Error>> {
@@ -262,6 +262,19 @@ mod tests {
             original_ptr, cloned_ptr,
             "Cloned view should point to the same GPU memory"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_column_view_memory_size() -> Result<(), Box<dyn std::error::Error>> {
+        let array = StringArray::from(vec!["hello", "world", ""]);
+        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+
+        let size = column.get_array_memory_size();
+        let min_offsets_and_chars =
+            (array.len() + 1) * std::mem::size_of::<i32>() + array.value_data().len();
+        assert!(size >= min_offsets_and_chars);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This PR changes cuDF DataFusion aggregate execution to flush aggregate chunks by estimated input bytes instead of by a fixed batch count. The default aggregate chunk target is derived from the configured RMM device pool cap:

```text
clamp(cudf.device_pool_max_bytes / 16, 64 MiB, 1 GiB)
```

With the default 4 GiB device pool cap, this yields a 256 MiB aggregate chunk target. The benchmark runner and harness now expose `--cudf-device-pool-max-bytes` and `--cudf-aggregate-chunk-target-bytes` so the behavior can be reproduced and tuned explicitly.

This also fixes string column memory sizing in the cuDF bridge. The aggregate chunk threshold uses Arrow's `get_array_memory_size()`, and the old string sizing path called `cudf::size_of(STRING)`, which aborts for non-fixed-width types. String columns are now sized from offsets plus chars.

## Why

SF10 TPC-H q1 was failing even though it has no joins. The aggregate operator buffered too much input before flushing, then hit the 4 GiB RMM pool cap while concatenating/aggregating the chunk.

The previous fixed `1024` batch threshold did not adapt to pool size, row width, string payloads, or deployment memory limits. Deriving the default from the configured device pool gives the operator a bounded memory budget while preserving an explicit override for benchmarking and deployment tuning.

## Validation

Tests and checks run:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p libcudf-rs column_view::tests::test_string_column_view_memory_size`
- `cargo test -p libcudf-datafusion aggregate_chunk_target_resolves_from_override_or_pool_cap`
- `cargo test -p libcudf-datafusion aggregate::` - 21 passed
- `cargo test -p libcudf-datafusion-benchmarks` - 8 passed
- `cargo build -p libcudf-datafusion-benchmarks --release`

Benchmark validation:

| Dataset/query | Mode | Result | Sampled peak GPU memory |
| --- | --- | --- | --- |
| SF10 q1 | old behavior, forced huge aggregate chunk target | OOM at 4 GiB pool cap | 4181 MiB |
| SF10 q1 | new default derived chunk target | completed in 4914.8 ms, 4 rows | 2421 MiB |

Regression timing check where both paths complete:

| Dataset/query | Mode | Avg time |
| --- | --- | --- |
| SF1 q1 | old behavior, forced huge aggregate chunk target | 540 ms |
| SF1 q1 | new default derived chunk target | 438 ms |

## Notes

The tiny aggregate chunk regression asserts grouped values without depending on cuDF group output order. The normal aggregate tests still use snapshots for output shape.
