### PR TITLE
Improve CuDFLoadExec

### DIFF
--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -1,11 +1,11 @@
 use crate::aggregate::PreparedCuDFAggregate;
 use crate::errors::cudf_to_df;
+use crate::metrics::CuDFBaselineMetrics;
 use arrow::array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::SchemaRef;
 use datafusion::common::{exec_err, internal_err};
 use datafusion::error::Result;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream};
-use crate::metrics::CuDFBaselineMetrics;
 use datafusion::physical_expr_common::metrics::{
     ExecutionPlanMetricsSet, MetricBuilder, MetricType, RatioMetrics, Time,
 };
@@ -52,8 +52,7 @@ impl GroupByMetrics {
                 .subset_time("aggregate_arguments_time", partition),
             aggregation_time: MetricBuilder::new(metrics)
                 .subset_time("aggregation_time", partition),
-            emitting_time: MetricBuilder::new(metrics)
-                .subset_time("emitting_time", partition),
+            emitting_time: MetricBuilder::new(metrics).subset_time("emitting_time", partition),
         }
     }
 }

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -3,14 +3,20 @@ use crate::metrics::CuDFBaselineMetrics;
 use crate::planner::CuDFConfig;
 use arrow::array::{Array, RecordBatch, RecordBatchOptions};
 use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema, SchemaRef};
-use datafusion::common::{exec_err, plan_err, ScalarValue};
+use datafusion::common::runtime::SpawnedTask;
+use datafusion::common::{assert_eq_or_internal_err, exec_err, plan_err, ScalarValue};
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_expr_common::metrics::MetricsSet;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
-use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_physical_plan::stream::{
+    RecordBatchReceiverStream, RecordBatchReceiverStreamBuilder,
+};
+use datafusion_physical_plan::{
+    internal_err, DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties,
+    PlanProperties,
+};
 use futures_util::stream::StreamExt;
 use libcudf_rs::{is_cudf_array, pin_record_batch, synchronize_default_stream, CuDFTable};
 use std::any::Any;
@@ -29,7 +35,7 @@ impl CuDFLoadExec {
     pub fn try_new(input: Arc<dyn ExecutionPlan>) -> Result<Self, DataFusionError> {
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(cudf_schema_compatibility_map(input.schema())),
-            input.properties().partitioning.clone(),
+            Partitioning::UnknownPartitioning(1),
             input.properties().emission_type,
             input.properties().boundedness,
         ));
@@ -83,70 +89,127 @@ impl ExecutionPlan for CuDFLoadExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
+        // CoalescePartitionsExec produces a single partition
         let pinned_input = context
             .session_config()
             .options()
             .extensions
             .get::<CuDFConfig>()
             .map_or(true, |cfg| cfg.pinned_input);
-        let host_stream = self.input.execute(partition, context)?;
-        let target_schema = self.schema();
 
-        let metrics = CuDFBaselineMetrics::new(&self.metrics, partition);
+        assert_eq_or_internal_err!(partition, 0, "CuDFLoadExec invalid partition {partition}");
 
-        let cudf_stream = host_stream.map(move |batch_or_err| {
-            let _timer_guard = metrics.elapsed_compute().timer();
-            let batch = match batch_or_err {
-                Ok(batch) => cast_to_target_schema(batch, Arc::clone(&target_schema))?,
-                Err(err) => return Err(err),
-            };
+        let input_partitions = self.input.output_partitioning().partition_count();
 
-            if batch.columns().iter().any(|c| is_cudf_array(c)) {
-                return exec_err!(
-                    "Cannot move RecordBatch from host to CuDF: a column is already a CuDF array"
-                );
-            }
-            let schema = batch.schema();
-            // When `pinned_input` is enabled, stage the host batch through
-            // pinned (page-locked) memory so the upload is a direct DMA
-            // without the driver's pageable-staging step. The pinned source
-            // must outlive the async copy, so the default stream is
-            // synchronized before the pinned batch is dropped at the end of
-            // this closure.
-            //
-            // TODO(memory-tracking): the bytes we pin here are not registered
-            // against DataFusion's `MemoryPool`, so they don't show up in
-            // `EXPLAIN ANALYZE` and won't trigger backpressure if a query has
-            // a memory cap. The OS-level `RLIMIT_MEMLOCK` / `cudaMallocHost`
-            // failure path is the current safety net. Worth wiring through a
-            // `MemoryReservation` (try_grow / shrink per batch) if someone
-            // starts configuring per-query memory caps for cuDF operators.
-            let table = if pinned_input {
-                let pinned_batch = pin_record_batch(batch).map_err(cudf_to_df)?;
-                let table = CuDFTable::from_arrow_host(pinned_batch).map_err(cudf_to_df)?;
-                synchronize_default_stream().map_err(cudf_to_df)?;
-                table
-            } else {
-                CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?
-            };
-            let num_rows = table.num_rows();
-            let cudf_cols: Vec<Arc<dyn Array>> = table
-                .into_columns()
-                .into_iter()
-                .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
-                .collect();
-            let batch = libcudf_rs::record_batch_with_schema(cudf_cols, &schema, num_rows)?;
-            metrics.record_output(&batch);
-            Ok(batch)
-        });
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            self.schema(),
-            cudf_stream,
-        )))
+        // use a stream that allows each sender to put in at
+        // least one result in an attempt to maximize
+        // parallelism.
+        let mut builder = CuDFRecordBatchReceiverStreamBuilder {
+            inner: RecordBatchReceiverStream::builder(self.schema(), input_partitions),
+            ctx: CuDFRecordBatchReceiverStreamBuilderCtx {
+                schema: self.schema(),
+                metrics: CuDFBaselineMetrics::new(&self.metrics, partition),
+                pinned_input,
+            },
+        };
+
+        // spawn independent tasks whose resulting streams (of batches)
+        // are sent to the channel for consumption.
+        for part_i in 0..input_partitions {
+            let input = Arc::clone(&self.input);
+            let host_stream = input.execute(part_i, context.clone())?;
+            builder.run_input(host_stream);
+        }
+
+        Ok(builder.build())
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
+    }
+}
+
+struct CuDFRecordBatchReceiverStreamBuilder {
+    inner: RecordBatchReceiverStreamBuilder,
+    ctx: CuDFRecordBatchReceiverStreamBuilderCtx,
+}
+
+#[derive(Clone)]
+struct CuDFRecordBatchReceiverStreamBuilderCtx {
+    schema: SchemaRef,
+    metrics: CuDFBaselineMetrics,
+    pinned_input: bool,
+}
+
+impl CuDFRecordBatchReceiverStreamBuilder {
+    fn run_input(&mut self, mut host_stream: SendableRecordBatchStream) {
+        let ctx = self.ctx.clone();
+        let output = self.inner.tx();
+        self.inner.spawn(async move {
+            // Transfer batches from inner stream to the output tx
+            // immediately.
+            while let Some(batch_or_err) = host_stream.next().await {
+                let ctx = ctx.clone();
+                let task = SpawnedTask::spawn_blocking(move || {
+                    let _timer_guard = ctx.metrics.elapsed_compute().timer();
+                    let batch = match batch_or_err {
+                        Ok(batch) => cast_to_target_schema(batch, Arc::clone(&ctx.schema))?,
+                        Err(err) => return Err(err),
+                    };
+
+                    if batch.columns().iter().any(|c| is_cudf_array(c)) {
+                        return exec_err!("Cannot move RecordBatch from host to CuDF: a column is already a CuDF array");
+                    }
+                    let schema = batch.schema();
+                    // When `pinned_input` is enabled, stage the host batch through
+                    // pinned (page-locked) memory so the upload is a direct DMA
+                    // without the driver's pageable-staging step. The pinned source
+                    // must outlive the async copy, so the default stream is
+                    // synchronized before the pinned batch is dropped at the end of
+                    // this closure.
+                    //
+                    // TODO(memory-tracking): the bytes we pin here are not registered
+                    // against DataFusion's `MemoryPool`, so they don't show up in
+                    // `EXPLAIN ANALYZE` and won't trigger backpressure if a query has
+                    // a memory cap. The OS-level `RLIMIT_MEMLOCK` / `cudaMallocHost`
+                    // failure path is the current safety net. Worth wiring through a
+                    // `MemoryReservation` (try_grow / shrink per batch) if someone
+                    // starts configuring per-query memory caps for cuDF operators.
+                    let table = if ctx.pinned_input {
+                        let pinned_batch = pin_record_batch(batch).map_err(cudf_to_df)?;
+                        let table =
+                            CuDFTable::from_arrow_host(pinned_batch).map_err(cudf_to_df)?;
+                        synchronize_default_stream().map_err(cudf_to_df)?;
+                        table
+                    } else {
+                        CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?
+                    };
+                    let num_rows = table.num_rows();
+                    let cudf_cols: Vec<Arc<dyn Array>> = table
+                        .into_columns()
+                        .into_iter()
+                        .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
+                        .collect();
+                    let batch =
+                        libcudf_rs::record_batch_with_schema(cudf_cols, &schema, num_rows)?;
+                    ctx.metrics.record_output(&batch);
+                    Ok(batch)
+                });
+                let send_result = match task.await {
+                    Ok(result) => output.send(result).await,
+                    Err(err) => output.send(internal_err!("{err}")).await,
+                };
+                if send_result.is_err() {
+                    break
+                }
+            }
+
+            Ok(())
+        });
+    }
+
+    fn build(self) -> SendableRecordBatchStream {
+        self.inner.build()
     }
 }
 

--- a/libcudf-datafusion/src/physical/cudf_unload.rs
+++ b/libcudf-datafusion/src/physical/cudf_unload.rs
@@ -1,10 +1,10 @@
 use crate::errors::cudf_to_df;
+use crate::metrics::CuDFBaselineMetrics;
 use arrow::array::{RecordBatch, RecordBatchOptions};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use datafusion::common::{plan_err, DataFusionError};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
-use crate::metrics::CuDFBaselineMetrics;
 use datafusion::physical_expr_common::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};

--- a/libcudf-datafusion/src/planner/rescale_leafs.rs
+++ b/libcudf-datafusion/src/planner/rescale_leafs.rs
@@ -1,6 +1,7 @@
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::ExecutionPlan;
 use std::sync::Arc;
 
@@ -24,10 +25,27 @@ impl PhysicalOptimizerRule for RescaleLeafsRule {
                 return Ok(Transformed::no(plan));
             }
 
-            match plan.repartitioned(*leaf_node_partitions, config)? {
-                Some(rescaled) => Ok(Transformed::yes(rescaled)),
-                None => Ok(Transformed::no(plan)),
-            }
+            let Some(rescaled) = plan.repartitioned(*leaf_node_partitions, config)? else {
+                return Ok(Transformed::no(plan));
+            };
+
+            // The rest of the plan was built assuming `target_partitions == 1`,
+            // so any operator above this leaf (e.g. `HashJoinExec` in
+            // `CollectLeft` mode, or `NestedLoopJoinExec`'s left side) expects
+            // a single-partition input. Coalesce only when the rescaled output
+            // is multi-partition; if the source ignored the rescale request
+            // and stayed at one partition, no wrapper is needed.
+            let rescaled = if rescaled
+                .properties()
+                .output_partitioning()
+                .partition_count()
+                > 1
+            {
+                Arc::new(CoalescePartitionsExec::new(rescaled)) as Arc<dyn ExecutionPlan>
+            } else {
+                rescaled
+            };
+            Ok(Transformed::yes(rescaled))
         })?;
         Ok(transformed.data)
     }

--- a/libcudf-datafusion/src/planner/rescale_leafs.rs
+++ b/libcudf-datafusion/src/planner/rescale_leafs.rs
@@ -1,7 +1,6 @@
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
-use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::ExecutionPlan;
 use std::sync::Arc;
 
@@ -25,10 +24,8 @@ impl PhysicalOptimizerRule for RescaleLeafsRule {
                 return Ok(Transformed::no(plan));
             }
 
-            match plan.repartitioned(*leaf_node_partitions, &config)? {
-                Some(rescaled) => Ok(Transformed::yes(Arc::new(CoalescePartitionsExec::new(
-                    rescaled,
-                )))),
+            match plan.repartitioned(*leaf_node_partitions, config)? {
+                Some(rescaled) => Ok(Transformed::yes(rescaled)),
                 None => Ok(Transformed::no(plan)),
             }
         })?;


### PR DESCRIPTION
## Summary

Improves `CuDFLoadExec` and tightens up `RescaleLeafsRule` so the rescale-then-coalesce pattern only kicks in when it's actually needed.

`RescaleLeafsRule` now wraps the rescaled leaf in `CoalescePartitionsExec` **only when** the rescaled output has more than one partition. Previously the wrapper was unconditional; this PR's earlier commit removed it entirely, which broke any query whose source actually fanned out (e.g. TPC-H q19/q20/q21/q22): upstream operators planned under `target_partitions == 1` (e.g. `HashJoinExec` in `CollectLeft` mode, the left side of `NestedLoopJoinExec`) asserted at execute time on multi-partition input. Conditional coalesce restores correctness without introducing spurious coalesces when the source ignored the rescale request.

## Test plan
- [x] `cargo test -p libcudf-datafusion` — 47 lib tests pass
- [x] `cargo test -p libcudf-datafusion --features tpch` — 22 plan tests + 22 correctness tests pass
- [x] `cargo insta test --features tpch` — no pending snapshots
- [x] `cargo fmt --all`

## Performance

```
tpch_sf10 q1: prev=4072 ms, new=2380 ms, diff=1.71 faster ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)