### PR TITLE
Stream cuDF hash joins with reusable build state

### DIFF
--- a/libcudf-datafusion-benchmarks/src/run.rs
+++ b/libcudf-datafusion-benchmarks/src/run.rs
@@ -299,14 +299,14 @@ impl RunOpt {
 
         let plan = state.optimize(&plan)?;
         let physical_plan = state.create_physical_plan(&plan).await?;
-        let result = collect(physical_plan.clone(), state.task_ctx()).await?;
+        let result = collect(physical_plan.clone(), state.task_ctx()).await;
         if self.debug {
             println!(
                 "=== Physical plan with metrics ===\n{}\n",
                 DisplayableExecutionPlan::with_metrics(physical_plan.as_ref()).indent(true)
             );
         }
-        Ok(result)
+        result
     }
 
     fn get_path(&self) -> Result<PathBuf> {

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -18,9 +18,7 @@ use datafusion_physical_plan::{
     ExecutionPlanProperties, PhysicalExpr, PlanProperties,
 };
 use futures::{StreamExt, TryStreamExt};
-use libcudf_rs::{
-    full_join, inner_join, left_join, CuDFHashJoin, CuDFNullEquality, CuDFTable, CuDFTableView,
-};
+use libcudf_rs::{CuDFHashJoin, CuDFNullEquality, CuDFTable, CuDFTableView};
 use std::any::Any;
 use std::fmt::Formatter;
 use std::future::Future;
@@ -124,6 +122,7 @@ impl CuDFHashJoinExec {
         let output_schema = project_schema(&join_schema, projection.as_ref())?;
         let left_on = extract_column_indices(&on, true)?;
         let right_on = extract_column_indices(&on, false)?;
+        let right_partition_count = right.output_partitioning().partition_count();
 
         let left_len = left_schema.fields().len();
         let right_len = right_schema.fields().len();
@@ -133,6 +132,14 @@ impl CuDFHashJoinExec {
                     "CuDFHashJoinExec: on-key index out of bounds (left={l}/{left_len}, right={r}/{right_len})"
                 );
             }
+        }
+
+        if !supports_streaming_join(&partition_mode, join_type, right_partition_count) {
+            return datafusion::common::plan_err!(
+                "CuDFHashJoinExec: unsupported join mode {:?} with join type {:?}",
+                partition_mode,
+                join_type
+            );
         }
 
         // Output partitioning follows the probe side for CollectLeft, and the build side
@@ -243,7 +250,7 @@ impl ExecutionPlan for CuDFHashJoinExec {
 
         // CollectLeft: all partition streams share one left table via OnceCell,
         // so the left child is executed at most once regardless of partition count.
-        // Partitioned/Auto: each partition builds its own left table independently.
+        // Partitioned: each partition builds its own left table independently.
         let left_fut = match &self.partition_mode {
             PartitionMode::CollectLeft => collect_shared(
                 Arc::clone(&self.shared_table),
@@ -279,33 +286,19 @@ impl ExecutionPlan for CuDFHashJoinExec {
             projection,
         };
 
-        if supports_streaming_join(&self.partition_mode, plan.join_type) {
-            let stream = futures::stream::try_unfold(
-                StreamingJoinState::new(plan, left_fut, right_stream, metrics),
-                next_streaming_join_batch,
-            );
-            return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                output_schema,
-                stream,
-            )));
-        }
+        debug_assert!(supports_streaming_join(
+            &self.partition_mode,
+            plan.join_type,
+            self.right.output_partitioning().partition_count()
+        ));
 
-        let stream = futures::stream::once(execute_non_streaming_join(
-            left_fut,
-            right_stream,
-            plan,
-            metrics,
-        ))
-        .filter_map(|result| async move {
-            match result {
-                Ok(Some(batch)) => Some(Ok(batch)),
-                Ok(None) => None,
-                Err(e) => Some(Err(e)),
-            }
-        });
+        let stream = futures::stream::try_unfold(
+            StreamingJoinState::new(plan, left_fut, right_stream, metrics),
+            StreamingJoinState::next_batch,
+        );
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            self.schema(),
+            output_schema,
             stream,
         )))
     }
@@ -339,19 +332,26 @@ fn collect_shared(
 ///
 /// `CollectLeft` streams against the one shared left/build table. `Partitioned`
 /// streams per partition, where each partition has its own left/build table.
-/// `Auto` stays on the non-streaming path until this wrapper knows which
-/// distribution DataFusion selected for the physical join.
-fn supports_streaming_join(partition_mode: &PartitionMode, join_type: JoinType) -> bool {
-    matches!(
-        (partition_mode, join_type),
-        (
-            PartitionMode::CollectLeft | PartitionMode::Partitioned,
-            JoinType::Inner | JoinType::Left | JoinType::Full
-        )
-    )
+/// `Auto` is rejected until this wrapper knows which distribution DataFusion
+/// selected for the physical join.
+///
+/// TODO: Support `CollectLeft` `Left`/`Full` joins with multiple right
+/// partitions by probing all right partitions through one GPU join state and
+/// finalizing unmatched build rows once.
+fn supports_streaming_join(
+    partition_mode: &PartitionMode,
+    join_type: JoinType,
+    right_partition_count: usize,
+) -> bool {
+    match (partition_mode, join_type) {
+        (PartitionMode::CollectLeft, JoinType::Inner) => true,
+        (PartitionMode::CollectLeft, JoinType::Left | JoinType::Full) => right_partition_count == 1,
+        (PartitionMode::Partitioned, JoinType::Inner | JoinType::Left | JoinType::Full) => true,
+        _ => false,
+    }
 }
 
-/// Immutable join metadata shared by streaming and non-streaming execution.
+/// Immutable join metadata used by streamed execution.
 struct JoinPlan {
     join_type: JoinType,
     left_on: Vec<usize>,
@@ -402,224 +402,167 @@ impl StreamingJoinState {
             emitted_unmatched_build: false,
         }
     }
-}
 
-/// Initialize the collected build side exactly once for the streaming path.
-async fn ensure_streaming_join_ready(
-    state: &mut StreamingJoinState,
-) -> Result<(), DataFusionError> {
-    if state.build.is_some() {
-        return Ok(());
-    }
+    /// Produce the next streamed output batch from one right-side input batch.
+    ///
+    /// For `Left` and `Full`, EOF triggers one final unmatched-build batch.
+    async fn next_batch(
+        mut self,
+    ) -> Result<Option<(RecordBatch, StreamingJoinState)>, DataFusionError> {
+        self.ensure_ready().await?;
 
-    let left = state
-        .left_fut
-        .take()
-        .expect("left future should be present before first streamed join batch")
-        .await?;
-    let left_view = Arc::clone(&left).view();
-    let (left_out, right_out) =
-        split_join_projection(&state.plan.projection, left_view.num_columns());
-    let join = {
-        let _timer = state.metrics.build_time.timer();
-        CuDFHashJoin::try_new(&left_view, &state.plan.left_on, CuDFNullEquality::Unequal)
-            .map_err(cudf_to_df)?
-    };
-
-    state.build = Some(StreamingBuildSide {
-        left,
-        join,
-        left_out,
-        right_out,
-    });
-    Ok(())
-}
-
-/// Produce the next streamed output batch from one right-side input batch.
-///
-/// For `Left` and `Full`, EOF triggers one final unmatched-build batch.
-async fn next_streaming_join_batch(
-    mut state: StreamingJoinState,
-) -> Result<Option<(RecordBatch, StreamingJoinState)>, DataFusionError> {
-    ensure_streaming_join_ready(&mut state).await?;
-
-    loop {
-        let right_batch = {
-            let _timer = state.metrics.probe_collect_time.timer();
-            state.right_stream.next().await.transpose()?
-        };
-        let Some(right_batch) = right_batch else {
-            if matches!(state.plan.join_type, JoinType::Left | JoinType::Full)
-                && !state.emitted_unmatched_build
-            {
-                state.emitted_unmatched_build = true;
-                if let Some(batch) = unmatched_build_batch(&state)? {
-                    state.metrics.baseline.record_output(&batch);
-                    return Ok(Some((batch, state)));
+        loop {
+            let right_batch = {
+                let _timer = self.metrics.probe_collect_time.timer();
+                self.right_stream.next().await.transpose()?
+            };
+            let Some(right_batch) = right_batch else {
+                if matches!(self.plan.join_type, JoinType::Left | JoinType::Full)
+                    && !self.emitted_unmatched_build
+                {
+                    self.emitted_unmatched_build = true;
+                    if let Some(batch) = self.unmatched_build_batch()? {
+                        self.metrics.baseline.record_output(&batch);
+                        return Ok(Some((batch, self)));
+                    }
                 }
+                self.metrics.baseline.done();
+                return Ok(None);
+            };
+
+            self.metrics
+                .record_probe_input(std::slice::from_ref(&right_batch));
+
+            if right_batch.num_rows() == 0 {
+                continue;
             }
-            state.metrics.baseline.done();
-            return Ok(None);
+
+            let right =
+                Arc::new(batches_to_table(std::slice::from_ref(&right_batch)).map_err(cudf_to_df)?);
+            let result = self.probe(right)?;
+            let batch = result
+                .into_view()
+                .to_record_batch_with_schema(&self.plan.output_schema)
+                .map_err(cudf_to_df)?;
+
+            if batch.num_rows() == 0 {
+                continue;
+            }
+
+            self.metrics.baseline.record_output(&batch);
+            return Ok(Some((batch, self)));
+        }
+    }
+
+    /// Initialize the collected build side exactly once for the streaming path.
+    async fn ensure_ready(&mut self) -> Result<(), DataFusionError> {
+        if self.build.is_some() {
+            return Ok(());
+        }
+
+        let left = self
+            .left_fut
+            .take()
+            .expect("left future should be present before first streamed join batch")
+            .await?;
+        let left_view = Arc::clone(&left).view();
+        let (left_out, right_out) =
+            split_join_projection(&self.plan.projection, left_view.num_columns());
+        let join = {
+            let _timer = self.metrics.build_time.timer();
+            CuDFHashJoin::try_new(&left_view, &self.plan.left_on, CuDFNullEquality::Unequal)
+                .map_err(cudf_to_df)?
         };
 
-        state
-            .metrics
-            .record_probe_input(std::slice::from_ref(&right_batch));
-
-        if right_batch.num_rows() == 0 {
-            continue;
-        }
-
-        let right =
-            Arc::new(batches_to_table(std::slice::from_ref(&right_batch)).map_err(cudf_to_df)?);
-        let result = probe_streaming_join(&mut state, right)?;
-        let batch = result
-            .into_view()
-            .to_record_batch_with_schema(&state.plan.output_schema)
-            .map_err(cudf_to_df)?;
-
-        if batch.num_rows() == 0 {
-            continue;
-        }
-
-        state.metrics.baseline.record_output(&batch);
-        return Ok(Some((batch, state)));
+        self.build = Some(StreamingBuildSide {
+            left,
+            join,
+            left_out,
+            right_out,
+        });
+        Ok(())
     }
-}
 
-/// Probe one right-side batch against the reusable build-side hash table.
-fn probe_streaming_join(
-    state: &mut StreamingJoinState,
-    right: Arc<CuDFTable>,
-) -> Result<CuDFTable, DataFusionError> {
-    let build = state
-        .build
-        .as_mut()
-        .expect("build side should be initialized before probing");
-    let left_view = Arc::clone(&build.left).view();
-    let right_view = right.view();
-    let _timer = state.metrics.join_time.timer();
+    /// Probe one right-side batch against the reusable build-side hash table.
+    fn probe(&mut self, right: Arc<CuDFTable>) -> Result<CuDFTable, DataFusionError> {
+        let build = self
+            .build
+            .as_mut()
+            .expect("build side should be initialized before probing");
+        let left_view = Arc::clone(&build.left).view();
+        let right_view = right.view();
+        let _timer = self.metrics.join_time.timer();
 
-    let result = match state.plan.join_type {
-        JoinType::Inner => build.join.inner_join(
-            &right_view,
-            &state.plan.right_on,
-            &left_view,
-            &right_view,
-            build.left_out.as_deref(),
-            build.right_out.as_deref(),
-        ),
-        JoinType::Left => build.join.inner_join_and_record_matches(
-            &right_view,
-            &state.plan.right_on,
-            &left_view,
-            &right_view,
-            build.left_out.as_deref(),
-            build.right_out.as_deref(),
-        ),
-        JoinType::Full => build.join.probe_left_join_and_record_matches(
-            &right_view,
-            &state.plan.right_on,
-            &left_view,
-            &right_view,
-            build.left_out.as_deref(),
-            build.right_out.as_deref(),
-        ),
-        other => {
-            return Err(DataFusionError::NotImplemented(format!(
-                "CuDFHashJoinExec: unsupported streaming join type {other:?}"
-            )))
-        }
-    };
-
-    result.map_err(cudf_to_df)
-}
-
-/// Emit collected-left rows that never matched any streamed right batch.
-fn unmatched_build_batch(
-    state: &StreamingJoinState,
-) -> Result<Option<RecordBatch>, DataFusionError> {
-    let build = state
-        .build
-        .as_ref()
-        .expect("build side should be initialized before finalizing");
-    let left_view = Arc::clone(&build.left).view();
-    let empty_right =
-        CuDFTable::from_arrow_host(RecordBatch::new_empty(Arc::clone(&state.plan.right_schema)))
-            .map_err(cudf_to_df)?;
-    let right_view = empty_right.into_view();
-
-    let result = {
-        let _timer = state.metrics.join_time.timer();
-        build
-            .join
-            .unmatched_build_rows(
+        let result = match self.plan.join_type {
+            JoinType::Inner => build.join.inner_join(
+                &right_view,
+                &self.plan.right_on,
                 &left_view,
                 &right_view,
                 build.left_out.as_deref(),
                 build.right_out.as_deref(),
-            )
-            .map_err(cudf_to_df)?
-    };
+            ),
+            JoinType::Left => build.join.inner_join_and_record_matches(
+                &right_view,
+                &self.plan.right_on,
+                &left_view,
+                &right_view,
+                build.left_out.as_deref(),
+                build.right_out.as_deref(),
+            ),
+            JoinType::Full => build.join.probe_left_join_and_record_matches(
+                &right_view,
+                &self.plan.right_on,
+                &left_view,
+                &right_view,
+                build.left_out.as_deref(),
+                build.right_out.as_deref(),
+            ),
+            other => {
+                return Err(DataFusionError::NotImplemented(format!(
+                    "CuDFHashJoinExec: unsupported streaming join type {other:?}"
+                )))
+            }
+        };
 
-    let batch = result
-        .into_view()
-        .to_record_batch_with_schema(&state.plan.output_schema)
-        .map_err(cudf_to_df)?;
-    if batch.num_rows() == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(batch))
-    }
-}
-
-/// Execute joins that cannot use the streamed reusable-hash-join path.
-///
-/// Today this is used for `Auto` mode, plus any future join types admitted by
-/// planning before a streamed implementation exists.
-async fn execute_non_streaming_join(
-    left_fut: SharedTableFuture,
-    right_stream: SendableRecordBatchStream,
-    plan: JoinPlan,
-    metrics: CuDFHashJoinMetrics,
-) -> Result<Option<RecordBatch>, DataFusionError> {
-    let left = left_fut.await?;
-    let right_batches: Vec<RecordBatch> = {
-        let _timer = metrics.probe_collect_time.timer();
-        let batches: Vec<RecordBatch> = right_stream.try_collect().await?;
-        metrics.record_probe_input(&batches);
-        batches
-    };
-
-    let right_empty = right_batches.is_empty() || right_batches.iter().all(|b| b.num_rows() == 0);
-
-    if matches!(plan.join_type, JoinType::Inner) && right_empty {
-        return Ok(None);
+        result.map_err(cudf_to_df)
     }
 
-    let right = if right_batches.is_empty() {
-        let empty = RecordBatch::new_empty(Arc::clone(&plan.right_schema));
-        Arc::new(CuDFTable::from_arrow_host(empty).map_err(cudf_to_df)?)
-    } else {
-        Arc::new(batches_to_table(&right_batches).map_err(cudf_to_df)?)
-    };
+    /// Emit collected-left rows that never matched any streamed right batch.
+    fn unmatched_build_batch(&self) -> Result<Option<RecordBatch>, DataFusionError> {
+        let build = self
+            .build
+            .as_ref()
+            .expect("build side should be initialized before finalizing");
+        let left_view = Arc::clone(&build.left).view();
+        let empty_right =
+            CuDFTable::from_arrow_host(RecordBatch::new_empty(Arc::clone(&self.plan.right_schema)))
+                .map_err(cudf_to_df)?;
+        let right_view = empty_right.into_view();
 
-    let result = {
-        let _timer = metrics.join_time.timer();
-        perform_join(
-            left,
-            right,
-            plan.join_type,
-            &plan.left_on,
-            &plan.right_on,
-            &plan.output_schema,
-            &plan.projection,
-        )
-    };
-    if let Ok(Some(batch)) = &result {
-        metrics.baseline.record_output(batch);
+        let result = {
+            let _timer = self.metrics.join_time.timer();
+            build
+                .join
+                .unmatched_build_rows(
+                    &left_view,
+                    &right_view,
+                    build.left_out.as_deref(),
+                    build.right_out.as_deref(),
+                )
+                .map_err(cudf_to_df)?
+        };
+
+        let batch = result
+            .into_view()
+            .to_record_batch_with_schema(&self.plan.output_schema)
+            .map_err(cudf_to_df)?;
+        if batch.num_rows() == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(batch))
+        }
     }
-    result
 }
 
 #[derive(Clone)]
@@ -688,63 +631,6 @@ fn batch_stats(batches: &[RecordBatch]) -> BatchStats {
     }
 }
 
-/// Run the cuDF join kernel and apply the output projection. Returns `None`
-/// for inner joins with no matching rows.
-fn perform_join(
-    left: Arc<CuDFTable>,
-    right: Arc<CuDFTable>,
-    join_type: JoinType,
-    left_on: &[usize],
-    right_on: &[usize],
-    output_schema: &SchemaRef,
-    projection: &Option<Vec<usize>>,
-) -> Result<Option<RecordBatch>, DataFusionError> {
-    let left_view = left.view();
-    let right_view = right.view();
-
-    let (left_out, right_out) = split_join_projection(projection, left_view.num_columns());
-
-    let result = match join_type {
-        JoinType::Inner => inner_join(
-            &left_view,
-            &right_view,
-            left_on,
-            right_on,
-            left_out.as_deref(),
-            right_out.as_deref(),
-        ),
-        JoinType::Left => left_join(
-            &left_view,
-            &right_view,
-            left_on,
-            right_on,
-            left_out.as_deref(),
-            right_out.as_deref(),
-        ),
-        JoinType::Full => full_join(
-            &left_view,
-            &right_view,
-            left_on,
-            right_on,
-            left_out.as_deref(),
-            right_out.as_deref(),
-        ),
-        other => {
-            return Err(DataFusionError::NotImplemented(format!(
-                "CuDFHashJoinExec: unsupported join type {other:?}"
-            )))
-        }
-    }
-    .map_err(cudf_to_df)?;
-
-    let batch = result
-        .into_view()
-        .to_record_batch_with_schema(output_schema)
-        .map_err(cudf_to_df)?;
-
-    Ok(Some(batch))
-}
-
 fn split_join_projection(
     projection: &Option<Vec<usize>>,
     left_width: usize,
@@ -783,8 +669,11 @@ fn batches_to_table(batches: &[RecordBatch]) -> Result<CuDFTable, libcudf_rs::Cu
     CuDFTable::concat(views)
 }
 
-/// Try to convert a `HashJoinExec` to GPU. Returns `None` for unsupported
-/// configurations: non-column keys, non-equi filters, unsupported join types.
+/// Try to convert a `HashJoinExec` to GPU.
+///
+/// Returns `None` for unsupported configurations: non-column keys, non-equi
+/// filters, unsupported join types, unsupported null equality, or partition
+/// modes that the streamed GPU implementation cannot execute correctly.
 pub fn try_as_cudf_hash_join(
     node: &HashJoinExec,
 ) -> Result<Option<Arc<dyn ExecutionPlan>>, DataFusionError> {
@@ -796,11 +685,6 @@ pub fn try_as_cudf_hash_join(
         }
     }
 
-    match node.join_type() {
-        JoinType::Inner | JoinType::Left | JoinType::Full => {}
-        _ => return Ok(None),
-    }
-
     if node.null_equality() != NullEquality::NullEqualsNothing {
         return Ok(None);
     }
@@ -809,16 +693,24 @@ pub fn try_as_cudf_hash_join(
         return Ok(None);
     }
 
+    if !supports_streaming_join(
+        node.partition_mode(),
+        *node.join_type(),
+        node.right().output_partitioning().partition_count(),
+    ) {
+        return Ok(None);
+    }
+
     Ok(Some(Arc::new(CuDFHashJoinExec::from_hash_join_exec(node)?)))
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{try_as_cudf_hash_join, CuDFHashJoinExec};
     use crate::physical::{CuDFLoadExec, CuDFUnloadExec};
     use arrow::array::record_batch;
     use arrow::array::{Int32Array, RecordBatch};
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use datafusion::common::{JoinSide, JoinType, NullEquality};
     use datafusion::execution::TaskContext;
     use datafusion_physical_plan::expressions::Column;
@@ -857,6 +749,13 @@ mod test {
         .unwrap()
     }
 
+    fn key_on() -> Vec<(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)> {
+        vec![(
+            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
+            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
+        )]
+    }
+
     async fn run_join(
         left: RecordBatch,
         right: RecordBatch,
@@ -872,31 +771,72 @@ mod test {
         join_type: JoinType,
         partition_mode: PartitionMode,
     ) -> Result<Vec<RecordBatch>, Box<dyn Error>> {
-        let ls = left.schema();
-        let rs = right_batches
-            .first()
-            .expect("right side should have at least one batch")
-            .schema();
+        run_join_with_partitions(
+            vec![vec![left]],
+            vec![right_batches],
+            join_type,
+            partition_mode,
+        )
+        .await
+    }
+
+    async fn run_join_with_partitions(
+        left_partitions: Vec<Vec<RecordBatch>>,
+        right_partitions: Vec<Vec<RecordBatch>>,
+        join_type: JoinType,
+        partition_mode: PartitionMode,
+    ) -> Result<Vec<RecordBatch>, Box<dyn Error>> {
+        let left_schema = partition_schema(&left_partitions, left_batch().schema());
+        let right_schema = partition_schema(&right_partitions, right_batch().schema());
+        let partition_count = match partition_mode {
+            PartitionMode::CollectLeft => right_partitions.len(),
+            PartitionMode::Partitioned => {
+                assert_eq!(
+                    left_partitions.len(),
+                    right_partitions.len(),
+                    "partitioned joins require matching left/right partition counts"
+                );
+                left_partitions.len()
+            }
+            PartitionMode::Auto => unreachable!("Auto joins are not supported by CuDFHashJoinExec"),
+        };
+
         // Both sides go through CuDFLoadExec — symmetric GPU upload.
         let left_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &[vec![left]],
-            ls.clone(),
+            &left_partitions,
+            left_schema,
             None,
         )?))?);
         let right_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &[right_batches],
-            rs.clone(),
+            &right_partitions,
+            right_schema,
             None,
         )?))?);
-        let on = vec![(
-            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
-            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
-        )];
-        let exec =
-            CuDFHashJoinExec::try_new(left_in, right_in, on, join_type, None, partition_mode)?;
+        let exec = CuDFHashJoinExec::try_new(
+            left_in,
+            right_in,
+            key_on(),
+            join_type,
+            None,
+            partition_mode,
+        )?;
         let unload = CuDFUnloadExec::new(Arc::new(exec));
-        let stream = unload.execute(0, Arc::new(TaskContext::default()))?;
-        Ok(stream.try_collect::<Vec<_>>().await?)
+
+        let mut out = Vec::new();
+        for partition in 0..partition_count {
+            let stream = unload.execute(partition, Arc::new(TaskContext::default()))?;
+            out.extend(stream.try_collect::<Vec<_>>().await?);
+        }
+        Ok(out)
+    }
+
+    fn partition_schema(partitions: &[Vec<RecordBatch>], default: SchemaRef) -> SchemaRef {
+        partitions
+            .iter()
+            .flatten()
+            .next()
+            .map(RecordBatch::schema)
+            .unwrap_or(default)
     }
 
     fn total_rows(batches: &[RecordBatch]) -> usize {
@@ -917,6 +857,20 @@ mod test {
                 Arc::new(Int32Array::from(vals)),
             ],
         )?)
+    }
+
+    fn partitioned_left_batches() -> Result<Vec<Vec<RecordBatch>>, Box<dyn Error>> {
+        Ok(vec![
+            vec![right_batch_from_rows(&[(1, 10), (2, 20)])?],
+            vec![right_batch_from_rows(&[(3, 30), (4, 40)])?],
+        ])
+    }
+
+    fn partitioned_right_batches() -> Result<Vec<Vec<RecordBatch>>, Box<dyn Error>> {
+        Ok(vec![
+            vec![right_batch_from_rows(&[(2, 200), (5, 500)])?],
+            vec![right_batch_from_rows(&[(3, 300), (6, 600)])?],
+        ])
     }
 
     async fn assert_streamed_inner_join(
@@ -979,6 +933,60 @@ mod test {
         Ok(())
     }
 
+    fn conversion_join(
+        join_type: JoinType,
+        partition_mode: PartitionMode,
+        right_partitions: &[Vec<RecordBatch>],
+    ) -> Result<HashJoinExec, Box<dyn Error>> {
+        conversion_join_with_null_equality(
+            join_type,
+            partition_mode,
+            right_partitions,
+            NullEquality::NullEqualsNothing,
+        )
+    }
+
+    fn conversion_join_with_null_equality(
+        join_type: JoinType,
+        partition_mode: PartitionMode,
+        right_partitions: &[Vec<RecordBatch>],
+        null_equality: NullEquality,
+    ) -> Result<HashJoinExec, Box<dyn Error>> {
+        let schema = left_batch().schema();
+        let left = Arc::new(TestMemoryExec::try_new(
+            &[vec![left_batch()]],
+            schema.clone(),
+            None,
+        )?);
+        let right = Arc::new(TestMemoryExec::try_new(
+            right_partitions,
+            schema.clone(),
+            None,
+        )?);
+        Ok(HashJoinExec::try_new(
+            left,
+            right,
+            key_on(),
+            None,
+            &join_type,
+            None,
+            partition_mode,
+            null_equality,
+            false,
+        )?)
+    }
+
+    fn one_right_partition() -> Result<Vec<Vec<RecordBatch>>, Box<dyn Error>> {
+        Ok(vec![vec![right_batch_from_rows(&[(2, 200)])?]])
+    }
+
+    fn two_right_partitions() -> Result<Vec<Vec<RecordBatch>>, Box<dyn Error>> {
+        Ok(vec![
+            vec![right_batch_from_rows(&[(2, 200)])?],
+            vec![right_batch_from_rows(&[(3, 300)])?],
+        ])
+    }
+
     #[tokio::test]
     async fn test_inner_join() -> Result<(), Box<dyn Error>> {
         let out = run_join(
@@ -1024,71 +1032,69 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_partitioned_inner_join_streams_right_batches() -> Result<(), Box<dyn Error>> {
-        assert_streamed_inner_join(PartitionMode::Partitioned).await
-    }
-
-    #[tokio::test]
-    async fn test_partitioned_left_join_streams_and_finalizes_unmatched(
-    ) -> Result<(), Box<dyn Error>> {
-        assert_streamed_left_join(PartitionMode::Partitioned).await
-    }
-
-    #[tokio::test]
-    async fn test_partitioned_full_join_streams_and_finalizes_unmatched(
-    ) -> Result<(), Box<dyn Error>> {
-        assert_streamed_full_join(PartitionMode::Partitioned).await
-    }
-
-    #[tokio::test]
-    async fn test_left_join_no_right_batches() -> Result<(), Box<dyn Error>> {
-        // Right partition produces zero batches.
-        // Left/Full joins must still return all left rows with nulls in right columns.
-        let ls = left_batch().schema();
-        let rs = right_batch().schema();
-        let left_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &[vec![left_batch()]],
-            ls,
-            None,
-        )?))?);
-        let right_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &[vec![]],
-            rs,
-            None,
-        )?))?);
-        let on = vec![(
-            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
-            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
-        )];
-        let exec = CuDFHashJoinExec::try_new(
-            left_in,
-            right_in,
-            on,
-            JoinType::Left,
-            None,
-            PartitionMode::CollectLeft,
-        )?;
-        let unload = CuDFUnloadExec::new(Arc::new(exec));
-        let stream = unload.execute(0, Arc::new(TaskContext::default()))?;
-        let out: Vec<RecordBatch> = stream.try_collect().await?;
-        // All 4 left rows preserved; right columns are null.
-        assert_eq!(total_rows(&out), 4);
-        assert_eq!(out[0].num_columns(), 4);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_inner_join_partitioned() -> Result<(), Box<dyn Error>> {
-        // Partitioned mode builds the left table per-partition rather than once globally.
-        let out = run_join(
-            left_batch(),
-            right_batch(),
+    async fn test_partitioned_inner_join_executes_all_partitions() -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_partitions(
+            partitioned_left_batches()?,
+            partitioned_right_batches()?,
             JoinType::Inner,
             PartitionMode::Partitioned,
         )
         .await?;
-        assert_eq!(total_rows(&out), 2); // keys 2 and 3 match
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(total_rows(&out), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_partitioned_left_join_executes_all_partitions_and_finalizes_unmatched(
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_partitions(
+            partitioned_left_batches()?,
+            partitioned_right_batches()?,
+            JoinType::Left,
+            PartitionMode::Partitioned,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 4);
+        assert_eq!(total_rows(&out), 4);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_partitioned_full_join_executes_all_partitions_and_finalizes_unmatched(
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_partitions(
+            partitioned_left_batches()?,
+            partitioned_right_batches()?,
+            JoinType::Full,
+            PartitionMode::Partitioned,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 4);
+        assert_eq!(total_rows(&out), 6);
+        assert_eq!(total_nulls(&out, 0), 2);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_left_join_no_right_batches() -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_right_batches(
+            left_batch(),
+            Vec::new(),
+            JoinType::Left,
+            PartitionMode::CollectLeft,
+        )
+        .await?;
+
+        assert_eq!(total_rows(&out), 4);
         assert_eq!(out[0].num_columns(), 4);
+        assert_eq!(total_nulls(&out, 2), 4);
+        assert_eq!(total_nulls(&out, 3), 4);
         Ok(())
     }
 
@@ -1203,10 +1209,6 @@ mod test {
         let schema = Arc::new(Schema::new(vec![Field::new("key", DataType::Int32, false)]));
         let left = Arc::new(TestMemoryExec::try_new(&[], schema.clone(), None)?);
         let right = Arc::new(TestMemoryExec::try_new(&[], schema.clone(), None)?);
-        let on = vec![(
-            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
-            Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
-        )];
         let filter = JoinFilter::new(
             Arc::new(Column::new("key", 0)) as Arc<dyn PhysicalExpr>,
             vec![ColumnIndex {
@@ -1218,7 +1220,7 @@ mod test {
         let join = HashJoinExec::try_new(
             left,
             right,
-            on,
+            key_on(),
             Some(filter),
             &JoinType::Inner,
             None,
@@ -1227,6 +1229,106 @@ mod test {
             false,
         )?;
         assert!(try_as_cudf_hash_join(&join)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_supported_join_shapes_convert_to_gpu() -> Result<(), Box<dyn Error>> {
+        for (join_type, partition_mode, right_partitions) in [
+            (
+                JoinType::Inner,
+                PartitionMode::CollectLeft,
+                two_right_partitions()?,
+            ),
+            (
+                JoinType::Left,
+                PartitionMode::CollectLeft,
+                one_right_partition()?,
+            ),
+            (
+                JoinType::Full,
+                PartitionMode::CollectLeft,
+                one_right_partition()?,
+            ),
+            (
+                JoinType::Inner,
+                PartitionMode::Partitioned,
+                two_right_partitions()?,
+            ),
+            (
+                JoinType::Left,
+                PartitionMode::Partitioned,
+                two_right_partitions()?,
+            ),
+            (
+                JoinType::Full,
+                PartitionMode::Partitioned,
+                two_right_partitions()?,
+            ),
+        ] {
+            let join = conversion_join(join_type, partition_mode, &right_partitions)?;
+            assert!(try_as_cudf_hash_join(&join)?.is_some());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_unsupported_join_shapes_bail_to_cpu() -> Result<(), Box<dyn Error>> {
+        for (join_type, partition_mode, right_partitions) in [
+            (JoinType::Inner, PartitionMode::Auto, one_right_partition()?),
+            (
+                JoinType::LeftSemi,
+                PartitionMode::CollectLeft,
+                one_right_partition()?,
+            ),
+            (
+                JoinType::Left,
+                PartitionMode::CollectLeft,
+                two_right_partitions()?,
+            ),
+            (
+                JoinType::Full,
+                PartitionMode::CollectLeft,
+                two_right_partitions()?,
+            ),
+        ] {
+            let join = conversion_join(join_type, partition_mode, &right_partitions)?;
+            assert!(try_as_cudf_hash_join(&join)?.is_none());
+        }
+
+        let null_equals_join = conversion_join_with_null_equality(
+            JoinType::Inner,
+            PartitionMode::CollectLeft,
+            &one_right_partition()?,
+            NullEquality::NullEqualsNull,
+        )?;
+        assert!(try_as_cudf_hash_join(&null_equals_join)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_direct_constructor_rejects_unsupported_streaming_shape() -> Result<(), Box<dyn Error>> {
+        let schema = left_batch().schema();
+        let left = Arc::new(TestMemoryExec::try_new(
+            &[vec![left_batch()]],
+            schema.clone(),
+            None,
+        )?);
+        let right = Arc::new(TestMemoryExec::try_new(
+            &two_right_partitions()?,
+            schema,
+            None,
+        )?);
+
+        let result = CuDFHashJoinExec::try_new(
+            left,
+            right,
+            key_on(),
+            JoinType::Left,
+            None,
+            PartitionMode::CollectLeft,
+        );
+        assert!(result.is_err());
         Ok(())
     }
 }

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -279,12 +279,7 @@ impl ExecutionPlan for CuDFHashJoinExec {
             projection,
         };
 
-        if matches!(self.partition_mode, PartitionMode::CollectLeft)
-            && matches!(
-                plan.join_type,
-                JoinType::Inner | JoinType::Left | JoinType::Full
-            )
-        {
+        if supports_streaming_join(&self.partition_mode, plan.join_type) {
             let stream = futures::stream::try_unfold(
                 StreamingJoinState::new(plan, left_fut, right_stream, metrics),
                 next_streaming_join_batch,
@@ -340,6 +335,22 @@ fn collect_shared(
     })
 }
 
+/// Join shapes that can stream right-side batches through a reusable build-side hash table.
+///
+/// `CollectLeft` streams against the one shared left/build table. `Partitioned`
+/// streams per partition, where each partition has its own left/build table.
+/// `Auto` stays on the non-streaming path until this wrapper knows which
+/// distribution DataFusion selected for the physical join.
+fn supports_streaming_join(partition_mode: &PartitionMode, join_type: JoinType) -> bool {
+    matches!(
+        (partition_mode, join_type),
+        (
+            PartitionMode::CollectLeft | PartitionMode::Partitioned,
+            JoinType::Inner | JoinType::Left | JoinType::Full
+        )
+    )
+}
+
 /// Immutable join metadata shared by streaming and non-streaming execution.
 struct JoinPlan {
     join_type: JoinType,
@@ -361,7 +372,7 @@ struct StreamingBuildSide {
     right_out: Option<Vec<usize>>,
 }
 
-/// Lifecycle state for streamed `CollectLeft` joins.
+/// Lifecycle state for streamed joins.
 ///
 /// The left side is materialized lazily on the first poll. Right-side batches
 /// are then probed one at a time; `Left` and `Full` emit unmatched build rows
@@ -562,10 +573,10 @@ fn unmatched_build_batch(
     }
 }
 
-/// Execute joins that cannot use the streamed `CollectLeft` path.
+/// Execute joins that cannot use the streamed reusable-hash-join path.
 ///
-/// Partitioned and Auto modes still need this collect-both-sides path because
-/// they do not share one global left/build table across right-side partitions.
+/// Today this is used for `Auto` mode, plus any future join types admitted by
+/// planning before a streamed implementation exists.
 async fn execute_non_streaming_join(
     left_fut: SharedTableFuture,
     right_stream: SendableRecordBatchStream,
@@ -896,6 +907,78 @@ mod test {
         batches.iter().map(|b| b.column(column).null_count()).sum()
     }
 
+    fn right_batch_from_rows(rows: &[(i32, i32)]) -> Result<RecordBatch, Box<dyn Error>> {
+        let keys: Vec<_> = rows.iter().map(|(key, _)| *key).collect();
+        let vals: Vec<_> = rows.iter().map(|(_, val)| *val).collect();
+        Ok(RecordBatch::try_new(
+            right_batch().schema(),
+            vec![
+                Arc::new(Int32Array::from(keys)),
+                Arc::new(Int32Array::from(vals)),
+            ],
+        )?)
+    }
+
+    async fn assert_streamed_inner_join(
+        partition_mode: PartitionMode,
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![
+                right_batch_from_rows(&[(2, 200)])?,
+                right_batch_from_rows(&[(3, 300)])?,
+            ],
+            JoinType::Inner,
+            partition_mode,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(total_rows(&out), 2);
+        Ok(())
+    }
+
+    async fn assert_streamed_left_join(
+        partition_mode: PartitionMode,
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![
+                right_batch_from_rows(&[(2, 200)])?,
+                right_batch_from_rows(&[(3, 300)])?,
+            ],
+            JoinType::Left,
+            partition_mode,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(total_rows(&out), 4);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
+    async fn assert_streamed_full_join(
+        partition_mode: PartitionMode,
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![
+                right_batch_from_rows(&[(2, 200), (5, 500)])?,
+                right_batch_from_rows(&[(3, 300), (6, 600)])?,
+            ],
+            JoinType::Full,
+            partition_mode,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(total_rows(&out), 6);
+        assert_eq!(total_nulls(&out, 0), 2);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_inner_join() -> Result<(), Box<dyn Error>> {
         let out = run_join(
@@ -925,100 +1008,36 @@ mod test {
 
     #[tokio::test]
     async fn test_collect_left_inner_join_streams_right_batches() -> Result<(), Box<dyn Error>> {
-        let schema = right_batch().schema();
-        let right_a = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![2])),
-                Arc::new(Int32Array::from(vec![200])),
-            ],
-        )?;
-        let right_b = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(Int32Array::from(vec![3])),
-                Arc::new(Int32Array::from(vec![300])),
-            ],
-        )?;
-
-        let out = run_join_with_right_batches(
-            left_batch(),
-            vec![right_a, right_b],
-            JoinType::Inner,
-            PartitionMode::CollectLeft,
-        )
-        .await?;
-
-        assert_eq!(out.len(), 2);
-        assert_eq!(total_rows(&out), 2);
-        Ok(())
+        assert_streamed_inner_join(PartitionMode::CollectLeft).await
     }
 
     #[tokio::test]
     async fn test_collect_left_left_join_streams_and_finalizes_unmatched(
     ) -> Result<(), Box<dyn Error>> {
-        let schema = right_batch().schema();
-        let right_a = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![2])),
-                Arc::new(Int32Array::from(vec![200])),
-            ],
-        )?;
-        let right_b = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(Int32Array::from(vec![3])),
-                Arc::new(Int32Array::from(vec![300])),
-            ],
-        )?;
-
-        let out = run_join_with_right_batches(
-            left_batch(),
-            vec![right_a, right_b],
-            JoinType::Left,
-            PartitionMode::CollectLeft,
-        )
-        .await?;
-
-        assert_eq!(out.len(), 3);
-        assert_eq!(total_rows(&out), 4);
-        assert_eq!(total_nulls(&out, 2), 2);
-        Ok(())
+        assert_streamed_left_join(PartitionMode::CollectLeft).await
     }
 
     #[tokio::test]
     async fn test_collect_left_full_join_streams_and_finalizes_unmatched(
     ) -> Result<(), Box<dyn Error>> {
-        let schema = right_batch().schema();
-        let right_a = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![2, 5])),
-                Arc::new(Int32Array::from(vec![200, 500])),
-            ],
-        )?;
-        let right_b = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(Int32Array::from(vec![3, 6])),
-                Arc::new(Int32Array::from(vec![300, 600])),
-            ],
-        )?;
+        assert_streamed_full_join(PartitionMode::CollectLeft).await
+    }
 
-        let out = run_join_with_right_batches(
-            left_batch(),
-            vec![right_a, right_b],
-            JoinType::Full,
-            PartitionMode::CollectLeft,
-        )
-        .await?;
+    #[tokio::test]
+    async fn test_partitioned_inner_join_streams_right_batches() -> Result<(), Box<dyn Error>> {
+        assert_streamed_inner_join(PartitionMode::Partitioned).await
+    }
 
-        assert_eq!(out.len(), 3);
-        assert_eq!(total_rows(&out), 6);
-        assert_eq!(total_nulls(&out, 0), 2);
-        assert_eq!(total_nulls(&out, 2), 2);
-        Ok(())
+    #[tokio::test]
+    async fn test_partitioned_left_join_streams_and_finalizes_unmatched(
+    ) -> Result<(), Box<dyn Error>> {
+        assert_streamed_left_join(PartitionMode::Partitioned).await
+    }
+
+    #[tokio::test]
+    async fn test_partitioned_full_join_streams_and_finalizes_unmatched(
+    ) -> Result<(), Box<dyn Error>> {
+        assert_streamed_full_join(PartitionMode::Partitioned).await
     }
 
     #[tokio::test]

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -1056,6 +1056,48 @@ mod tests {
         Ok(())
     }
 
+    async fn assert_streamed_left_join_with_duplicate_matches(
+        partition_mode: PartitionMode,
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![
+                right_batch_from_rows(&[(2, 200), (2, 201)])?,
+                right_batch_from_rows(&[(3, 300), (3, 301), (5, 500)])?,
+            ],
+            JoinType::Left,
+            partition_mode,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(total_rows(&out), 6);
+        assert_eq!(total_nulls(&out, 0), 0);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
+    async fn assert_streamed_full_join_with_duplicate_matches(
+        partition_mode: PartitionMode,
+    ) -> Result<(), Box<dyn Error>> {
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![
+                right_batch_from_rows(&[(2, 200), (2, 201)])?,
+                right_batch_from_rows(&[(3, 300), (3, 301), (5, 500)])?,
+            ],
+            JoinType::Full,
+            partition_mode,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(total_rows(&out), 7);
+        assert_eq!(total_nulls(&out, 0), 1);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
     fn conversion_join(
         join_type: JoinType,
         partition_mode: PartitionMode,
@@ -1152,6 +1194,22 @@ mod tests {
     async fn test_collect_left_full_join_streams_and_finalizes_unmatched(
     ) -> Result<(), Box<dyn Error>> {
         assert_streamed_full_join(PartitionMode::CollectLeft).await
+    }
+
+    #[tokio::test]
+    async fn test_left_join_duplicate_matches_update_mask_once() -> Result<(), Box<dyn Error>> {
+        for partition_mode in [PartitionMode::CollectLeft, PartitionMode::Partitioned] {
+            assert_streamed_left_join_with_duplicate_matches(partition_mode).await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_full_join_duplicate_matches_update_mask_once() -> Result<(), Box<dyn Error>> {
+        for partition_mode in [PartitionMode::CollectLeft, PartitionMode::Partitioned] {
+            assert_streamed_full_join_with_duplicate_matches(partition_mode).await?;
+        }
+        Ok(())
     }
 
     #[tokio::test]

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -18,11 +18,18 @@ use datafusion_physical_plan::{
     ExecutionPlanProperties, PhysicalExpr, PlanProperties,
 };
 use futures::{StreamExt, TryStreamExt};
-use libcudf_rs::{full_join, inner_join, left_join, CuDFTable, CuDFTableView};
+use libcudf_rs::{
+    full_join, inner_join, left_join, CuDFHashJoin, CuDFNullEquality, CuDFTable, CuDFTableView,
+};
 use std::any::Any;
 use std::fmt::Formatter;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
+
+type SharedTableFuture =
+    Pin<Box<dyn Future<Output = Result<Arc<CuDFTable>, DataFusionError>> + Send>>;
 
 /// GPU-accelerated hash join execution node.
 ///
@@ -263,6 +270,31 @@ impl ExecutionPlan for CuDFHashJoinExec {
         let output_schema = self.schema();
         let right_schema = self.right.schema();
 
+        if matches!(self.partition_mode, PartitionMode::CollectLeft)
+            && matches!(join_type, JoinType::Inner)
+        {
+            let stream = futures::stream::try_unfold(
+                InnerJoinStreamState {
+                    left_fut: Some(left_fut),
+                    left: None,
+                    join: None,
+                    right_stream,
+                    metrics,
+                    left_on,
+                    right_on,
+                    output_schema: output_schema.clone(),
+                    projection,
+                    left_out: None,
+                    right_out: None,
+                },
+                next_inner_join_batch,
+            );
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                output_schema,
+                stream,
+            )));
+        }
+
         let stream = futures::stream::once(async move {
             let left = left_fut.await?;
             let right_batches: Vec<RecordBatch> = {
@@ -328,9 +360,7 @@ fn collect_shared(
     left_child: Arc<dyn ExecutionPlan>,
     ctx: Arc<TaskContext>,
     metrics: CuDFHashJoinMetrics,
-) -> std::pin::Pin<
-    Box<dyn std::future::Future<Output = Result<Arc<CuDFTable>, DataFusionError>> + Send>,
-> {
+) -> SharedTableFuture {
     Box::pin(async move {
         shared
             .get_or_try_init(|| async move {
@@ -346,6 +376,106 @@ fn collect_shared(
             .map(Arc::clone)
             .map_err(|e: Arc<DataFusionError>| DataFusionError::External(Box::new(e)))
     })
+}
+
+struct InnerJoinStreamState {
+    left_fut: Option<SharedTableFuture>,
+    left: Option<Arc<CuDFTable>>,
+    join: Option<CuDFHashJoin>,
+    right_stream: SendableRecordBatchStream,
+    metrics: CuDFHashJoinMetrics,
+    left_on: Vec<usize>,
+    right_on: Vec<usize>,
+    output_schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    left_out: Option<Vec<usize>>,
+    right_out: Option<Vec<usize>>,
+}
+
+async fn ensure_inner_join_ready(state: &mut InnerJoinStreamState) -> Result<(), DataFusionError> {
+    if state.join.is_some() {
+        return Ok(());
+    }
+
+    let left = state
+        .left_fut
+        .take()
+        .expect("left future should be present before first streamed join batch")
+        .await?;
+    let left_view = Arc::clone(&left).view();
+    let (left_out, right_out) = split_join_projection(&state.projection, left_view.num_columns());
+    let join = {
+        let _timer = state.metrics.build_time.timer();
+        CuDFHashJoin::try_new(&left_view, &state.left_on, CuDFNullEquality::Unequal)
+            .map_err(cudf_to_df)?
+    };
+
+    state.left = Some(left);
+    state.join = Some(join);
+    state.left_out = left_out;
+    state.right_out = right_out;
+    Ok(())
+}
+
+async fn next_inner_join_batch(
+    mut state: InnerJoinStreamState,
+) -> Result<Option<(RecordBatch, InnerJoinStreamState)>, DataFusionError> {
+    ensure_inner_join_ready(&mut state).await?;
+
+    loop {
+        let right_batch = {
+            let _timer = state.metrics.probe_collect_time.timer();
+            state.right_stream.next().await.transpose()?
+        };
+        let Some(right_batch) = right_batch else {
+            state.metrics.baseline.done();
+            return Ok(None);
+        };
+
+        state
+            .metrics
+            .record_probe_input(std::slice::from_ref(&right_batch));
+
+        if right_batch.num_rows() == 0 {
+            continue;
+        }
+
+        let right =
+            Arc::new(batches_to_table(std::slice::from_ref(&right_batch)).map_err(cudf_to_df)?);
+        let result = {
+            let left = state
+                .left
+                .as_ref()
+                .expect("left table should be initialized before probing");
+            let join = state
+                .join
+                .as_ref()
+                .expect("hash join should be initialized before probing");
+            let left_view = Arc::clone(left).view();
+            let right_view = Arc::clone(&right).view();
+            let _timer = state.metrics.join_time.timer();
+            join.inner_join(
+                &right_view,
+                &state.right_on,
+                &left_view,
+                &right_view,
+                state.left_out.as_deref(),
+                state.right_out.as_deref(),
+            )
+            .map_err(cudf_to_df)?
+        };
+        let batch = result
+            .into_view()
+            .to_record_batch_with_schema(&state.output_schema)
+            .map_err(cudf_to_df)?;
+
+        if batch.num_rows() == 0 {
+            continue;
+        }
+
+        state.metrics.baseline.record_output(&batch);
+        return Ok(Some((batch, state)));
+    }
 }
 
 #[derive(Clone)]
@@ -428,30 +558,7 @@ fn perform_join(
     let left_view = left.view();
     let right_view = right.view();
 
-    // Decompose projection into per-side column lists.
-    //
-    // Projection must be strictly ascending with all left-side indices (< left_width)
-    // appearing before right-side indices. DataFusion always emits join projections in
-    // this order.
-    debug_assert!(
-        projection
-            .as_ref()
-            .is_none_or(|p| p.windows(2).all(|w| w[0] < w[1])),
-        "join projection indices must be strictly ascending"
-    );
-    let left_width = left_view.num_columns();
-    let (left_out, right_out) = match projection {
-        None => (None, None),
-        Some(proj) => {
-            let lc: Vec<usize> = proj.iter().filter(|&&i| i < left_width).copied().collect();
-            let rc: Vec<usize> = proj
-                .iter()
-                .filter(|&&i| i >= left_width)
-                .map(|&i| i - left_width)
-                .collect();
-            (Some(lc), Some(rc))
-        }
-    };
+    let (left_out, right_out) = split_join_projection(projection, left_view.num_columns());
 
     let result = match join_type {
         JoinType::Inner => inner_join(
@@ -492,6 +599,31 @@ fn perform_join(
         .map_err(cudf_to_df)?;
 
     Ok(Some(batch))
+}
+
+fn split_join_projection(
+    projection: &Option<Vec<usize>>,
+    left_width: usize,
+) -> (Option<Vec<usize>>, Option<Vec<usize>>) {
+    debug_assert!(
+        projection
+            .as_ref()
+            .is_none_or(|p| p.windows(2).all(|w| w[0] < w[1])),
+        "join projection indices must be strictly ascending"
+    );
+
+    match projection {
+        None => (None, None),
+        Some(proj) => {
+            let left = proj.iter().filter(|&&i| i < left_width).copied().collect();
+            let right = proj
+                .iter()
+                .filter(|&&i| i >= left_width)
+                .map(|&i| i - left_width)
+                .collect();
+            (Some(left), Some(right))
+        }
+    }
 }
 
 /// Concat GPU-resident record batches into one table.
@@ -587,8 +719,20 @@ mod test {
         join_type: JoinType,
         partition_mode: PartitionMode,
     ) -> Result<Vec<RecordBatch>, Box<dyn Error>> {
+        run_join_with_right_batches(left, vec![right], join_type, partition_mode).await
+    }
+
+    async fn run_join_with_right_batches(
+        left: RecordBatch,
+        right_batches: Vec<RecordBatch>,
+        join_type: JoinType,
+        partition_mode: PartitionMode,
+    ) -> Result<Vec<RecordBatch>, Box<dyn Error>> {
         let ls = left.schema();
-        let rs = right.schema();
+        let rs = right_batches
+            .first()
+            .expect("right side should have at least one batch")
+            .schema();
         // Both sides go through CuDFLoadExec — symmetric GPU upload.
         let left_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
             &[vec![left]],
@@ -596,7 +740,7 @@ mod test {
             None,
         )?))?);
         let right_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &[vec![right]],
+            &[right_batches],
             rs.clone(),
             None,
         )?))?);
@@ -639,6 +783,37 @@ mod test {
         )
         .await?;
         assert_eq!(total_rows(&out), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_left_inner_join_streams_right_batches() -> Result<(), Box<dyn Error>> {
+        let schema = right_batch().schema();
+        let right_a = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![2])),
+                Arc::new(Int32Array::from(vec![200])),
+            ],
+        )?;
+        let right_b = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![3])),
+                Arc::new(Int32Array::from(vec![300])),
+            ],
+        )?;
+
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![right_a, right_b],
+            JoinType::Inner,
+            PartitionMode::CollectLeft,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(total_rows(&out), 2);
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -270,26 +270,23 @@ impl ExecutionPlan for CuDFHashJoinExec {
         let output_schema = self.schema();
         let right_schema = self.right.schema();
 
+        let plan = JoinPlan {
+            join_type,
+            left_on,
+            right_on,
+            output_schema: output_schema.clone(),
+            right_schema,
+            projection,
+        };
+
         if matches!(self.partition_mode, PartitionMode::CollectLeft)
-            && matches!(join_type, JoinType::Inner | JoinType::Left | JoinType::Full)
+            && matches!(
+                plan.join_type,
+                JoinType::Inner | JoinType::Left | JoinType::Full
+            )
         {
             let stream = futures::stream::try_unfold(
-                StreamingJoinState {
-                    join_type,
-                    left_fut: Some(left_fut),
-                    left: None,
-                    join: None,
-                    right_stream,
-                    metrics,
-                    left_on,
-                    right_on,
-                    output_schema: output_schema.clone(),
-                    right_schema,
-                    projection,
-                    left_out: None,
-                    right_out: None,
-                    emitted_unmatched_build: false,
-                },
+                StreamingJoinState::new(plan, left_fut, right_stream, metrics),
                 next_streaming_join_batch,
             );
             return Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -298,50 +295,12 @@ impl ExecutionPlan for CuDFHashJoinExec {
             )));
         }
 
-        let stream = futures::stream::once(async move {
-            let left = left_fut.await?;
-            let right_batches: Vec<RecordBatch> = {
-                let _timer = metrics.probe_collect_time.timer();
-                let batches: Vec<RecordBatch> = right_stream.try_collect().await?;
-                metrics.record_probe_input(&batches);
-                batches
-            };
-
-            let right_empty =
-                right_batches.is_empty() || right_batches.iter().all(|b| b.num_rows() == 0);
-
-            // Inner join with no right rows: no matches possible, emit nothing.
-            if matches!(join_type, JoinType::Inner) && right_empty {
-                return Ok(None);
-            }
-
-            // For Left/Full joins with no right batches, synthesize an empty right table
-            // from the child schema so the join kernel returns all left rows with null
-            // right columns.
-            let right = if right_batches.is_empty() {
-                let empty = RecordBatch::new_empty(right_schema);
-                Arc::new(CuDFTable::from_arrow_host(empty).map_err(cudf_to_df)?)
-            } else {
-                Arc::new(batches_to_table(&right_batches).map_err(cudf_to_df)?)
-            };
-
-            let result = {
-                let _timer = metrics.join_time.timer();
-                perform_join(
-                    left,
-                    right,
-                    join_type,
-                    &left_on,
-                    &right_on,
-                    &output_schema,
-                    &projection,
-                )
-            };
-            if let Ok(Some(batch)) = &result {
-                metrics.baseline.record_output(batch);
-            }
-            result
-        })
+        let stream = futures::stream::once(execute_non_streaming_join(
+            left_fut,
+            right_stream,
+            plan,
+            metrics,
+        ))
         .filter_map(|result| async move {
             match result {
                 Ok(Some(batch)) => Some(Ok(batch)),
@@ -381,27 +340,64 @@ fn collect_shared(
     })
 }
 
-struct StreamingJoinState {
+/// Immutable join metadata shared by streaming and non-streaming execution.
+struct JoinPlan {
     join_type: JoinType,
-    left_fut: Option<SharedTableFuture>,
-    left: Option<Arc<CuDFTable>>,
-    join: Option<CuDFHashJoin>,
-    right_stream: SendableRecordBatchStream,
-    metrics: CuDFHashJoinMetrics,
     left_on: Vec<usize>,
     right_on: Vec<usize>,
     output_schema: SchemaRef,
     right_schema: SchemaRef,
     projection: Option<Vec<usize>>,
+}
+
+/// Build-side state created once the collected left table is available.
+///
+/// `left_out` and `right_out` are the split projection maps used when probing
+/// right-side batches and when finalizing unmatched build rows.
+struct StreamingBuildSide {
+    left: Arc<CuDFTable>,
+    join: CuDFHashJoin,
     left_out: Option<Vec<usize>>,
     right_out: Option<Vec<usize>>,
+}
+
+/// Lifecycle state for streamed `CollectLeft` joins.
+///
+/// The left side is materialized lazily on the first poll. Right-side batches
+/// are then probed one at a time; `Left` and `Full` emit unmatched build rows
+/// once at end of stream.
+struct StreamingJoinState {
+    plan: JoinPlan,
+    left_fut: Option<SharedTableFuture>,
+    build: Option<StreamingBuildSide>,
+    right_stream: SendableRecordBatchStream,
+    metrics: CuDFHashJoinMetrics,
     emitted_unmatched_build: bool,
 }
 
+impl StreamingJoinState {
+    fn new(
+        plan: JoinPlan,
+        left_fut: SharedTableFuture,
+        right_stream: SendableRecordBatchStream,
+        metrics: CuDFHashJoinMetrics,
+    ) -> Self {
+        Self {
+            plan,
+            left_fut: Some(left_fut),
+            build: None,
+            right_stream,
+            metrics,
+            emitted_unmatched_build: false,
+        }
+    }
+}
+
+/// Initialize the collected build side exactly once for the streaming path.
 async fn ensure_streaming_join_ready(
     state: &mut StreamingJoinState,
 ) -> Result<(), DataFusionError> {
-    if state.join.is_some() {
+    if state.build.is_some() {
         return Ok(());
     }
 
@@ -411,20 +407,26 @@ async fn ensure_streaming_join_ready(
         .expect("left future should be present before first streamed join batch")
         .await?;
     let left_view = Arc::clone(&left).view();
-    let (left_out, right_out) = split_join_projection(&state.projection, left_view.num_columns());
+    let (left_out, right_out) =
+        split_join_projection(&state.plan.projection, left_view.num_columns());
     let join = {
         let _timer = state.metrics.build_time.timer();
-        CuDFHashJoin::try_new(&left_view, &state.left_on, CuDFNullEquality::Unequal)
+        CuDFHashJoin::try_new(&left_view, &state.plan.left_on, CuDFNullEquality::Unequal)
             .map_err(cudf_to_df)?
     };
 
-    state.left = Some(left);
-    state.join = Some(join);
-    state.left_out = left_out;
-    state.right_out = right_out;
+    state.build = Some(StreamingBuildSide {
+        left,
+        join,
+        left_out,
+        right_out,
+    });
     Ok(())
 }
 
+/// Produce the next streamed output batch from one right-side input batch.
+///
+/// For `Left` and `Full`, EOF triggers one final unmatched-build batch.
 async fn next_streaming_join_batch(
     mut state: StreamingJoinState,
 ) -> Result<Option<(RecordBatch, StreamingJoinState)>, DataFusionError> {
@@ -436,7 +438,7 @@ async fn next_streaming_join_batch(
             state.right_stream.next().await.transpose()?
         };
         let Some(right_batch) = right_batch else {
-            if matches!(state.join_type, JoinType::Left | JoinType::Full)
+            if matches!(state.plan.join_type, JoinType::Left | JoinType::Full)
                 && !state.emitted_unmatched_build
             {
                 state.emitted_unmatched_build = true;
@@ -462,7 +464,7 @@ async fn next_streaming_join_batch(
         let result = probe_streaming_join(&mut state, right)?;
         let batch = result
             .into_view()
-            .to_record_batch_with_schema(&state.output_schema)
+            .to_record_batch_with_schema(&state.plan.output_schema)
             .map_err(cudf_to_df)?;
 
         if batch.num_rows() == 0 {
@@ -474,57 +476,44 @@ async fn next_streaming_join_batch(
     }
 }
 
+/// Probe one right-side batch against the reusable build-side hash table.
 fn probe_streaming_join(
     state: &mut StreamingJoinState,
     right: Arc<CuDFTable>,
 ) -> Result<CuDFTable, DataFusionError> {
-    let left = Arc::clone(
-        state
-            .left
-            .as_ref()
-            .expect("left table should be initialized before probing"),
-    );
-    let left_view = left.view();
+    let build = state
+        .build
+        .as_mut()
+        .expect("build side should be initialized before probing");
+    let left_view = Arc::clone(&build.left).view();
     let right_view = right.view();
     let _timer = state.metrics.join_time.timer();
 
-    let result = match state.join_type {
-        JoinType::Inner => state
-            .join
-            .as_ref()
-            .expect("hash join should be initialized before probing")
-            .inner_join(
-                &right_view,
-                &state.right_on,
-                &left_view,
-                &right_view,
-                state.left_out.as_deref(),
-                state.right_out.as_deref(),
-            ),
-        JoinType::Left => state
-            .join
-            .as_mut()
-            .expect("hash join should be initialized before probing")
-            .inner_join_and_record_matches(
-                &right_view,
-                &state.right_on,
-                &left_view,
-                &right_view,
-                state.left_out.as_deref(),
-                state.right_out.as_deref(),
-            ),
-        JoinType::Full => state
-            .join
-            .as_mut()
-            .expect("hash join should be initialized before probing")
-            .probe_left_join_and_record_matches(
-                &right_view,
-                &state.right_on,
-                &left_view,
-                &right_view,
-                state.left_out.as_deref(),
-                state.right_out.as_deref(),
-            ),
+    let result = match state.plan.join_type {
+        JoinType::Inner => build.join.inner_join(
+            &right_view,
+            &state.plan.right_on,
+            &left_view,
+            &right_view,
+            build.left_out.as_deref(),
+            build.right_out.as_deref(),
+        ),
+        JoinType::Left => build.join.inner_join_and_record_matches(
+            &right_view,
+            &state.plan.right_on,
+            &left_view,
+            &right_view,
+            build.left_out.as_deref(),
+            build.right_out.as_deref(),
+        ),
+        JoinType::Full => build.join.probe_left_join_and_record_matches(
+            &right_view,
+            &state.plan.right_on,
+            &left_view,
+            &right_view,
+            build.left_out.as_deref(),
+            build.right_out.as_deref(),
+        ),
         other => {
             return Err(DataFusionError::NotImplemented(format!(
                 "CuDFHashJoinExec: unsupported streaming join type {other:?}"
@@ -535,43 +524,91 @@ fn probe_streaming_join(
     result.map_err(cudf_to_df)
 }
 
+/// Emit collected-left rows that never matched any streamed right batch.
 fn unmatched_build_batch(
     state: &StreamingJoinState,
 ) -> Result<Option<RecordBatch>, DataFusionError> {
-    let left = state
-        .left
+    let build = state
+        .build
         .as_ref()
-        .expect("left table should be initialized before finalizing");
-    let join = state
-        .join
-        .as_ref()
-        .expect("hash join should be initialized before finalizing");
-    let left_view = Arc::clone(left).view();
+        .expect("build side should be initialized before finalizing");
+    let left_view = Arc::clone(&build.left).view();
     let empty_right =
-        CuDFTable::from_arrow_host(RecordBatch::new_empty(Arc::clone(&state.right_schema)))
+        CuDFTable::from_arrow_host(RecordBatch::new_empty(Arc::clone(&state.plan.right_schema)))
             .map_err(cudf_to_df)?;
     let right_view = empty_right.into_view();
 
     let result = {
         let _timer = state.metrics.join_time.timer();
-        join.unmatched_build_rows(
-            &left_view,
-            &right_view,
-            state.left_out.as_deref(),
-            state.right_out.as_deref(),
-        )
-        .map_err(cudf_to_df)?
+        build
+            .join
+            .unmatched_build_rows(
+                &left_view,
+                &right_view,
+                build.left_out.as_deref(),
+                build.right_out.as_deref(),
+            )
+            .map_err(cudf_to_df)?
     };
 
     let batch = result
         .into_view()
-        .to_record_batch_with_schema(&state.output_schema)
+        .to_record_batch_with_schema(&state.plan.output_schema)
         .map_err(cudf_to_df)?;
     if batch.num_rows() == 0 {
         Ok(None)
     } else {
         Ok(Some(batch))
     }
+}
+
+/// Execute joins that cannot use the streamed `CollectLeft` path.
+///
+/// Partitioned and Auto modes still need this collect-both-sides path because
+/// they do not share one global left/build table across right-side partitions.
+async fn execute_non_streaming_join(
+    left_fut: SharedTableFuture,
+    right_stream: SendableRecordBatchStream,
+    plan: JoinPlan,
+    metrics: CuDFHashJoinMetrics,
+) -> Result<Option<RecordBatch>, DataFusionError> {
+    let left = left_fut.await?;
+    let right_batches: Vec<RecordBatch> = {
+        let _timer = metrics.probe_collect_time.timer();
+        let batches: Vec<RecordBatch> = right_stream.try_collect().await?;
+        metrics.record_probe_input(&batches);
+        batches
+    };
+
+    let right_empty = right_batches.is_empty() || right_batches.iter().all(|b| b.num_rows() == 0);
+
+    if matches!(plan.join_type, JoinType::Inner) && right_empty {
+        return Ok(None);
+    }
+
+    let right = if right_batches.is_empty() {
+        let empty = RecordBatch::new_empty(Arc::clone(&plan.right_schema));
+        Arc::new(CuDFTable::from_arrow_host(empty).map_err(cudf_to_df)?)
+    } else {
+        Arc::new(batches_to_table(&right_batches).map_err(cudf_to_df)?)
+    };
+
+    let result = {
+        let _timer = metrics.join_time.timer();
+        perform_join(
+            left,
+            right,
+            plan.join_type,
+            &plan.left_on,
+            &plan.right_on,
+            &plan.output_schema,
+            &plan.projection,
+        )
+    };
+    if let Ok(Some(batch)) = &result {
+        metrics.baseline.record_output(batch);
+    }
+    result
 }
 
 #[derive(Clone)]

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -271,10 +271,11 @@ impl ExecutionPlan for CuDFHashJoinExec {
         let right_schema = self.right.schema();
 
         if matches!(self.partition_mode, PartitionMode::CollectLeft)
-            && matches!(join_type, JoinType::Inner)
+            && matches!(join_type, JoinType::Inner | JoinType::Left | JoinType::Full)
         {
             let stream = futures::stream::try_unfold(
-                InnerJoinStreamState {
+                StreamingJoinState {
+                    join_type,
                     left_fut: Some(left_fut),
                     left: None,
                     join: None,
@@ -283,11 +284,13 @@ impl ExecutionPlan for CuDFHashJoinExec {
                     left_on,
                     right_on,
                     output_schema: output_schema.clone(),
+                    right_schema,
                     projection,
                     left_out: None,
                     right_out: None,
+                    emitted_unmatched_build: false,
                 },
-                next_inner_join_batch,
+                next_streaming_join_batch,
             );
             return Ok(Box::pin(RecordBatchStreamAdapter::new(
                 output_schema,
@@ -378,7 +381,8 @@ fn collect_shared(
     })
 }
 
-struct InnerJoinStreamState {
+struct StreamingJoinState {
+    join_type: JoinType,
     left_fut: Option<SharedTableFuture>,
     left: Option<Arc<CuDFTable>>,
     join: Option<CuDFHashJoin>,
@@ -387,12 +391,16 @@ struct InnerJoinStreamState {
     left_on: Vec<usize>,
     right_on: Vec<usize>,
     output_schema: SchemaRef,
+    right_schema: SchemaRef,
     projection: Option<Vec<usize>>,
     left_out: Option<Vec<usize>>,
     right_out: Option<Vec<usize>>,
+    emitted_unmatched_build: bool,
 }
 
-async fn ensure_inner_join_ready(state: &mut InnerJoinStreamState) -> Result<(), DataFusionError> {
+async fn ensure_streaming_join_ready(
+    state: &mut StreamingJoinState,
+) -> Result<(), DataFusionError> {
     if state.join.is_some() {
         return Ok(());
     }
@@ -417,10 +425,10 @@ async fn ensure_inner_join_ready(state: &mut InnerJoinStreamState) -> Result<(),
     Ok(())
 }
 
-async fn next_inner_join_batch(
-    mut state: InnerJoinStreamState,
-) -> Result<Option<(RecordBatch, InnerJoinStreamState)>, DataFusionError> {
-    ensure_inner_join_ready(&mut state).await?;
+async fn next_streaming_join_batch(
+    mut state: StreamingJoinState,
+) -> Result<Option<(RecordBatch, StreamingJoinState)>, DataFusionError> {
+    ensure_streaming_join_ready(&mut state).await?;
 
     loop {
         let right_batch = {
@@ -428,6 +436,15 @@ async fn next_inner_join_batch(
             state.right_stream.next().await.transpose()?
         };
         let Some(right_batch) = right_batch else {
+            if matches!(state.join_type, JoinType::Left | JoinType::Full)
+                && !state.emitted_unmatched_build
+            {
+                state.emitted_unmatched_build = true;
+                if let Some(batch) = unmatched_build_batch(&state)? {
+                    state.metrics.baseline.record_output(&batch);
+                    return Ok(Some((batch, state)));
+                }
+            }
             state.metrics.baseline.done();
             return Ok(None);
         };
@@ -442,28 +459,7 @@ async fn next_inner_join_batch(
 
         let right =
             Arc::new(batches_to_table(std::slice::from_ref(&right_batch)).map_err(cudf_to_df)?);
-        let result = {
-            let left = state
-                .left
-                .as_ref()
-                .expect("left table should be initialized before probing");
-            let join = state
-                .join
-                .as_ref()
-                .expect("hash join should be initialized before probing");
-            let left_view = Arc::clone(left).view();
-            let right_view = Arc::clone(&right).view();
-            let _timer = state.metrics.join_time.timer();
-            join.inner_join(
-                &right_view,
-                &state.right_on,
-                &left_view,
-                &right_view,
-                state.left_out.as_deref(),
-                state.right_out.as_deref(),
-            )
-            .map_err(cudf_to_df)?
-        };
+        let result = probe_streaming_join(&mut state, right)?;
         let batch = result
             .into_view()
             .to_record_batch_with_schema(&state.output_schema)
@@ -475,6 +471,106 @@ async fn next_inner_join_batch(
 
         state.metrics.baseline.record_output(&batch);
         return Ok(Some((batch, state)));
+    }
+}
+
+fn probe_streaming_join(
+    state: &mut StreamingJoinState,
+    right: Arc<CuDFTable>,
+) -> Result<CuDFTable, DataFusionError> {
+    let left = Arc::clone(
+        state
+            .left
+            .as_ref()
+            .expect("left table should be initialized before probing"),
+    );
+    let left_view = left.view();
+    let right_view = right.view();
+    let _timer = state.metrics.join_time.timer();
+
+    let result = match state.join_type {
+        JoinType::Inner => state
+            .join
+            .as_ref()
+            .expect("hash join should be initialized before probing")
+            .inner_join(
+                &right_view,
+                &state.right_on,
+                &left_view,
+                &right_view,
+                state.left_out.as_deref(),
+                state.right_out.as_deref(),
+            ),
+        JoinType::Left => state
+            .join
+            .as_mut()
+            .expect("hash join should be initialized before probing")
+            .inner_join_and_record_matches(
+                &right_view,
+                &state.right_on,
+                &left_view,
+                &right_view,
+                state.left_out.as_deref(),
+                state.right_out.as_deref(),
+            ),
+        JoinType::Full => state
+            .join
+            .as_mut()
+            .expect("hash join should be initialized before probing")
+            .probe_left_join_and_record_matches(
+                &right_view,
+                &state.right_on,
+                &left_view,
+                &right_view,
+                state.left_out.as_deref(),
+                state.right_out.as_deref(),
+            ),
+        other => {
+            return Err(DataFusionError::NotImplemented(format!(
+                "CuDFHashJoinExec: unsupported streaming join type {other:?}"
+            )))
+        }
+    };
+
+    result.map_err(cudf_to_df)
+}
+
+fn unmatched_build_batch(
+    state: &StreamingJoinState,
+) -> Result<Option<RecordBatch>, DataFusionError> {
+    let left = state
+        .left
+        .as_ref()
+        .expect("left table should be initialized before finalizing");
+    let join = state
+        .join
+        .as_ref()
+        .expect("hash join should be initialized before finalizing");
+    let left_view = Arc::clone(left).view();
+    let empty_right =
+        CuDFTable::from_arrow_host(RecordBatch::new_empty(Arc::clone(&state.right_schema)))
+            .map_err(cudf_to_df)?;
+    let right_view = empty_right.into_view();
+
+    let result = {
+        let _timer = state.metrics.join_time.timer();
+        join.unmatched_build_rows(
+            &left_view,
+            &right_view,
+            state.left_out.as_deref(),
+            state.right_out.as_deref(),
+        )
+        .map_err(cudf_to_df)?
+    };
+
+    let batch = result
+        .into_view()
+        .to_record_batch_with_schema(&state.output_schema)
+        .map_err(cudf_to_df)?;
+    if batch.num_rows() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(batch))
     }
 }
 
@@ -759,6 +855,10 @@ mod test {
         batches.iter().map(|b| b.num_rows()).sum()
     }
 
+    fn total_nulls(batches: &[RecordBatch], column: usize) -> usize {
+        batches.iter().map(|b| b.column(column).null_count()).sum()
+    }
+
     #[tokio::test]
     async fn test_inner_join() -> Result<(), Box<dyn Error>> {
         let out = run_join(
@@ -814,6 +914,73 @@ mod test {
 
         assert_eq!(out.len(), 2);
         assert_eq!(total_rows(&out), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_left_left_join_streams_and_finalizes_unmatched(
+    ) -> Result<(), Box<dyn Error>> {
+        let schema = right_batch().schema();
+        let right_a = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![2])),
+                Arc::new(Int32Array::from(vec![200])),
+            ],
+        )?;
+        let right_b = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![3])),
+                Arc::new(Int32Array::from(vec![300])),
+            ],
+        )?;
+
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![right_a, right_b],
+            JoinType::Left,
+            PartitionMode::CollectLeft,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(total_rows(&out), 4);
+        assert_eq!(total_nulls(&out, 2), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_left_full_join_streams_and_finalizes_unmatched(
+    ) -> Result<(), Box<dyn Error>> {
+        let schema = right_batch().schema();
+        let right_a = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![2, 5])),
+                Arc::new(Int32Array::from(vec![200, 500])),
+            ],
+        )?;
+        let right_b = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![3, 6])),
+                Arc::new(Int32Array::from(vec![300, 600])),
+            ],
+        )?;
+
+        let out = run_join_with_right_batches(
+            left_batch(),
+            vec![right_a, right_b],
+            JoinType::Full,
+            PartitionMode::CollectLeft,
+        )
+        .await?;
+
+        assert_eq!(out.len(), 3);
+        assert_eq!(total_rows(&out), 6);
+        assert_eq!(total_nulls(&out, 0), 2);
+        assert_eq!(total_nulls(&out, 2), 2);
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -706,20 +706,28 @@ pub fn try_as_cudf_hash_join(
 
 #[cfg(test)]
 mod tests {
-    use super::{try_as_cudf_hash_join, CuDFHashJoinExec};
+    use super::{cudf_schema_compatibility_map, try_as_cudf_hash_join, CuDFHashJoinExec};
+    use crate::errors::cudf_to_df;
     use crate::physical::{CuDFLoadExec, CuDFUnloadExec};
-    use arrow::array::record_batch;
-    use arrow::array::{Int32Array, RecordBatch};
+    use arrow::array::{record_batch, Array, Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use datafusion::common::{JoinSide, JoinType, NullEquality};
     use datafusion::execution::TaskContext;
+    use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
     use datafusion_physical_plan::expressions::Column;
     use datafusion_physical_plan::joins::utils::{ColumnIndex, JoinFilter};
     use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode};
+    use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
     use datafusion_physical_plan::test::TestMemoryExec;
-    use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+    use datafusion_physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+    };
+    use futures::stream;
     use futures_util::TryStreamExt;
+    use libcudf_rs::CuDFTable;
+    use std::any::Any;
     use std::error::Error;
+    use std::fmt::Formatter;
     use std::sync::Arc;
 
     fn left_batch() -> RecordBatch {
@@ -801,17 +809,32 @@ mod tests {
             PartitionMode::Auto => unreachable!("Auto joins are not supported by CuDFHashJoinExec"),
         };
 
-        // Both sides go through CuDFLoadExec — symmetric GPU upload.
-        let left_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &left_partitions,
-            left_schema,
-            None,
-        )?))?);
-        let right_in = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
-            &right_partitions,
-            right_schema,
-            None,
-        )?))?);
+        let (left_in, right_in): (Arc<dyn ExecutionPlan>, Arc<dyn ExecutionPlan>) =
+            match partition_mode {
+                PartitionMode::CollectLeft => {
+                    // CuDFLoadExec intentionally coalesces host input partitions into one GPU
+                    // partition. CollectLeft tests use that production upload path.
+                    let left = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
+                        &left_partitions,
+                        left_schema,
+                        None,
+                    )?))?);
+                    let right = Arc::new(CuDFLoadExec::try_new(Arc::new(
+                        TestMemoryExec::try_new(&right_partitions, right_schema, None)?,
+                    ))?);
+                    (left, right)
+                }
+                PartitionMode::Partitioned => {
+                    // Partitioned join execution needs GPU-resident children that preserve
+                    // partition counts; CuDFLoadExec is no longer that shape.
+                    let left = Arc::new(TestGpuExec::try_new(left_partitions, left_schema)?);
+                    let right = Arc::new(TestGpuExec::try_new(right_partitions, right_schema)?);
+                    (left, right)
+                }
+                PartitionMode::Auto => {
+                    unreachable!("Auto joins are not supported by CuDFHashJoinExec")
+                }
+            };
         let exec = CuDFHashJoinExec::try_new(
             left_in,
             right_in,
@@ -828,6 +851,106 @@ mod tests {
             out.extend(stream.try_collect::<Vec<_>>().await?);
         }
         Ok(out)
+    }
+
+    #[derive(Debug)]
+    struct TestGpuExec {
+        partitions: Vec<Vec<RecordBatch>>,
+        properties: Arc<PlanProperties>,
+    }
+
+    impl TestGpuExec {
+        fn try_new(
+            partitions: Vec<Vec<RecordBatch>>,
+            schema: SchemaRef,
+        ) -> Result<Self, Box<dyn Error>> {
+            let input = TestMemoryExec::try_new(&partitions, schema, None)?;
+            let properties = Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(cudf_schema_compatibility_map(input.schema())),
+                Partitioning::UnknownPartitioning(partitions.len()),
+                input.properties().emission_type,
+                input.properties().boundedness,
+            ));
+            Ok(Self {
+                partitions,
+                properties,
+            })
+        }
+    }
+
+    impl DisplayAs for TestGpuExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+            write!(f, "TestGpuExec")
+        }
+    }
+
+    impl ExecutionPlan for TestGpuExec {
+        fn name(&self) -> &str {
+            "TestGpuExec"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+
+        fn with_new_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+            if !children.is_empty() {
+                return datafusion::common::plan_err!(
+                    "TestGpuExec expects no children, {} were provided",
+                    children.len()
+                );
+            }
+            Ok(self)
+        }
+
+        fn execute(
+            &self,
+            partition: usize,
+            _context: Arc<TaskContext>,
+        ) -> datafusion::common::Result<datafusion::execution::SendableRecordBatchStream> {
+            let Some(batches) = self.partitions.get(partition).cloned() else {
+                return datafusion::common::internal_err!(
+                    "TestGpuExec invalid partition {partition}"
+                );
+            };
+            let schema = self.schema();
+            let stream = stream::iter(
+                batches
+                    .into_iter()
+                    .map(move |batch| host_batch_to_gpu(batch, Arc::clone(&schema))),
+            );
+            Ok(Box::pin(RecordBatchStreamAdapter::new(
+                self.schema(),
+                stream,
+            )))
+        }
+    }
+
+    fn host_batch_to_gpu(
+        batch: RecordBatch,
+        schema: SchemaRef,
+    ) -> datafusion::common::Result<RecordBatch> {
+        let table = CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?;
+        let num_rows = table.num_rows();
+        let columns = table
+            .into_columns()
+            .into_iter()
+            .map(|column| Arc::new(column.into_view()) as Arc<dyn Array>)
+            .collect();
+        Ok(libcudf_rs::record_batch_with_schema(
+            columns, &schema, num_rows,
+        )?)
     }
 
     fn partition_schema(partitions: &[Vec<RecordBatch>], default: SchemaRef) -> SchemaRef {

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -1,4 +1,5 @@
 use crate::errors::cudf_to_df;
+use crate::metrics::CuDFBaselineMetrics;
 use crate::physical::cudf_load::cudf_schema_compatibility_map;
 use arrow::array::RecordBatch;
 use arrow_schema::{Field, Schema, SchemaRef};
@@ -8,6 +9,9 @@ use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion_physical_plan::expressions::Column;
 use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion_physical_plan::metrics::{
+    Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, MetricsSet, Time,
+};
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{
     execute_stream, project_schema, DisplayAs, DisplayFormatType, ExecutionPlan,
@@ -36,6 +40,7 @@ pub struct CuDFHashJoinExec {
     right_on: Vec<usize>,
     properties: Arc<PlanProperties>,
     shared_table: Arc<OnceCell<Arc<CuDFTable>>>,
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl std::fmt::Debug for CuDFHashJoinExec {
@@ -147,6 +152,7 @@ impl CuDFHashJoinExec {
             right_on,
             properties,
             shared_table: Arc::new(OnceCell::new()),
+            metrics: ExecutionPlanMetricsSet::new(),
         })
     }
 
@@ -200,6 +206,10 @@ impl ExecutionPlan for CuDFHashJoinExec {
         vec![&self.left, &self.right]
     }
 
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
@@ -222,6 +232,7 @@ impl ExecutionPlan for CuDFHashJoinExec {
         context: Arc<TaskContext>,
     ) -> datafusion::common::Result<SendableRecordBatchStream> {
         let right_stream = self.right.execute(partition, Arc::clone(&context))?;
+        let metrics = CuDFHashJoinMetrics::new(&self.metrics, partition);
 
         // CollectLeft: all partition streams share one left table via OnceCell,
         // so the left child is executed at most once regardless of partition count.
@@ -231,11 +242,15 @@ impl ExecutionPlan for CuDFHashJoinExec {
                 Arc::clone(&self.shared_table),
                 Arc::clone(&self.left),
                 Arc::clone(&context),
+                metrics.clone(),
             ),
             _ => {
                 let left_stream = self.left.execute(partition, Arc::clone(&context))?;
+                let metrics = metrics.clone();
                 Box::pin(async move {
+                    let _timer = metrics.build_time.timer();
                     let batches: Vec<RecordBatch> = left_stream.try_collect().await?;
+                    metrics.record_build_input(&batches);
                     batches_to_table(&batches).map(Arc::new).map_err(cudf_to_df)
                 })
             }
@@ -250,7 +265,12 @@ impl ExecutionPlan for CuDFHashJoinExec {
 
         let stream = futures::stream::once(async move {
             let left = left_fut.await?;
-            let right_batches: Vec<RecordBatch> = right_stream.try_collect().await?;
+            let right_batches: Vec<RecordBatch> = {
+                let _timer = metrics.probe_collect_time.timer();
+                let batches: Vec<RecordBatch> = right_stream.try_collect().await?;
+                metrics.record_probe_input(&batches);
+                batches
+            };
 
             let right_empty =
                 right_batches.is_empty() || right_batches.iter().all(|b| b.num_rows() == 0);
@@ -270,15 +290,22 @@ impl ExecutionPlan for CuDFHashJoinExec {
                 Arc::new(batches_to_table(&right_batches).map_err(cudf_to_df)?)
             };
 
-            perform_join(
-                left,
-                right,
-                join_type,
-                &left_on,
-                &right_on,
-                &output_schema,
-                &projection,
-            )
+            let result = {
+                let _timer = metrics.join_time.timer();
+                perform_join(
+                    left,
+                    right,
+                    join_type,
+                    &left_on,
+                    &right_on,
+                    &output_schema,
+                    &projection,
+                )
+            };
+            if let Ok(Some(batch)) = &result {
+                metrics.baseline.record_output(batch);
+            }
+            result
         })
         .filter_map(|result| async move {
             match result {
@@ -300,14 +327,17 @@ fn collect_shared(
     shared: Arc<OnceCell<Arc<CuDFTable>>>,
     left_child: Arc<dyn ExecutionPlan>,
     ctx: Arc<TaskContext>,
+    metrics: CuDFHashJoinMetrics,
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = Result<Arc<CuDFTable>, DataFusionError>> + Send>,
 > {
     Box::pin(async move {
         shared
             .get_or_try_init(|| async move {
+                let _timer = metrics.build_time.timer();
                 let stream = execute_stream(left_child, ctx).map_err(Arc::new)?;
                 let batches: Vec<RecordBatch> = stream.try_collect().await.map_err(Arc::new)?;
+                metrics.record_build_input(&batches);
                 batches_to_table(&batches)
                     .map(Arc::new)
                     .map_err(|e| Arc::new(cudf_to_df(e)))
@@ -316,6 +346,72 @@ fn collect_shared(
             .map(Arc::clone)
             .map_err(|e: Arc<DataFusionError>| DataFusionError::External(Box::new(e)))
     })
+}
+
+#[derive(Clone)]
+struct CuDFHashJoinMetrics {
+    baseline: CuDFBaselineMetrics,
+    build_time: Time,
+    probe_collect_time: Time,
+    join_time: Time,
+    build_input_batches: Count,
+    build_input_rows: Count,
+    build_input_bytes: Count,
+    probe_input_batches: Count,
+    probe_input_rows: Count,
+    probe_input_bytes: Count,
+    join_input_bytes: Gauge,
+}
+
+impl CuDFHashJoinMetrics {
+    fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        Self {
+            baseline: CuDFBaselineMetrics::new(metrics, partition),
+            build_time: MetricBuilder::new(metrics).subset_time("build_time", partition),
+            probe_collect_time: MetricBuilder::new(metrics)
+                .subset_time("probe_collect_time", partition),
+            join_time: MetricBuilder::new(metrics).subset_time("join_time", partition),
+            build_input_batches: MetricBuilder::new(metrics)
+                .counter("build_input_batches", partition),
+            build_input_rows: MetricBuilder::new(metrics).counter("build_input_rows", partition),
+            build_input_bytes: MetricBuilder::new(metrics).counter("build_input_bytes", partition),
+            probe_input_batches: MetricBuilder::new(metrics)
+                .counter("probe_input_batches", partition),
+            probe_input_rows: MetricBuilder::new(metrics).counter("probe_input_rows", partition),
+            probe_input_bytes: MetricBuilder::new(metrics).counter("probe_input_bytes", partition),
+            join_input_bytes: MetricBuilder::new(metrics).gauge("join_input_bytes", partition),
+        }
+    }
+
+    fn record_build_input(&self, batches: &[RecordBatch]) {
+        let stats = batch_stats(batches);
+        self.build_input_batches.add(stats.batches);
+        self.build_input_rows.add(stats.rows);
+        self.build_input_bytes.add(stats.bytes);
+        self.join_input_bytes.add(stats.bytes);
+    }
+
+    fn record_probe_input(&self, batches: &[RecordBatch]) {
+        let stats = batch_stats(batches);
+        self.probe_input_batches.add(stats.batches);
+        self.probe_input_rows.add(stats.rows);
+        self.probe_input_bytes.add(stats.bytes);
+        self.join_input_bytes.add(stats.bytes);
+    }
+}
+
+struct BatchStats {
+    batches: usize,
+    rows: usize,
+    bytes: usize,
+}
+
+fn batch_stats(batches: &[RecordBatch]) -> BatchStats {
+    BatchStats {
+        batches: batches.len(),
+        rows: batches.iter().map(|b| b.num_rows()).sum(),
+        bytes: batches.iter().map(|b| b.get_array_memory_size()).sum(),
+    }
 }
 
 /// Run the cuDF join kernel and apply the output projection. Returns `None`

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -73,6 +73,34 @@ std::unique_ptr<Table> full_join_gather(
                           cudf::out_of_bounds_policy::NULLIFY);
 }
 
+HashJoin::HashJoin() = default;
+
+HashJoin::~HashJoin() = default;
+
+std::unique_ptr<HashJoin> hash_join_create(
+    const TableView& build_keys, bool nulls_equal)
+{
+    auto result = std::make_unique<HashJoin>();
+    auto compare_nulls = nulls_equal
+        ? cudf::null_equality::EQUAL
+        : cudf::null_equality::UNEQUAL;
+    result->inner = std::make_unique<cudf::hash_join>(*build_keys.inner, compare_nulls);
+    return result;
+}
+
+std::unique_ptr<Table> hash_join_inner_join_gather(
+    const HashJoin& join,
+    const TableView& probe_keys,
+    const TableView& build_payload,
+    const TableView& probe_payload)
+{
+    auto [probe_idx, build_idx] = join.inner->inner_join(*probe_keys.inner);
+    return gather_combine(std::move(build_idx), std::move(probe_idx),
+                          *build_payload.inner, *probe_payload.inner,
+                          cudf::out_of_bounds_policy::DONT_CHECK,
+                          cudf::out_of_bounds_policy::DONT_CHECK);
+}
+
 std::unique_ptr<Table> left_semi_join_gather(
     const TableView& left_keys, const TableView& right_keys,
     const TableView& left_payload)

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -93,12 +93,10 @@ HashJoin::HashJoin() = default;
 HashJoin::~HashJoin() = default;
 
 std::unique_ptr<HashJoin> hash_join_create(
-    const TableView& build_keys, bool nulls_equal)
+    const TableView& build_keys, int32_t null_equality)
 {
     auto result = std::make_unique<HashJoin>();
-    auto compare_nulls = nulls_equal
-        ? cudf::null_equality::EQUAL
-        : cudf::null_equality::UNEQUAL;
+    auto compare_nulls = static_cast<cudf::null_equality>(null_equality);
     result->inner = std::make_unique<cudf::hash_join>(*build_keys.inner, compare_nulls);
     return result;
 }

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -226,32 +226,22 @@ std::unique_ptr<Table> hash_join_unmatched_build_gather(
                                 cudf::out_of_bounds_policy::NULLIFY);
 }
 
-std::unique_ptr<Table> left_semi_join_gather(
-    const TableView& left_keys, const TableView& right_keys,
-    const TableView& left_payload)
+std::unique_ptr<Column> left_semi_join_indices(
+    const TableView& left_keys,
+    const TableView& right_keys)
 {
     cudf::filtered_join fj(*right_keys.inner, cudf::null_equality::EQUAL,
                            cudf::set_as_build_table::RIGHT, cudf::get_default_stream());
-    auto idx = fj.semi_join(*left_keys.inner);
-    auto idx_col = uvector_to_column(std::move(idx));
-    auto result = std::make_unique<Table>();
-    result->inner = cudf::gather(*left_payload.inner, idx_col->view(),
-                                 cudf::out_of_bounds_policy::DONT_CHECK);
-    return result;
+    return uvector_to_bridge_column(fj.semi_join(*left_keys.inner));
 }
 
-std::unique_ptr<Table> left_anti_join_gather(
-    const TableView& left_keys, const TableView& right_keys,
-    const TableView& left_payload)
+std::unique_ptr<Column> left_anti_join_indices(
+    const TableView& left_keys,
+    const TableView& right_keys)
 {
     cudf::filtered_join fj(*right_keys.inner, cudf::null_equality::EQUAL,
                            cudf::set_as_build_table::RIGHT, cudf::get_default_stream());
-    auto idx = fj.anti_join(*left_keys.inner);
-    auto idx_col = uvector_to_column(std::move(idx));
-    auto result = std::make_unique<Table>();
-    result->inner = cudf::gather(*left_payload.inner, idx_col->view(),
-                                 cudf::out_of_bounds_policy::DONT_CHECK);
-    return result;
+    return uvector_to_bridge_column(fj.anti_join(*left_keys.inner));
 }
 
 std::unique_ptr<Table> cross_join(const TableView& left, const TableView& right) {

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -2,9 +2,16 @@
 #include <cudf/join/join.hpp>
 #include <cudf/join/filtered_join.hpp>
 #include <cudf/column/column.hpp>
+#include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/filling.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <limits>
 
 namespace libcudf_bridge {
+
+constexpr cudf::size_type JoinNoneValue = std::numeric_limits<cudf::size_type>::min();
 
 static std::unique_ptr<cudf::column> uvector_to_column(
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> vec)
@@ -12,20 +19,55 @@ static std::unique_ptr<cudf::column> uvector_to_column(
     return std::make_unique<cudf::column>(std::move(*vec), rmm::device_buffer{}, 0);
 }
 
+static std::unique_ptr<cudf::column> sequence_column(
+    cudf::size_type size,
+    cudf::size_type init,
+    cudf::size_type step)
+{
+    auto stream = cudf::get_default_stream();
+    cudf::numeric_scalar<cudf::size_type> init_scalar(init, true, stream);
+    cudf::numeric_scalar<cudf::size_type> step_scalar(step, true, stream);
+    return cudf::sequence(size, init_scalar, step_scalar, stream);
+}
+
+static std::unique_ptr<cudf::column> unmatched_build_indices(
+    const HashJoin& join)
+{
+    // TODO(perf): This keeps one matched-index column per probe batch so the
+    // sys crate can stay on host-callable cuDF primitives. A compact device
+    // bitset would use less memory, but needs a CUDA helper or a cuDF primitive.
+    if (join.matched_build_indices.empty()) {
+        return sequence_column(join.build_rows, cudf::size_type{0}, cudf::size_type{1});
+    }
+
+    auto all_build_idx =
+        sequence_column(join.build_rows, cudf::size_type{0}, cudf::size_type{1});
+
+    std::vector<cudf::column_view> matched_views;
+    matched_views.reserve(join.matched_build_indices.size());
+    for (auto const& column : join.matched_build_indices) {
+        matched_views.push_back(column->view());
+    }
+    auto matched_idx = cudf::concatenate(matched_views);
+
+    cudf::table_view all_build_table{{all_build_idx->view()}};
+    cudf::table_view matched_table{{matched_idx->view()}};
+    cudf::filtered_join fj(matched_table, cudf::null_equality::EQUAL,
+                           cudf::set_as_build_table::RIGHT, cudf::get_default_stream());
+    return uvector_to_column(fj.anti_join(all_build_table));
+}
+
 // Gather left and right payloads with their respective maps and combine into one table.
-static std::unique_ptr<Table> gather_combine(
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_idx,
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> right_idx,
+static std::unique_ptr<Table> gather_combine_views(
+    const cudf::column_view& left_idx,
+    const cudf::column_view& right_idx,
     const cudf::table_view& left_payload,
     const cudf::table_view& right_payload,
     cudf::out_of_bounds_policy left_policy,
     cudf::out_of_bounds_policy right_policy)
 {
-    auto left_col  = uvector_to_column(std::move(left_idx));
-    auto right_col = uvector_to_column(std::move(right_idx));
-
-    auto left_result  = cudf::gather(left_payload,  left_col->view(),  left_policy);
-    auto right_result = cudf::gather(right_payload, right_col->view(), right_policy);
+    auto left_result  = cudf::gather(left_payload,  left_idx,  left_policy);
+    auto right_result = cudf::gather(right_payload, right_idx, right_policy);
 
     auto cols       = left_result->release();
     auto right_cols = right_result->release();
@@ -36,6 +78,21 @@ static std::unique_ptr<Table> gather_combine(
     auto result = std::make_unique<Table>();
     result->inner = std::make_unique<cudf::table>(std::move(cols));
     return result;
+}
+
+static std::unique_ptr<Table> gather_combine(
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_idx,
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> right_idx,
+    const cudf::table_view& left_payload,
+    const cudf::table_view& right_payload,
+    cudf::out_of_bounds_policy left_policy,
+    cudf::out_of_bounds_policy right_policy)
+{
+    auto left_col  = uvector_to_column(std::move(left_idx));
+    auto right_col = uvector_to_column(std::move(right_idx));
+    return gather_combine_views(left_col->view(), right_col->view(),
+                                left_payload, right_payload,
+                                left_policy, right_policy);
 }
 
 std::unique_ptr<Table> inner_join_gather(
@@ -85,6 +142,7 @@ std::unique_ptr<HashJoin> hash_join_create(
         ? cudf::null_equality::EQUAL
         : cudf::null_equality::UNEQUAL;
     result->inner = std::make_unique<cudf::hash_join>(*build_keys.inner, compare_nulls);
+    result->build_rows = build_keys.inner->num_rows();
     return result;
 }
 
@@ -99,6 +157,54 @@ std::unique_ptr<Table> hash_join_inner_join_gather(
                           *build_payload.inner, *probe_payload.inner,
                           cudf::out_of_bounds_policy::DONT_CHECK,
                           cudf::out_of_bounds_policy::DONT_CHECK);
+}
+
+std::unique_ptr<Table> hash_join_inner_join_gather_and_mark(
+    HashJoin& join,
+    const TableView& probe_keys,
+    const TableView& build_payload,
+    const TableView& probe_payload)
+{
+    auto [probe_idx, build_idx] = join.inner->inner_join(*probe_keys.inner);
+    auto build_col = uvector_to_column(std::move(build_idx));
+    auto probe_col = uvector_to_column(std::move(probe_idx));
+    auto result = gather_combine_views(build_col->view(), probe_col->view(),
+                                       *build_payload.inner, *probe_payload.inner,
+                                       cudf::out_of_bounds_policy::DONT_CHECK,
+                                       cudf::out_of_bounds_policy::DONT_CHECK);
+    join.matched_build_indices.push_back(std::move(build_col));
+    return result;
+}
+
+std::unique_ptr<Table> hash_join_probe_left_join_gather_and_mark(
+    HashJoin& join,
+    const TableView& probe_keys,
+    const TableView& build_payload,
+    const TableView& probe_payload)
+{
+    auto [probe_idx, build_idx] = join.inner->left_join(*probe_keys.inner);
+    auto build_col = uvector_to_column(std::move(build_idx));
+    auto probe_col = uvector_to_column(std::move(probe_idx));
+    auto result = gather_combine_views(build_col->view(), probe_col->view(),
+                                       *build_payload.inner, *probe_payload.inner,
+                                       cudf::out_of_bounds_policy::NULLIFY,
+                                       cudf::out_of_bounds_policy::DONT_CHECK);
+    join.matched_build_indices.push_back(std::move(build_col));
+    return result;
+}
+
+std::unique_ptr<Table> hash_join_unmatched_build_gather(
+    const HashJoin& join,
+    const TableView& build_payload,
+    const TableView& probe_payload)
+{
+    auto unmatched = unmatched_build_indices(join);
+    auto null_probe_idx =
+        sequence_column(unmatched->size(), JoinNoneValue, cudf::size_type{0});
+    return gather_combine_views(unmatched->view(), null_probe_idx->view(),
+                                *build_payload.inner, *probe_payload.inner,
+                                cudf::out_of_bounds_policy::DONT_CHECK,
+                                cudf::out_of_bounds_policy::NULLIFY);
 }
 
 std::unique_ptr<Table> left_semi_join_gather(

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -19,6 +19,24 @@ static std::unique_ptr<cudf::column> uvector_to_column(
     return std::make_unique<cudf::column>(std::move(*vec), rmm::device_buffer{}, 0);
 }
 
+static std::unique_ptr<Column> uvector_to_bridge_column(
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> vec)
+{
+    auto result = std::make_unique<Column>();
+    result->inner = uvector_to_column(std::move(vec));
+    return result;
+}
+
+static std::unique_ptr<JoinIndices> make_join_indices(
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_idx,
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> right_idx)
+{
+    auto result = std::make_unique<JoinIndices>();
+    result->left = uvector_to_bridge_column(std::move(left_idx));
+    result->right = uvector_to_bridge_column(std::move(right_idx));
+    return result;
+}
+
 static std::unique_ptr<cudf::column> sequence_column(
     cudf::size_type size,
     cudf::size_type init,
@@ -93,6 +111,26 @@ static std::unique_ptr<Table> gather_combine(
     return gather_combine_views(left_col->view(), right_col->view(),
                                 left_payload, right_payload,
                                 left_policy, right_policy);
+}
+
+JoinIndices::JoinIndices() = default;
+
+JoinIndices::~JoinIndices() = default;
+
+std::unique_ptr<Column> JoinIndices::release_left() {
+    return std::move(left);
+}
+
+std::unique_ptr<Column> JoinIndices::release_right() {
+    return std::move(right);
+}
+
+std::unique_ptr<JoinIndices> inner_join_indices(
+    const TableView& left_keys,
+    const TableView& right_keys)
+{
+    auto [left_idx, right_idx] = cudf::inner_join(*left_keys.inner, *right_keys.inner);
+    return make_join_indices(std::move(left_idx), std::move(right_idx));
 }
 
 std::unique_ptr<Table> inner_join_gather(

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -133,39 +133,20 @@ std::unique_ptr<JoinIndices> inner_join_indices(
     return make_join_indices(std::move(left_idx), std::move(right_idx));
 }
 
-std::unique_ptr<Table> inner_join_gather(
-    const TableView& left_keys,  const TableView& right_keys,
-    const TableView& left_payload, const TableView& right_payload)
-{
-    auto [left_idx, right_idx] = cudf::inner_join(*left_keys.inner, *right_keys.inner);
-    return gather_combine(std::move(left_idx), std::move(right_idx),
-                          *left_payload.inner, *right_payload.inner,
-                          cudf::out_of_bounds_policy::DONT_CHECK,
-                          cudf::out_of_bounds_policy::DONT_CHECK);
-}
-
-std::unique_ptr<Table> left_join_gather(
-    const TableView& left_keys,  const TableView& right_keys,
-    const TableView& left_payload, const TableView& right_payload)
+std::unique_ptr<JoinIndices> left_join_indices(
+    const TableView& left_keys,
+    const TableView& right_keys)
 {
     auto [left_idx, right_idx] = cudf::left_join(*left_keys.inner, *right_keys.inner);
-    // Left map never contains sentinels (all left rows appear), right map uses INT32_MIN
-    // for unmatched rows which NULLIFY converts to null output rows.
-    return gather_combine(std::move(left_idx), std::move(right_idx),
-                          *left_payload.inner, *right_payload.inner,
-                          cudf::out_of_bounds_policy::DONT_CHECK,
-                          cudf::out_of_bounds_policy::NULLIFY);
+    return make_join_indices(std::move(left_idx), std::move(right_idx));
 }
 
-std::unique_ptr<Table> full_join_gather(
-    const TableView& left_keys,  const TableView& right_keys,
-    const TableView& left_payload, const TableView& right_payload)
+std::unique_ptr<JoinIndices> full_join_indices(
+    const TableView& left_keys,
+    const TableView& right_keys)
 {
     auto [left_idx, right_idx] = cudf::full_join(*left_keys.inner, *right_keys.inner);
-    return gather_combine(std::move(left_idx), std::move(right_idx),
-                          *left_payload.inner, *right_payload.inner,
-                          cudf::out_of_bounds_policy::NULLIFY,
-                          cudf::out_of_bounds_policy::NULLIFY);
+    return make_join_indices(std::move(left_idx), std::move(right_idx));
 }
 
 HashJoin::HashJoin() = default;

--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -2,16 +2,9 @@
 #include <cudf/join/join.hpp>
 #include <cudf/join/filtered_join.hpp>
 #include <cudf/column/column.hpp>
-#include <cudf/concatenate.hpp>
-#include <cudf/copying.hpp>
-#include <cudf/filling.hpp>
-#include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
-#include <limits>
 
 namespace libcudf_bridge {
-
-constexpr cudf::size_type JoinNoneValue = std::numeric_limits<cudf::size_type>::min();
 
 static std::unique_ptr<cudf::column> uvector_to_column(
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> vec)
@@ -37,82 +30,6 @@ static std::unique_ptr<JoinIndices> make_join_indices(
     return result;
 }
 
-static std::unique_ptr<cudf::column> sequence_column(
-    cudf::size_type size,
-    cudf::size_type init,
-    cudf::size_type step)
-{
-    auto stream = cudf::get_default_stream();
-    cudf::numeric_scalar<cudf::size_type> init_scalar(init, true, stream);
-    cudf::numeric_scalar<cudf::size_type> step_scalar(step, true, stream);
-    return cudf::sequence(size, init_scalar, step_scalar, stream);
-}
-
-static std::unique_ptr<cudf::column> unmatched_build_indices(
-    const HashJoin& join)
-{
-    // TODO(perf): This keeps one matched-index column per probe batch so the
-    // sys crate can stay on host-callable cuDF primitives. A compact device
-    // bitset would use less memory, but needs a CUDA helper or a cuDF primitive.
-    if (join.matched_build_indices.empty()) {
-        return sequence_column(join.build_rows, cudf::size_type{0}, cudf::size_type{1});
-    }
-
-    auto all_build_idx =
-        sequence_column(join.build_rows, cudf::size_type{0}, cudf::size_type{1});
-
-    std::vector<cudf::column_view> matched_views;
-    matched_views.reserve(join.matched_build_indices.size());
-    for (auto const& column : join.matched_build_indices) {
-        matched_views.push_back(column->view());
-    }
-    auto matched_idx = cudf::concatenate(matched_views);
-
-    cudf::table_view all_build_table{{all_build_idx->view()}};
-    cudf::table_view matched_table{{matched_idx->view()}};
-    cudf::filtered_join fj(matched_table, cudf::null_equality::EQUAL,
-                           cudf::set_as_build_table::RIGHT, cudf::get_default_stream());
-    return uvector_to_column(fj.anti_join(all_build_table));
-}
-
-// Gather left and right payloads with their respective maps and combine into one table.
-static std::unique_ptr<Table> gather_combine_views(
-    const cudf::column_view& left_idx,
-    const cudf::column_view& right_idx,
-    const cudf::table_view& left_payload,
-    const cudf::table_view& right_payload,
-    cudf::out_of_bounds_policy left_policy,
-    cudf::out_of_bounds_policy right_policy)
-{
-    auto left_result  = cudf::gather(left_payload,  left_idx,  left_policy);
-    auto right_result = cudf::gather(right_payload, right_idx, right_policy);
-
-    auto cols       = left_result->release();
-    auto right_cols = right_result->release();
-    cols.insert(cols.end(),
-        std::make_move_iterator(right_cols.begin()),
-        std::make_move_iterator(right_cols.end()));
-
-    auto result = std::make_unique<Table>();
-    result->inner = std::make_unique<cudf::table>(std::move(cols));
-    return result;
-}
-
-static std::unique_ptr<Table> gather_combine(
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_idx,
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> right_idx,
-    const cudf::table_view& left_payload,
-    const cudf::table_view& right_payload,
-    cudf::out_of_bounds_policy left_policy,
-    cudf::out_of_bounds_policy right_policy)
-{
-    auto left_col  = uvector_to_column(std::move(left_idx));
-    auto right_col = uvector_to_column(std::move(right_idx));
-    return gather_combine_views(left_col->view(), right_col->view(),
-                                left_payload, right_payload,
-                                left_policy, right_policy);
-}
-
 JoinIndices::JoinIndices() = default;
 
 JoinIndices::~JoinIndices() = default;
@@ -123,6 +40,28 @@ std::unique_ptr<Column> JoinIndices::release_left() {
 
 std::unique_ptr<Column> JoinIndices::release_right() {
     return std::move(right);
+}
+
+HashJoinIndices::HashJoinIndices() = default;
+
+HashJoinIndices::~HashJoinIndices() = default;
+
+std::unique_ptr<Column> HashJoinIndices::release_probe() {
+    return std::move(probe);
+}
+
+std::unique_ptr<Column> HashJoinIndices::release_build() {
+    return std::move(build);
+}
+
+static std::unique_ptr<HashJoinIndices> make_hash_join_indices(
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> probe_idx,
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> build_idx)
+{
+    auto result = std::make_unique<HashJoinIndices>();
+    result->probe = uvector_to_bridge_column(std::move(probe_idx));
+    result->build = uvector_to_bridge_column(std::move(build_idx));
+    return result;
 }
 
 std::unique_ptr<JoinIndices> inner_join_indices(
@@ -161,69 +100,23 @@ std::unique_ptr<HashJoin> hash_join_create(
         ? cudf::null_equality::EQUAL
         : cudf::null_equality::UNEQUAL;
     result->inner = std::make_unique<cudf::hash_join>(*build_keys.inner, compare_nulls);
-    result->build_rows = build_keys.inner->num_rows();
     return result;
 }
 
-std::unique_ptr<Table> hash_join_inner_join_gather(
+std::unique_ptr<HashJoinIndices> hash_join_inner_join_indices(
     const HashJoin& join,
-    const TableView& probe_keys,
-    const TableView& build_payload,
-    const TableView& probe_payload)
+    const TableView& probe_keys)
 {
     auto [probe_idx, build_idx] = join.inner->inner_join(*probe_keys.inner);
-    return gather_combine(std::move(build_idx), std::move(probe_idx),
-                          *build_payload.inner, *probe_payload.inner,
-                          cudf::out_of_bounds_policy::DONT_CHECK,
-                          cudf::out_of_bounds_policy::DONT_CHECK);
+    return make_hash_join_indices(std::move(probe_idx), std::move(build_idx));
 }
 
-std::unique_ptr<Table> hash_join_inner_join_gather_and_mark(
-    HashJoin& join,
-    const TableView& probe_keys,
-    const TableView& build_payload,
-    const TableView& probe_payload)
-{
-    auto [probe_idx, build_idx] = join.inner->inner_join(*probe_keys.inner);
-    auto build_col = uvector_to_column(std::move(build_idx));
-    auto probe_col = uvector_to_column(std::move(probe_idx));
-    auto result = gather_combine_views(build_col->view(), probe_col->view(),
-                                       *build_payload.inner, *probe_payload.inner,
-                                       cudf::out_of_bounds_policy::DONT_CHECK,
-                                       cudf::out_of_bounds_policy::DONT_CHECK);
-    join.matched_build_indices.push_back(std::move(build_col));
-    return result;
-}
-
-std::unique_ptr<Table> hash_join_probe_left_join_gather_and_mark(
-    HashJoin& join,
-    const TableView& probe_keys,
-    const TableView& build_payload,
-    const TableView& probe_payload)
+std::unique_ptr<HashJoinIndices> hash_join_left_join_indices(
+    const HashJoin& join,
+    const TableView& probe_keys)
 {
     auto [probe_idx, build_idx] = join.inner->left_join(*probe_keys.inner);
-    auto build_col = uvector_to_column(std::move(build_idx));
-    auto probe_col = uvector_to_column(std::move(probe_idx));
-    auto result = gather_combine_views(build_col->view(), probe_col->view(),
-                                       *build_payload.inner, *probe_payload.inner,
-                                       cudf::out_of_bounds_policy::NULLIFY,
-                                       cudf::out_of_bounds_policy::DONT_CHECK);
-    join.matched_build_indices.push_back(std::move(build_col));
-    return result;
-}
-
-std::unique_ptr<Table> hash_join_unmatched_build_gather(
-    const HashJoin& join,
-    const TableView& build_payload,
-    const TableView& probe_payload)
-{
-    auto unmatched = unmatched_build_indices(join);
-    auto null_probe_idx =
-        sequence_column(unmatched->size(), JoinNoneValue, cudf::size_type{0});
-    return gather_combine_views(unmatched->view(), null_probe_idx->view(),
-                                *build_payload.inner, *probe_payload.inner,
-                                cudf::out_of_bounds_policy::DONT_CHECK,
-                                cudf::out_of_bounds_policy::NULLIFY);
+    return make_hash_join_indices(std::move(probe_idx), std::move(build_idx));
 }
 
 std::unique_ptr<Column> left_semi_join_indices(

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <cstdint>
 #include "rust/cxx.h"
 #include "table.h"
 #include "column.h"
@@ -44,7 +45,7 @@ namespace libcudf_bridge {
     };
 
     std::unique_ptr<HashJoin> hash_join_create(
-        const TableView& build_keys, bool nulls_equal);
+        const TableView& build_keys, int32_t null_equality);
 
     std::unique_ptr<HashJoinIndices> hash_join_inner_join_indices(
         const HashJoin& join,

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -4,8 +4,26 @@
 #include "rust/cxx.h"
 #include "table.h"
 #include "column.h"
+#include <cudf/join/hash_join.hpp>
 
 namespace libcudf_bridge {
+    struct HashJoin {
+        std::unique_ptr<cudf::hash_join> inner;
+
+        HashJoin();
+
+        ~HashJoin();
+    };
+
+    std::unique_ptr<HashJoin> hash_join_create(
+        const TableView& build_keys, bool nulls_equal);
+
+    std::unique_ptr<Table> hash_join_inner_join_gather(
+        const HashJoin& join,
+        const TableView& probe_keys,
+        const TableView& build_payload,
+        const TableView& probe_payload);
+
     std::unique_ptr<Table> inner_join_gather(
         const TableView& left_keys,  const TableView& right_keys,
         const TableView& left_payload, const TableView& right_payload);

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -5,10 +5,14 @@
 #include "table.h"
 #include "column.h"
 #include <cudf/join/hash_join.hpp>
+#include <cudf/column/column.hpp>
+#include <vector>
 
 namespace libcudf_bridge {
     struct HashJoin {
         std::unique_ptr<cudf::hash_join> inner;
+        cudf::size_type build_rows = 0;
+        std::vector<std::unique_ptr<cudf::column>> matched_build_indices;
 
         HashJoin();
 
@@ -21,6 +25,23 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> hash_join_inner_join_gather(
         const HashJoin& join,
         const TableView& probe_keys,
+        const TableView& build_payload,
+        const TableView& probe_payload);
+
+    std::unique_ptr<Table> hash_join_inner_join_gather_and_mark(
+        HashJoin& join,
+        const TableView& probe_keys,
+        const TableView& build_payload,
+        const TableView& probe_payload);
+
+    std::unique_ptr<Table> hash_join_probe_left_join_gather_and_mark(
+        HashJoin& join,
+        const TableView& probe_keys,
+        const TableView& build_payload,
+        const TableView& probe_payload);
+
+    std::unique_ptr<Table> hash_join_unmatched_build_gather(
+        const HashJoin& join,
         const TableView& build_payload,
         const TableView& probe_payload);
 

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -70,13 +70,13 @@ namespace libcudf_bridge {
         const TableView& left_keys,
         const TableView& right_keys);
 
-    std::unique_ptr<Table> left_semi_join_gather(
-        const TableView& left_keys, const TableView& right_keys,
-        const TableView& left_payload);
+    std::unique_ptr<Column> left_semi_join_indices(
+        const TableView& left_keys,
+        const TableView& right_keys);
 
-    std::unique_ptr<Table> left_anti_join_gather(
-        const TableView& left_keys, const TableView& right_keys,
-        const TableView& left_payload);
+    std::unique_ptr<Column> left_anti_join_indices(
+        const TableView& left_keys,
+        const TableView& right_keys);
 
     std::unique_ptr<Table> cross_join(const TableView& left, const TableView& right);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -9,6 +9,19 @@
 #include <vector>
 
 namespace libcudf_bridge {
+    struct JoinIndices {
+        std::unique_ptr<Column> left;
+        std::unique_ptr<Column> right;
+
+        JoinIndices();
+
+        ~JoinIndices();
+
+        std::unique_ptr<Column> release_left();
+
+        std::unique_ptr<Column> release_right();
+    };
+
     struct HashJoin {
         std::unique_ptr<cudf::hash_join> inner;
         cudf::size_type build_rows = 0;
@@ -44,6 +57,10 @@ namespace libcudf_bridge {
         const HashJoin& join,
         const TableView& build_payload,
         const TableView& probe_payload);
+
+    std::unique_ptr<JoinIndices> inner_join_indices(
+        const TableView& left_keys,
+        const TableView& right_keys);
 
     std::unique_ptr<Table> inner_join_gather(
         const TableView& left_keys,  const TableView& right_keys,

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -22,10 +22,21 @@ namespace libcudf_bridge {
         std::unique_ptr<Column> release_right();
     };
 
+    struct HashJoinIndices {
+        std::unique_ptr<Column> probe;
+        std::unique_ptr<Column> build;
+
+        HashJoinIndices();
+
+        ~HashJoinIndices();
+
+        std::unique_ptr<Column> release_probe();
+
+        std::unique_ptr<Column> release_build();
+    };
+
     struct HashJoin {
         std::unique_ptr<cudf::hash_join> inner;
-        cudf::size_type build_rows = 0;
-        std::vector<std::unique_ptr<cudf::column>> matched_build_indices;
 
         HashJoin();
 
@@ -35,28 +46,13 @@ namespace libcudf_bridge {
     std::unique_ptr<HashJoin> hash_join_create(
         const TableView& build_keys, bool nulls_equal);
 
-    std::unique_ptr<Table> hash_join_inner_join_gather(
+    std::unique_ptr<HashJoinIndices> hash_join_inner_join_indices(
         const HashJoin& join,
-        const TableView& probe_keys,
-        const TableView& build_payload,
-        const TableView& probe_payload);
+        const TableView& probe_keys);
 
-    std::unique_ptr<Table> hash_join_inner_join_gather_and_mark(
-        HashJoin& join,
-        const TableView& probe_keys,
-        const TableView& build_payload,
-        const TableView& probe_payload);
-
-    std::unique_ptr<Table> hash_join_probe_left_join_gather_and_mark(
-        HashJoin& join,
-        const TableView& probe_keys,
-        const TableView& build_payload,
-        const TableView& probe_payload);
-
-    std::unique_ptr<Table> hash_join_unmatched_build_gather(
+    std::unique_ptr<HashJoinIndices> hash_join_left_join_indices(
         const HashJoin& join,
-        const TableView& build_payload,
-        const TableView& probe_payload);
+        const TableView& probe_keys);
 
     std::unique_ptr<JoinIndices> inner_join_indices(
         const TableView& left_keys,

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -62,17 +62,13 @@ namespace libcudf_bridge {
         const TableView& left_keys,
         const TableView& right_keys);
 
-    std::unique_ptr<Table> inner_join_gather(
-        const TableView& left_keys,  const TableView& right_keys,
-        const TableView& left_payload, const TableView& right_payload);
+    std::unique_ptr<JoinIndices> left_join_indices(
+        const TableView& left_keys,
+        const TableView& right_keys);
 
-    std::unique_ptr<Table> left_join_gather(
-        const TableView& left_keys,  const TableView& right_keys,
-        const TableView& left_payload, const TableView& right_payload);
-
-    std::unique_ptr<Table> full_join_gather(
-        const TableView& left_keys,  const TableView& right_keys,
-        const TableView& left_payload, const TableView& right_payload);
+    std::unique_ptr<JoinIndices> full_join_indices(
+        const TableView& left_keys,
+        const TableView& right_keys);
 
     std::unique_ptr<Table> left_semi_join_gather(
         const TableView& left_keys, const TableView& right_keys,

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -84,6 +84,11 @@ pub mod ffi {
         /// various aggregations on value columns based on those keys.
         type GroupBy;
 
+        /// Reusable cuDF hash join object.
+        ///
+        /// Builds a hash table once and probes it with subsequent join calls.
+        type HashJoin;
+
         /// Opaque owning wrapper for an RMM CUDA stream.
         type CudaStream;
 
@@ -449,6 +454,20 @@ pub mod ffi {
         ) -> Result<UniquePtr<Table>>;
 
         // Join operations.
+
+        /// Create a reusable hash join object from build-side keys.
+        fn hash_join_create(
+            build_keys: &TableView,
+            nulls_equal: bool,
+        ) -> Result<UniquePtr<HashJoin>>;
+
+        /// Probe a reusable hash join object and gather matching payload rows.
+        fn hash_join_inner_join_gather(
+            join: &HashJoin,
+            probe_keys: &TableView,
+            build_payload: &TableView,
+            probe_payload: &TableView,
+        ) -> Result<UniquePtr<Table>>;
 
         /// Inner join: gather matching rows from both payloads into one output table.
         fn inner_join_gather(
@@ -992,6 +1011,12 @@ unsafe impl Send for ffi::GroupBy {}
 
 /// SAFETY: GroupBy configuration can be accessed from multiple threads.
 unsafe impl Sync for ffi::GroupBy {}
+
+/// SAFETY: cuDF hash_join supports repeated probe calls after construction.
+unsafe impl Send for ffi::HashJoin {}
+
+/// SAFETY: cuDF hash_join probe methods take shared references and are safe to share.
+unsafe impl Sync for ffi::HashJoin {}
 
 /// SAFETY: AggregationRequest configuration can be sent between threads.
 unsafe impl Send for ffi::AggregationRequest {}

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -328,6 +328,9 @@ pub mod ffi {
         /// Create a table from vertically concatenating ColumnView together
         fn concat_column_views(views: &[UniquePtr<ColumnView>]) -> Result<UniquePtr<Column>>;
 
+        /// Create a column by repeating a scalar value.
+        fn make_column_from_scalar(scalar: &Scalar, size: usize) -> Result<UniquePtr<Column>>;
+
         /// Fill a column with a sequence starting at `init` and stepping by `step`.
         fn sequence(size: usize, init: &Scalar, step: &Scalar) -> Result<UniquePtr<Column>>;
 
@@ -367,6 +370,22 @@ pub mod ffi {
             source_table: &TableView,
             gather_map: &ColumnView,
             out_of_bounds_policy: i32,
+        ) -> Result<UniquePtr<Table>>;
+
+        /// Scatter scalar rows into a copy of a target table.
+        fn scatter_scalars(
+            source: &[*const Scalar],
+            indices: &ColumnView,
+            target: &TableView,
+        ) -> Result<UniquePtr<Table>>;
+
+        /// Create a table without duplicate rows.
+        fn distinct(
+            input: &TableView,
+            keys: &[i32],
+            keep: i32,
+            nulls_equal: i32,
+            nans_equal: i32,
         ) -> Result<UniquePtr<Table>>;
 
         /// Create a sliced view of a column
@@ -741,6 +760,30 @@ pub enum NullEquality {
     Equal = 0,
     /// Null values do not compare equal.
     Unequal = 1,
+}
+
+/// NaN comparison policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum NanEquality {
+    /// All NaN values compare equal.
+    AllEqual = 0,
+    /// NaN values do not compare equal.
+    Unequal = 1,
+}
+
+/// Duplicate row retention policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum DuplicateKeepOption {
+    /// Keep an unspecified duplicate occurrence.
+    KeepAny = 0,
+    /// Keep the first duplicate occurrence.
+    KeepFirst = 1,
+    /// Keep the last duplicate occurrence.
+    KeepLast = 2,
+    /// Remove all duplicate occurrences.
+    KeepNone = 3,
 }
 
 /// Binary operators supported by cuDF

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -486,7 +486,7 @@ pub mod ffi {
         /// Create a reusable hash join object from build-side keys.
         fn hash_join_create(
             build_keys: &TableView,
-            nulls_equal: bool,
+            null_equality: i32,
         ) -> Result<UniquePtr<HashJoin>>;
 
         /// Probe a reusable hash join object and return probe/build row indices.
@@ -731,6 +731,16 @@ pub enum OutOfBoundsPolicy {
     Nullify = 0,
     /// Do not check bounds.
     DontCheck = 1,
+}
+
+/// Null comparison policy for join keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum NullEquality {
+    /// Null values compare equal.
+    Equal = 0,
+    /// Null values do not compare equal.
+    Unequal = 1,
 }
 
 /// Binary operators supported by cuDF

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -1035,11 +1035,8 @@ unsafe impl Send for ffi::GroupBy {}
 /// SAFETY: GroupBy configuration can be accessed from multiple threads.
 unsafe impl Sync for ffi::GroupBy {}
 
-/// SAFETY: cuDF hash_join supports repeated probe calls after construction.
+/// SAFETY: HashJoin owns its cuDF state and is only moved across threads.
 unsafe impl Send for ffi::HashJoin {}
-
-/// SAFETY: cuDF hash_join probe methods take shared references and are safe to share.
-unsafe impl Sync for ffi::HashJoin {}
 
 /// SAFETY: AggregationRequest configuration can be sent between threads.
 unsafe impl Send for ffi::AggregationRequest {}

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -469,6 +469,29 @@ pub mod ffi {
             probe_payload: &TableView,
         ) -> Result<UniquePtr<Table>>;
 
+        /// Probe a reusable hash join object, record matched build rows, and gather inner rows.
+        fn hash_join_inner_join_gather_and_mark(
+            join: Pin<&mut HashJoin>,
+            probe_keys: &TableView,
+            build_payload: &TableView,
+            probe_payload: &TableView,
+        ) -> Result<UniquePtr<Table>>;
+
+        /// Probe a reusable hash join object preserving probe rows, recording matched build rows.
+        fn hash_join_probe_left_join_gather_and_mark(
+            join: Pin<&mut HashJoin>,
+            probe_keys: &TableView,
+            build_payload: &TableView,
+            probe_payload: &TableView,
+        ) -> Result<UniquePtr<Table>>;
+
+        /// Gather build rows that did not match any previous marked probe.
+        fn hash_join_unmatched_build_gather(
+            join: &HashJoin,
+            build_payload: &TableView,
+            probe_payload: &TableView,
+        ) -> Result<UniquePtr<Table>>;
+
         /// Inner join: gather matching rows from both payloads into one output table.
         fn inner_join_gather(
             left_keys: &TableView,

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -98,6 +98,15 @@ pub mod ffi {
         /// Take the right input indices from this join result.
         fn release_right(self: Pin<&mut JoinIndices>) -> UniquePtr<Column>;
 
+        /// Pair of reusable hash-join probe/build index maps.
+        type HashJoinIndices;
+
+        /// Take the probe-side indices from this reusable hash join result.
+        fn release_probe(self: Pin<&mut HashJoinIndices>) -> UniquePtr<Column>;
+
+        /// Take the build-side indices from this reusable hash join result.
+        fn release_build(self: Pin<&mut HashJoinIndices>) -> UniquePtr<Column>;
+
         /// Opaque owning wrapper for an RMM CUDA stream.
         type CudaStream;
 
@@ -319,6 +328,9 @@ pub mod ffi {
         /// Create a table from vertically concatenating ColumnView together
         fn concat_column_views(views: &[UniquePtr<ColumnView>]) -> Result<UniquePtr<Column>>;
 
+        /// Fill a column with a sequence starting at `init` and stepping by `step`.
+        fn sequence(size: usize, init: &Scalar, step: &Scalar) -> Result<UniquePtr<Column>>;
+
         /// Create a TableView from a set of ColumnView pointers (non-owning)
         fn create_table_view_from_column_views(
             column_views: &[*const ColumnView],
@@ -477,36 +489,17 @@ pub mod ffi {
             nulls_equal: bool,
         ) -> Result<UniquePtr<HashJoin>>;
 
-        /// Probe a reusable hash join object and gather matching payload rows.
-        fn hash_join_inner_join_gather(
+        /// Probe a reusable hash join object and return probe/build row indices.
+        fn hash_join_inner_join_indices(
             join: &HashJoin,
             probe_keys: &TableView,
-            build_payload: &TableView,
-            probe_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
+        ) -> Result<UniquePtr<HashJoinIndices>>;
 
-        /// Probe a reusable hash join object, record matched build rows, and gather inner rows.
-        fn hash_join_inner_join_gather_and_mark(
-            join: Pin<&mut HashJoin>,
-            probe_keys: &TableView,
-            build_payload: &TableView,
-            probe_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
-
-        /// Probe a reusable hash join object preserving probe rows, recording matched build rows.
-        fn hash_join_probe_left_join_gather_and_mark(
-            join: Pin<&mut HashJoin>,
-            probe_keys: &TableView,
-            build_payload: &TableView,
-            probe_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
-
-        /// Gather build rows that did not match any previous marked probe.
-        fn hash_join_unmatched_build_gather(
+        /// Probe a reusable hash join object preserving probe rows.
+        fn hash_join_left_join_indices(
             join: &HashJoin,
-            build_payload: &TableView,
-            probe_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
+            probe_keys: &TableView,
+        ) -> Result<UniquePtr<HashJoinIndices>>;
 
         /// Inner join: return row index maps for the matching rows.
         fn inner_join_indices(

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -350,6 +350,13 @@ pub mod ffi {
         /// The resulting table will have the same number of rows as `gather_map` has elements.
         fn gather(source_table: &TableView, gather_map: &ColumnView) -> Result<UniquePtr<Table>>;
 
+        /// Gather rows from a table using an explicit out-of-bounds policy.
+        fn gather_with_policy(
+            source_table: &TableView,
+            gather_map: &ColumnView,
+            out_of_bounds_policy: i32,
+        ) -> Result<UniquePtr<Table>>;
+
         /// Create a sliced view of a column
         ///
         /// Returns a new column view that is a slice of the input column from `offset` to `offset + length`.
@@ -507,29 +514,17 @@ pub mod ffi {
             right_keys: &TableView,
         ) -> Result<UniquePtr<JoinIndices>>;
 
-        /// Inner join: gather matching rows from both payloads into one output table.
-        fn inner_join_gather(
+        /// Left join: return row index maps for the output rows.
+        fn left_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
-            left_payload: &TableView,
-            right_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
+        ) -> Result<UniquePtr<JoinIndices>>;
 
-        /// Left outer join: all left rows appear; unmatched right columns are null.
-        fn left_join_gather(
+        /// Full join: return row index maps for the output rows.
+        fn full_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
-            left_payload: &TableView,
-            right_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
-
-        /// Full outer join: all rows from both sides; unmatched columns on either side are null.
-        fn full_join_gather(
-            left_keys: &TableView,
-            right_keys: &TableView,
-            left_payload: &TableView,
-            right_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
+        ) -> Result<UniquePtr<JoinIndices>>;
 
         /// Left semi join: gather only matching left rows (no right columns in output).
         fn left_semi_join_gather(
@@ -735,6 +730,16 @@ pub enum NullOrder {
     After = 0,
     /// Nulls appear before all other values
     Before = 1,
+}
+
+/// Policy for out-of-bounds gather indices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum OutOfBoundsPolicy {
+    /// Out-of-bounds rows become null rows.
+    Nullify = 0,
+    /// Do not check bounds.
+    DontCheck = 1,
 }
 
 /// Binary operators supported by cuDF

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -89,6 +89,15 @@ pub mod ffi {
         /// Builds a hash table once and probes it with subsequent join calls.
         type HashJoin;
 
+        /// Pair of cuDF join index maps.
+        type JoinIndices;
+
+        /// Take the left input indices from this join result.
+        fn release_left(self: Pin<&mut JoinIndices>) -> UniquePtr<Column>;
+
+        /// Take the right input indices from this join result.
+        fn release_right(self: Pin<&mut JoinIndices>) -> UniquePtr<Column>;
+
         /// Opaque owning wrapper for an RMM CUDA stream.
         type CudaStream;
 
@@ -491,6 +500,12 @@ pub mod ffi {
             build_payload: &TableView,
             probe_payload: &TableView,
         ) -> Result<UniquePtr<Table>>;
+
+        /// Inner join: return row index maps for the matching rows.
+        fn inner_join_indices(
+            left_keys: &TableView,
+            right_keys: &TableView,
+        ) -> Result<UniquePtr<JoinIndices>>;
 
         /// Inner join: gather matching rows from both payloads into one output table.
         fn inner_join_gather(

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -526,19 +526,17 @@ pub mod ffi {
             right_keys: &TableView,
         ) -> Result<UniquePtr<JoinIndices>>;
 
-        /// Left semi join: gather only matching left rows (no right columns in output).
-        fn left_semi_join_gather(
+        /// Left semi join: return row indices for matching left rows.
+        fn left_semi_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
-            left_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
+        ) -> Result<UniquePtr<Column>>;
 
-        /// Left anti join: gather only non-matching left rows (no right columns in output).
-        fn left_anti_join_gather(
+        /// Left anti join: return row indices for non-matching left rows.
+        fn left_anti_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
-            left_payload: &TableView,
-        ) -> Result<UniquePtr<Table>>;
+        ) -> Result<UniquePtr<Column>>;
 
         /// Cross join: returns a full Cartesian product table
         fn cross_join(left: &TableView, right: &TableView) -> Result<UniquePtr<Table>>;

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -3,6 +3,7 @@
 
 #include <cudf/table/table.hpp>
 #include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
@@ -19,6 +20,7 @@
 
 #include <nanoarrow/nanoarrow.h>
 
+#include <functional>
 #include <limits>
 #include <sstream>
 
@@ -73,6 +75,18 @@ namespace libcudf_bridge {
         return table;
     }
 
+    std::unique_ptr<Column> make_column_from_scalar(const Scalar &scalar, size_t size) {
+        if (size > static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
+            throw std::out_of_range("column size exceeds cudf::size_type");
+        }
+
+        auto result = std::make_unique<Column>();
+        result->inner = cudf::make_column_from_scalar(
+            *scalar.inner,
+            static_cast<cudf::size_type>(size));
+        return result;
+    }
+
     std::unique_ptr<Column> sequence(size_t size, const Scalar &init, const Scalar &step) {
         if (size > static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
             throw std::out_of_range("sequence size exceeds cudf::size_type");
@@ -111,6 +125,43 @@ namespace libcudf_bridge {
             *gather_map.inner,
             static_cast<cudf::out_of_bounds_policy>(out_of_bounds_policy)
         );
+        return result;
+    }
+
+    std::unique_ptr<Table> scatter_scalars(
+        rust::Slice<const Scalar *const> source,
+        const ColumnView &indices,
+        const TableView &target) {
+        std::vector<std::reference_wrapper<cudf::scalar const>> scalars;
+        scalars.reserve(source.size());
+        for (auto *scalar: source) {
+            scalars.emplace_back(*scalar->inner);
+        }
+
+        auto result = std::make_unique<Table>();
+        result->inner = cudf::scatter(scalars, *indices.inner, *target.inner);
+        return result;
+    }
+
+    std::unique_ptr<Table> distinct(
+        const TableView &input,
+        rust::Slice<const int32_t> keys,
+        int32_t keep,
+        int32_t nulls_equal,
+        int32_t nans_equal) {
+        std::vector<cudf::size_type> key_indices;
+        key_indices.reserve(keys.size());
+        for (auto key: keys) {
+            key_indices.push_back(static_cast<cudf::size_type>(key));
+        }
+
+        auto result = std::make_unique<Table>();
+        result->inner = cudf::distinct(
+            *input.inner,
+            key_indices,
+            static_cast<cudf::duplicate_keep_option>(keep),
+            static_cast<cudf::null_equality>(nulls_equal),
+            static_cast<cudf::nan_equality>(nans_equal));
         return result;
     }
 

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -78,11 +78,19 @@ namespace libcudf_bridge {
 
     // Gather rows from a table based on a gather map
     std::unique_ptr<Table> gather(const TableView &source_table, const ColumnView &gather_map) {
+        return gather_with_policy(source_table, gather_map,
+                                  static_cast<int32_t>(cudf::out_of_bounds_policy::DONT_CHECK));
+    }
+
+    std::unique_ptr<Table> gather_with_policy(
+        const TableView &source_table,
+        const ColumnView &gather_map,
+        int32_t out_of_bounds_policy) {
         auto result = std::make_unique<Table>();
         result->inner = cudf::gather(
             *source_table.inner,
             *gather_map.inner,
-            cudf::out_of_bounds_policy::DONT_CHECK
+            static_cast<cudf::out_of_bounds_policy>(out_of_bounds_policy)
         );
         return result;
     }

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -5,8 +5,11 @@
 #include <cudf/column/column.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/filling.hpp>
 #include <cudf/interop.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/version_config.hpp>
 
@@ -16,6 +19,7 @@
 
 #include <nanoarrow/nanoarrow.h>
 
+#include <limits>
 #include <sstream>
 
 namespace libcudf_bridge {
@@ -67,6 +71,21 @@ namespace libcudf_bridge {
         auto table = std::make_unique<Column>();
         table->inner = cudf::concatenate(table_views);
         return table;
+    }
+
+    std::unique_ptr<Column> sequence(size_t size, const Scalar &init, const Scalar &step) {
+        if (size > static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
+            throw std::out_of_range("sequence size exceeds cudf::size_type");
+        }
+
+        auto stream = cudf::get_default_stream();
+        auto result = std::make_unique<Column>();
+        result->inner = cudf::sequence(
+            static_cast<cudf::size_type>(size),
+            *init.inner,
+            *step.inner,
+            stream);
+        return result;
     }
 
     // Direct cuDF operations - 1:1 mappings

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -25,6 +25,8 @@ namespace libcudf_bridge {
 
     std::unique_ptr<Column> concat_column_views(rust::Slice<const std::unique_ptr<ColumnView>> views);
 
+    std::unique_ptr<Column> make_column_from_scalar(const Scalar &scalar, size_t size);
+
     std::unique_ptr<Column> sequence(size_t size, const Scalar &init, const Scalar &step);
 
     // Gather rows from a table based on a gather map (column of indices)
@@ -34,6 +36,18 @@ namespace libcudf_bridge {
         const TableView &source_table,
         const ColumnView &gather_map,
         int32_t out_of_bounds_policy);
+
+    std::unique_ptr<Table> scatter_scalars(
+        rust::Slice<const Scalar *const> source,
+        const ColumnView &indices,
+        const TableView &target);
+
+    std::unique_ptr<Table> distinct(
+        const TableView &input,
+        rust::Slice<const int32_t> keys,
+        int32_t keep,
+        int32_t nulls_equal,
+        int32_t nans_equal);
 
     // Create a sliced view of a column
     std::unique_ptr<ColumnView> slice_column(const ColumnView &column, size_t offset, size_t length);

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -5,6 +5,7 @@
 #include "rust/cxx.h"
 #include "table.h"
 #include "column.h"
+#include "scalar.h"
 
 // Forward declarations of Arrow C ABI types
 struct ArrowSchema;
@@ -23,6 +24,8 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> concat_table_views(rust::Slice<const std::unique_ptr<TableView>> views);
 
     std::unique_ptr<Column> concat_column_views(rust::Slice<const std::unique_ptr<ColumnView>> views);
+
+    std::unique_ptr<Column> sequence(size_t size, const Scalar &init, const Scalar &step);
 
     // Gather rows from a table based on a gather map (column of indices)
     std::unique_ptr<Table> gather(const TableView &source_table, const ColumnView &gather_map);

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -27,6 +27,11 @@ namespace libcudf_bridge {
     // Gather rows from a table based on a gather map (column of indices)
     std::unique_ptr<Table> gather(const TableView &source_table, const ColumnView &gather_map);
 
+    std::unique_ptr<Table> gather_with_policy(
+        const TableView &source_table,
+        const ColumnView &gather_map,
+        int32_t out_of_bounds_policy);
+
     // Create a sliced view of a column
     std::unique_ptr<ColumnView> slice_column(const ColumnView &column, size_t offset, size_t length);
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -19,6 +19,10 @@ impl CuDFColumn {
         Self { inner }
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.inner.size()
+    }
+
     /// Convert an Arrow array to a cuDF column
     ///
     /// This transfers the Arrow array data to GPU memory for processing with cuDF.

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,9 +1,78 @@
-use crate::{CuDFError, CuDFTable, CuDFTableView};
+use crate::{CuDFError, CuDFRef, CuDFTable, CuDFTableView};
+use cxx::UniquePtr;
 use libcudf_sys::ffi;
+use std::sync::Arc;
 
 fn select_cols(view: &CuDFTableView, cols: &[usize]) -> cxx::UniquePtr<ffi::TableView> {
     let indices: Vec<i32> = cols.iter().map(|&i| i as i32).collect();
     view.inner().select(&indices)
+}
+
+/// Reusable hash join built from a fixed build-side key table.
+///
+/// The build-side table is kept alive for the lifetime of this object.
+pub struct CuDFHashJoin {
+    inner: UniquePtr<ffi::HashJoin>,
+    _build_ref: Option<Arc<dyn CuDFRef>>,
+}
+
+/// Controls whether null join-key values compare equal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CuDFNullEquality {
+    /// Null join-key values match other null join-key values.
+    Equal,
+    /// Null join-key values do not match anything.
+    Unequal,
+}
+
+impl CuDFNullEquality {
+    fn nulls_equal(self) -> bool {
+        matches!(self, Self::Equal)
+    }
+}
+
+impl CuDFHashJoin {
+    /// Build a reusable hash join from the selected build-side key columns.
+    pub fn try_new(
+        build: &CuDFTableView,
+        build_on: &[usize],
+        null_equality: CuDFNullEquality,
+    ) -> Result<Self, CuDFError> {
+        let build_keys = select_cols(build, build_on);
+        let inner = ffi::hash_join_create(&build_keys, null_equality.nulls_equal())?;
+        Ok(Self {
+            inner,
+            _build_ref: build._ref.clone(),
+        })
+    }
+
+    /// Probe this hash join and gather matching payload rows.
+    ///
+    /// Output columns are concatenated as `[build_cols | probe_cols]`.
+    pub fn inner_join(
+        &self,
+        probe: &CuDFTableView,
+        probe_on: &[usize],
+        build_payload: &CuDFTableView,
+        probe_payload: &CuDFTableView,
+        build_out_cols: Option<&[usize]>,
+        probe_out_cols: Option<&[usize]>,
+    ) -> Result<CuDFTable, CuDFError> {
+        let probe_keys = select_cols(probe, probe_on);
+        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
+        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let result = ffi::hash_join_inner_join_gather(
+            &self.inner,
+            &probe_keys,
+            selected_build_payload
+                .as_ref()
+                .unwrap_or_else(|| build_payload.inner()),
+            selected_probe_payload
+                .as_ref()
+                .unwrap_or_else(|| probe_payload.inner()),
+        )?;
+        Ok(CuDFTable::from_inner(result))
+    }
 }
 
 /// Perform an inner join on two tables using the specified key columns.
@@ -237,6 +306,66 @@ mod tests {
             .collect();
         pairs.sort();
         assert_eq!(pairs, vec![(20, 200), (30, 300)]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_hash_join_inner_join_multiple_probes() -> Result<(), Box<dyn std::error::Error>> {
+        let build = Arc::new(make_table(vec![1, 2, 3], vec![10, 20, 30]));
+        let build_view = Arc::clone(&build).view();
+        let join = CuDFHashJoin::try_new(&build_view, &[0], CuDFNullEquality::Unequal)?;
+
+        let probe_a = make_table(vec![2], vec![200]);
+        let probe_a_view = probe_a.into_view();
+        let result_a = join.inner_join(
+            &probe_a_view,
+            &[0],
+            &build_view,
+            &probe_a_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+
+        let probe_b = make_table(vec![3], vec![300]);
+        let probe_b_view = probe_b.into_view();
+        let result_b = join.inner_join(
+            &probe_b_view,
+            &[0],
+            &build_view,
+            &probe_b_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+
+        assert_eq!(result_a.num_rows(), 1);
+        assert_eq!(result_b.num_rows(), 1);
+        assert_eq!(result_a.num_columns(), 2);
+        assert_eq!(result_b.num_columns(), 2);
+
+        let batch_a = result_a.into_view().to_arrow_host()?;
+        let batch_b = result_b.into_view().to_arrow_host()?;
+        let left_a = batch_a
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let right_a = batch_a
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let left_b = batch_b
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let right_b = batch_b
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!((left_a.value(0), right_a.value(0)), (20, 200));
+        assert_eq!((left_b.value(0), right_b.value(0)), (30, 300));
         Ok(())
     }
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,7 +1,7 @@
 use crate::{CuDFColumn, CuDFError, CuDFRef, CuDFScalar, CuDFTable, CuDFTableView};
 use arrow::array::{Int32Array, Scalar};
 use cxx::UniquePtr;
-use libcudf_sys::{ffi, OutOfBoundsPolicy};
+use libcudf_sys::{ffi, NullEquality, OutOfBoundsPolicy};
 use std::sync::Arc;
 
 const NULL_GATHER_INDEX: i32 = i32::MIN;
@@ -109,8 +109,11 @@ pub enum CuDFNullEquality {
 }
 
 impl CuDFNullEquality {
-    fn nulls_equal(self) -> bool {
-        matches!(self, Self::Equal)
+    fn into_sys(self) -> NullEquality {
+        match self {
+            Self::Equal => NullEquality::Equal,
+            Self::Unequal => NullEquality::Unequal,
+        }
     }
 }
 
@@ -122,7 +125,7 @@ impl CuDFHashJoin {
         null_equality: CuDFNullEquality,
     ) -> Result<Self, CuDFError> {
         let build_keys = select_cols(build, build_on);
-        let inner = ffi::hash_join_create(&build_keys, null_equality.nulls_equal())?;
+        let inner = ffi::hash_join_create(&build_keys, null_equality.into_sys() as i32)?;
         Ok(Self {
             inner,
             build_rows: build.num_rows(),

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,7 +1,11 @@
+use crate::data_type::arrow_type_to_cudf_data_type;
 use crate::{CuDFColumn, CuDFError, CuDFRef, CuDFScalar, CuDFTable, CuDFTableView};
-use arrow::array::{Int32Array, Scalar};
+use arrow::array::{BooleanArray, Int32Array, Scalar};
+use arrow_schema::DataType;
 use cxx::UniquePtr;
-use libcudf_sys::{ffi, NullEquality, OutOfBoundsPolicy};
+use libcudf_sys::{
+    ffi, BinaryOperator, DuplicateKeepOption, NanEquality, NullEquality, OutOfBoundsPolicy,
+};
 use std::sync::Arc;
 
 const NULL_GATHER_INDEX: i32 = i32::MIN;
@@ -89,13 +93,27 @@ fn join_index_sequence(size: usize, init: i32, step: i32) -> Result<Arc<CuDFColu
     )?)))
 }
 
+fn int32_scalar(value: i32) -> Result<CuDFScalar, CuDFError> {
+    let array = Int32Array::from(vec![value]);
+    CuDFScalar::from_arrow_host(Scalar::new(&array))
+}
+
+fn bool_scalar(value: bool) -> Result<CuDFScalar, CuDFError> {
+    let array = BooleanArray::from(vec![value]);
+    CuDFScalar::from_arrow_host(Scalar::new(&array))
+}
+
+fn bool_data_type() -> cxx::UniquePtr<ffi::DataType> {
+    arrow_type_to_cudf_data_type(&DataType::Boolean).expect("Boolean is supported by cuDF")
+}
+
 /// Reusable hash join built from a fixed build-side key table.
 ///
 /// The build-side table is kept alive for the lifetime of this object.
 pub struct CuDFHashJoin {
     inner: UniquePtr<ffi::HashJoin>,
     build_rows: usize,
-    matched_build_indices: Vec<Arc<CuDFColumn>>,
+    matched_build_mask: Option<Arc<CuDFColumn>>,
     _build_ref: Option<Arc<dyn CuDFRef>>,
 }
 
@@ -129,7 +147,7 @@ impl CuDFHashJoin {
         Ok(Self {
             inner,
             build_rows: build.num_rows(),
-            matched_build_indices: Vec::new(),
+            matched_build_mask: None,
             _build_ref: build._ref.clone(),
         })
     }
@@ -189,7 +207,7 @@ impl CuDFHashJoin {
             OutOfBoundsPolicy::DontCheck,
             OutOfBoundsPolicy::DontCheck,
         )?;
-        self.matched_build_indices.push(build_indices);
+        self.record_matched_build_indices(build_indices)?;
         Ok(result)
     }
 
@@ -220,7 +238,7 @@ impl CuDFHashJoin {
             OutOfBoundsPolicy::Nullify,
             OutOfBoundsPolicy::DontCheck,
         )?;
-        self.matched_build_indices.push(build_indices);
+        self.record_matched_build_indices(build_indices)?;
         Ok(result)
     }
 
@@ -254,29 +272,108 @@ impl CuDFHashJoin {
         )
     }
 
-    fn unmatched_build_indices(&self) -> Result<Arc<CuDFColumn>, CuDFError> {
-        let all_build_indices = || join_index_sequence(self.build_rows, 0, 1);
-
-        let matched_views: Vec<_> = self
-            .matched_build_indices
-            .iter()
-            .filter(|indices| indices.len() > 0)
-            .map(|indices| Arc::clone(indices).view())
-            .collect();
-        if matched_views.is_empty() {
-            return all_build_indices();
+    fn record_matched_build_indices(
+        &mut self,
+        build_indices: Arc<CuDFColumn>,
+    ) -> Result<(), CuDFError> {
+        if self.build_rows == 0 || build_indices.len() == 0 {
+            return Ok(());
         }
 
-        let all_build_indices = all_build_indices()?;
-        let matched_indices = Arc::new(CuDFColumn::concat(matched_views)?);
+        let zero = int32_scalar(0)?;
+        let valid_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
+            Arc::clone(&build_indices).view().inner(),
+            zero.inner(),
+            BinaryOperator::GreaterEqual as i32,
+            &bool_data_type(),
+        )?));
+        let build_indices_table =
+            CuDFTableView::from_column_views(vec![Arc::clone(&build_indices).view()])?;
+        let valid_indices_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
+            build_indices_table.inner(),
+            Arc::clone(&valid_mask).view().inner(),
+        )?);
+        if valid_indices_table.num_rows() == 0 {
+            return Ok(());
+        }
+
+        let valid_indices_view = valid_indices_table.into_view();
+        let distinct_indices = CuDFTable::from_inner(ffi::distinct(
+            valid_indices_view.inner(),
+            &[0],
+            DuplicateKeepOption::KeepAny as i32,
+            NullEquality::Equal as i32,
+            NanEquality::AllEqual as i32,
+        )?);
+        if distinct_indices.num_rows() == 0 {
+            return Ok(());
+        }
+
+        let matched_build_mask = match &self.matched_build_mask {
+            Some(mask) => Arc::clone(mask),
+            None => {
+                let false_scalar = bool_scalar(false)?;
+                let mask = Arc::new(CuDFColumn::new(ffi::make_column_from_scalar(
+                    false_scalar.inner(),
+                    self.build_rows,
+                )?));
+                self.matched_build_mask = Some(Arc::clone(&mask));
+                mask
+            }
+        };
+
+        let scatter_indices = Arc::new(
+            distinct_indices
+                .into_columns()
+                .into_iter()
+                .next()
+                .expect("distinct matched indices has one column"),
+        );
+        let scatter_indices_view = Arc::clone(&scatter_indices).view();
+        let true_scalar = bool_scalar(true)?;
+        let source = [true_scalar.inner().as_ptr()];
+        let target = CuDFTableView::from_column_views(vec![matched_build_mask.view()])?;
+        let updated = CuDFTable::from_inner(ffi::scatter_scalars(
+            &source,
+            scatter_indices_view.inner(),
+            target.inner(),
+        )?);
+        self.matched_build_mask = Some(Arc::new(
+            updated
+                .into_columns()
+                .into_iter()
+                .next()
+                .expect("updated matched build mask has one column"),
+        ));
+        Ok(())
+    }
+
+    fn unmatched_build_indices(&self) -> Result<Arc<CuDFColumn>, CuDFError> {
+        let all_build_indices = join_index_sequence(self.build_rows, 0, 1)?;
+        let Some(matched_build_mask) = &self.matched_build_mask else {
+            return Ok(all_build_indices);
+        };
+
+        let false_scalar = bool_scalar(false)?;
+        let unmatched_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
+            Arc::clone(matched_build_mask).view().inner(),
+            false_scalar.inner(),
+            BinaryOperator::Equal as i32,
+            &bool_data_type(),
+        )?));
         let all_build_table =
             CuDFTableView::from_column_views(vec![Arc::clone(&all_build_indices).view()])?;
-        let matched_table =
-            CuDFTableView::from_column_views(vec![Arc::clone(&matched_indices).view()])?;
-        Ok(Arc::new(CuDFColumn::new(ffi::left_anti_join_indices(
+        let unmatched_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
             all_build_table.inner(),
-            matched_table.inner(),
-        )?)))
+            Arc::clone(&unmatched_mask).view().inner(),
+        )?);
+        Ok(Arc::new(
+            unmatched_table
+                .into_columns()
+                .into_iter()
+                .next()
+                .expect("unmatched build indices has one column"),
+        ))
     }
 }
 
@@ -696,6 +793,97 @@ mod tests {
             .unwrap();
         assert_eq!(int32_values(&unmatched_batch, 0), vec![10]);
         assert_eq!(unmatched_probe_vals.null_count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_hash_join_match_mask_handles_duplicate_and_unmatched_probe_rows(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let build = Arc::new(make_table(vec![1, 2, 3, 4], vec![10, 20, 30, 40]));
+        let build_view = Arc::clone(&build).view();
+        let mut join = CuDFHashJoin::try_new(&build_view, &[0], CuDFNullEquality::Unequal)?;
+
+        let probe_a = make_table(vec![2, 2], vec![200, 201]);
+        let probe_a_view = probe_a.into_view();
+        let inner = join.inner_join_and_record_matches(
+            &probe_a_view,
+            &[0],
+            &build_view,
+            &probe_a_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+        assert_eq!(inner.num_rows(), 2);
+
+        let probe_b = make_table(vec![2, 3, 3, 5], vec![202, 300, 301, 500]);
+        let probe_b_view = probe_b.into_view();
+        let probe_left = join.probe_left_join_and_record_matches(
+            &probe_b_view,
+            &[0],
+            &build_view,
+            &probe_b_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+        assert_eq!(probe_left.num_rows(), 4);
+
+        let probe_left_batch = probe_left.into_view().to_arrow_host()?;
+        let build_vals = probe_left_batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(build_vals.null_count(), 1);
+
+        let unmatched =
+            join.unmatched_build_rows(&build_view, &probe_b_view, Some(&[1]), Some(&[1]))?;
+        assert_eq!(unmatched.num_rows(), 2);
+        assert_eq!(unmatched.num_columns(), 2);
+
+        let unmatched_batch = unmatched.into_view().to_arrow_host()?;
+        let unmatched_probe_vals = unmatched_batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(int32_values(&unmatched_batch, 0), vec![10, 40]);
+        assert_eq!(unmatched_probe_vals.null_count(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_hash_join_match_mask_handles_all_build_rows_matched(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let build = Arc::new(make_table(vec![1, 2], vec![10, 20]));
+        let build_view = Arc::clone(&build).view();
+        let mut join = CuDFHashJoin::try_new(&build_view, &[0], CuDFNullEquality::Unequal)?;
+
+        let probe_a = make_table(vec![1, 1], vec![100, 101]);
+        let probe_a_view = probe_a.into_view();
+        join.inner_join_and_record_matches(
+            &probe_a_view,
+            &[0],
+            &build_view,
+            &probe_a_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+
+        let probe_b = make_table(vec![2, 2], vec![200, 201]);
+        let probe_b_view = probe_b.into_view();
+        join.inner_join_and_record_matches(
+            &probe_b_view,
+            &[0],
+            &build_view,
+            &probe_b_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+
+        let unmatched =
+            join.unmatched_build_rows(&build_view, &probe_b_view, Some(&[1]), Some(&[1]))?;
+        assert_eq!(unmatched.num_rows(), 0);
+        assert_eq!(unmatched.num_columns(), 2);
         Ok(())
     }
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -73,6 +73,82 @@ impl CuDFHashJoin {
         )?;
         Ok(CuDFTable::from_inner(result))
     }
+
+    /// Probe this hash join, record matched build rows, and emit inner-join rows.
+    pub fn inner_join_and_record_matches(
+        &mut self,
+        probe: &CuDFTableView,
+        probe_on: &[usize],
+        build_payload: &CuDFTableView,
+        probe_payload: &CuDFTableView,
+        build_out_cols: Option<&[usize]>,
+        probe_out_cols: Option<&[usize]>,
+    ) -> Result<CuDFTable, CuDFError> {
+        let probe_keys = select_cols(probe, probe_on);
+        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
+        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let result = ffi::hash_join_inner_join_gather_and_mark(
+            self.inner.pin_mut(),
+            &probe_keys,
+            selected_build_payload
+                .as_ref()
+                .unwrap_or_else(|| build_payload.inner()),
+            selected_probe_payload
+                .as_ref()
+                .unwrap_or_else(|| probe_payload.inner()),
+        )?;
+        Ok(CuDFTable::from_inner(result))
+    }
+
+    /// Probe this hash join preserving probe rows and record matched build rows.
+    ///
+    /// Output columns are concatenated as `[build_cols | probe_cols]`.
+    pub fn probe_left_join_and_record_matches(
+        &mut self,
+        probe: &CuDFTableView,
+        probe_on: &[usize],
+        build_payload: &CuDFTableView,
+        probe_payload: &CuDFTableView,
+        build_out_cols: Option<&[usize]>,
+        probe_out_cols: Option<&[usize]>,
+    ) -> Result<CuDFTable, CuDFError> {
+        let probe_keys = select_cols(probe, probe_on);
+        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
+        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let result = ffi::hash_join_probe_left_join_gather_and_mark(
+            self.inner.pin_mut(),
+            &probe_keys,
+            selected_build_payload
+                .as_ref()
+                .unwrap_or_else(|| build_payload.inner()),
+            selected_probe_payload
+                .as_ref()
+                .unwrap_or_else(|| probe_payload.inner()),
+        )?;
+        Ok(CuDFTable::from_inner(result))
+    }
+
+    /// Gather build rows not matched by previous recorded probes.
+    pub fn unmatched_build_rows(
+        &self,
+        build_payload: &CuDFTableView,
+        probe_payload: &CuDFTableView,
+        build_out_cols: Option<&[usize]>,
+        probe_out_cols: Option<&[usize]>,
+    ) -> Result<CuDFTable, CuDFError> {
+        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
+        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let result = ffi::hash_join_unmatched_build_gather(
+            &self.inner,
+            selected_build_payload
+                .as_ref()
+                .unwrap_or_else(|| build_payload.inner()),
+            selected_probe_payload
+                .as_ref()
+                .unwrap_or_else(|| probe_payload.inner()),
+        )?;
+        Ok(CuDFTable::from_inner(result))
+    }
 }
 
 /// Perform an inner join on two tables using the specified key columns.

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,7 +1,10 @@
-use crate::{CuDFError, CuDFRef, CuDFTable, CuDFTableView};
+use crate::{CuDFColumn, CuDFError, CuDFRef, CuDFScalar, CuDFTable, CuDFTableView};
+use arrow::array::{Int32Array, Scalar};
 use cxx::UniquePtr;
 use libcudf_sys::{ffi, OutOfBoundsPolicy};
 use std::sync::Arc;
+
+const NULL_GATHER_INDEX: i32 = i32::MIN;
 
 fn select_cols(view: &CuDFTableView, cols: &[usize]) -> cxx::UniquePtr<ffi::TableView> {
     let indices: Vec<i32> = cols.iter().map(|&i| i as i32).collect();
@@ -52,11 +55,47 @@ fn gather_join_indices(
     )
 }
 
+fn gather_hash_join_indices(
+    mut indices: UniquePtr<ffi::HashJoinIndices>,
+    build_payload: &ffi::TableView,
+    probe_payload: &ffi::TableView,
+    build_policy: OutOfBoundsPolicy,
+    probe_policy: OutOfBoundsPolicy,
+) -> Result<(CuDFTable, Arc<CuDFColumn>), CuDFError> {
+    let probe_indices = Arc::new(CuDFColumn::new(indices.pin_mut().release_probe()));
+    let build_indices = Arc::new(CuDFColumn::new(indices.pin_mut().release_build()));
+    let probe_indices_view = Arc::clone(&probe_indices).view();
+    let build_indices_view = Arc::clone(&build_indices).view();
+    let result = gather_join_output(
+        build_payload,
+        probe_payload,
+        build_indices_view.inner(),
+        probe_indices_view.inner(),
+        build_policy,
+        probe_policy,
+    )?;
+    Ok((result, build_indices))
+}
+
+fn join_index_sequence(size: usize, init: i32, step: i32) -> Result<Arc<CuDFColumn>, CuDFError> {
+    let init_array = Int32Array::from(vec![init]);
+    let step_array = Int32Array::from(vec![step]);
+    let init_scalar = CuDFScalar::from_arrow_host(Scalar::new(&init_array))?;
+    let step_scalar = CuDFScalar::from_arrow_host(Scalar::new(&step_array))?;
+    Ok(Arc::new(CuDFColumn::new(ffi::sequence(
+        size,
+        init_scalar.inner(),
+        step_scalar.inner(),
+    )?)))
+}
+
 /// Reusable hash join built from a fixed build-side key table.
 ///
 /// The build-side table is kept alive for the lifetime of this object.
 pub struct CuDFHashJoin {
     inner: UniquePtr<ffi::HashJoin>,
+    build_rows: usize,
+    matched_build_indices: Vec<Arc<CuDFColumn>>,
     _build_ref: Option<Arc<dyn CuDFRef>>,
 }
 
@@ -86,6 +125,8 @@ impl CuDFHashJoin {
         let inner = ffi::hash_join_create(&build_keys, null_equality.nulls_equal())?;
         Ok(Self {
             inner,
+            build_rows: build.num_rows(),
+            matched_build_indices: Vec::new(),
             _build_ref: build._ref.clone(),
         })
     }
@@ -105,17 +146,19 @@ impl CuDFHashJoin {
         let probe_keys = select_cols(probe, probe_on);
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let result = ffi::hash_join_inner_join_gather(
-            &self.inner,
-            &probe_keys,
+        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let (result, _) = gather_hash_join_indices(
+            indices,
             selected_build_payload
                 .as_ref()
                 .unwrap_or_else(|| build_payload.inner()),
             selected_probe_payload
                 .as_ref()
                 .unwrap_or_else(|| probe_payload.inner()),
+            OutOfBoundsPolicy::DontCheck,
+            OutOfBoundsPolicy::DontCheck,
         )?;
-        Ok(CuDFTable::from_inner(result))
+        Ok(result)
     }
 
     /// Probe this hash join, record matched build rows, and emit inner-join rows.
@@ -131,17 +174,20 @@ impl CuDFHashJoin {
         let probe_keys = select_cols(probe, probe_on);
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let result = ffi::hash_join_inner_join_gather_and_mark(
-            self.inner.pin_mut(),
-            &probe_keys,
+        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let (result, build_indices) = gather_hash_join_indices(
+            indices,
             selected_build_payload
                 .as_ref()
                 .unwrap_or_else(|| build_payload.inner()),
             selected_probe_payload
                 .as_ref()
                 .unwrap_or_else(|| probe_payload.inner()),
+            OutOfBoundsPolicy::DontCheck,
+            OutOfBoundsPolicy::DontCheck,
         )?;
-        Ok(CuDFTable::from_inner(result))
+        self.matched_build_indices.push(build_indices);
+        Ok(result)
     }
 
     /// Probe this hash join preserving probe rows and record matched build rows.
@@ -159,17 +205,20 @@ impl CuDFHashJoin {
         let probe_keys = select_cols(probe, probe_on);
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let result = ffi::hash_join_probe_left_join_gather_and_mark(
-            self.inner.pin_mut(),
-            &probe_keys,
+        let indices = ffi::hash_join_left_join_indices(&self.inner, &probe_keys)?;
+        let (result, build_indices) = gather_hash_join_indices(
+            indices,
             selected_build_payload
                 .as_ref()
                 .unwrap_or_else(|| build_payload.inner()),
             selected_probe_payload
                 .as_ref()
                 .unwrap_or_else(|| probe_payload.inner()),
+            OutOfBoundsPolicy::Nullify,
+            OutOfBoundsPolicy::DontCheck,
         )?;
-        Ok(CuDFTable::from_inner(result))
+        self.matched_build_indices.push(build_indices);
+        Ok(result)
     }
 
     /// Gather build rows not matched by previous recorded probes.
@@ -182,16 +231,49 @@ impl CuDFHashJoin {
     ) -> Result<CuDFTable, CuDFError> {
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let result = ffi::hash_join_unmatched_build_gather(
-            &self.inner,
+        let unmatched_build_indices = self.unmatched_build_indices()?;
+        let null_probe_indices =
+            join_index_sequence(unmatched_build_indices.len(), NULL_GATHER_INDEX, 0)?;
+        let unmatched_build_indices_view = Arc::clone(&unmatched_build_indices).view();
+        let null_probe_indices_view = Arc::clone(&null_probe_indices).view();
+
+        gather_join_output(
             selected_build_payload
                 .as_ref()
                 .unwrap_or_else(|| build_payload.inner()),
             selected_probe_payload
                 .as_ref()
                 .unwrap_or_else(|| probe_payload.inner()),
-        )?;
-        Ok(CuDFTable::from_inner(result))
+            unmatched_build_indices_view.inner(),
+            null_probe_indices_view.inner(),
+            OutOfBoundsPolicy::DontCheck,
+            OutOfBoundsPolicy::Nullify,
+        )
+    }
+
+    fn unmatched_build_indices(&self) -> Result<Arc<CuDFColumn>, CuDFError> {
+        let all_build_indices = || join_index_sequence(self.build_rows, 0, 1);
+
+        let matched_views: Vec<_> = self
+            .matched_build_indices
+            .iter()
+            .filter(|indices| indices.len() > 0)
+            .map(|indices| Arc::clone(indices).view())
+            .collect();
+        if matched_views.is_empty() {
+            return all_build_indices();
+        }
+
+        let all_build_indices = all_build_indices()?;
+        let matched_indices = Arc::new(CuDFColumn::concat(matched_views)?);
+        let all_build_table =
+            CuDFTableView::from_column_views(vec![Arc::clone(&all_build_indices).view()])?;
+        let matched_table =
+            CuDFTableView::from_column_views(vec![Arc::clone(&matched_indices).view()])?;
+        Ok(Arc::new(CuDFColumn::new(ffi::left_anti_join_indices(
+            all_build_table.inner(),
+            matched_table.inner(),
+        )?)))
     }
 }
 
@@ -547,6 +629,70 @@ mod tests {
             .unwrap();
         assert_eq!((left_a.value(0), right_a.value(0)), (20, 200));
         assert_eq!((left_b.value(0), right_b.value(0)), (30, 300));
+        Ok(())
+    }
+
+    #[test]
+    fn test_hash_join_records_unmatched_build_rows() -> Result<(), Box<dyn std::error::Error>> {
+        let build = Arc::new(make_table(vec![1, 2, 3], vec![10, 20, 30]));
+        let build_view = Arc::clone(&build).view();
+        let mut join = CuDFHashJoin::try_new(&build_view, &[0], CuDFNullEquality::Unequal)?;
+
+        let probe_a = make_table(vec![2], vec![200]);
+        let probe_a_view = probe_a.into_view();
+        let inner = join.inner_join_and_record_matches(
+            &probe_a_view,
+            &[0],
+            &build_view,
+            &probe_a_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+        let inner_batch = inner.into_view().to_arrow_host()?;
+        assert_eq!(int32_values(&inner_batch, 0), vec![20]);
+        assert_eq!(int32_values(&inner_batch, 1), vec![200]);
+
+        let probe_b = make_table(vec![3, 4], vec![300, 400]);
+        let probe_b_view = probe_b.into_view();
+        let probe_left = join.probe_left_join_and_record_matches(
+            &probe_b_view,
+            &[0],
+            &build_view,
+            &probe_b_view,
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+        assert_eq!(probe_left.num_rows(), 2);
+        assert_eq!(probe_left.num_columns(), 2);
+
+        let probe_left_batch = probe_left.into_view().to_arrow_host()?;
+        let build_vals = probe_left_batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(build_vals.null_count(), 1);
+        assert_eq!(int32_values(&probe_left_batch, 1), vec![300, 400]);
+
+        let non_null_build_vals: Vec<_> = (0..build_vals.len())
+            .filter(|&i| build_vals.is_valid(i))
+            .map(|i| build_vals.value(i))
+            .collect();
+        assert_eq!(non_null_build_vals, vec![30]);
+
+        let unmatched =
+            join.unmatched_build_rows(&build_view, &probe_b_view, Some(&[1]), Some(&[1]))?;
+        assert_eq!(unmatched.num_rows(), 1);
+        assert_eq!(unmatched.num_columns(), 2);
+
+        let unmatched_batch = unmatched.into_view().to_arrow_host()?;
+        let unmatched_probe_vals = unmatched_batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(int32_values(&unmatched_batch, 0), vec![10]);
+        assert_eq!(unmatched_probe_vals.null_count(), 1);
         Ok(())
     }
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -285,10 +285,13 @@ pub fn left_semi_join(
     left_on: &[usize],
     right_on: &[usize],
 ) -> Result<CuDFTable, CuDFError> {
-    Ok(CuDFTable::from_inner(ffi::left_semi_join_gather(
-        &select_cols(left, left_on),
-        &select_cols(right, right_on),
+    let left_keys = select_cols(left, left_on);
+    let right_keys = select_cols(right, right_on);
+    let indices = ffi::left_semi_join_indices(&left_keys, &right_keys)?;
+    let indices_view = indices.view();
+    Ok(CuDFTable::from_inner(ffi::gather(
         left.inner(),
+        &indices_view,
     )?))
 }
 
@@ -301,10 +304,13 @@ pub fn left_anti_join(
     left_on: &[usize],
     right_on: &[usize],
 ) -> Result<CuDFTable, CuDFError> {
-    Ok(CuDFTable::from_inner(ffi::left_anti_join_gather(
-        &select_cols(left, left_on),
-        &select_cols(right, right_on),
+    let left_keys = select_cols(left, left_on);
+    let right_keys = select_cols(right, right_on);
+    let indices = ffi::left_anti_join_indices(&left_keys, &right_keys)?;
+    let indices_view = indices.view();
+    Ok(CuDFTable::from_inner(ffi::gather(
         left.inner(),
+        &indices_view,
     )?))
 }
 
@@ -339,6 +345,15 @@ mod tests {
         )
         .unwrap();
         CuDFTable::from_arrow_host(batch).unwrap()
+    }
+
+    fn int32_values(batch: &RecordBatch, column: usize) -> Vec<i32> {
+        let values = batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        (0..values.len()).map(|i| values.value(i)).collect()
     }
 
     #[test]
@@ -575,6 +590,11 @@ mod tests {
         let result = left_semi_join(&left.into_view(), &right.into_view(), &[0], &[0])?;
         assert_eq!(result.num_rows(), 2); // keys 2 and 3 match
         assert_eq!(result.num_columns(), 2); // only left columns
+
+        let batch = result.into_view().to_arrow_host()?;
+        let mut keys = int32_values(&batch, 0);
+        keys.sort();
+        assert_eq!(keys, vec![2, 3]);
         Ok(())
     }
 
@@ -586,6 +606,11 @@ mod tests {
         let result = left_anti_join(&left.into_view(), &right.into_view(), &[0], &[0])?;
         assert_eq!(result.num_rows(), 2); // keys 1 and 4 have no match
         assert_eq!(result.num_columns(), 2); // only left columns
+
+        let batch = result.into_view().to_arrow_host()?;
+        let mut keys = int32_values(&batch, 0);
+        keys.sort();
+        assert_eq!(keys, vec![1, 4]);
         Ok(())
     }
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -8,6 +8,19 @@ fn select_cols(view: &CuDFTableView, cols: &[usize]) -> cxx::UniquePtr<ffi::Tabl
     view.inner().select(&indices)
 }
 
+fn gather_join_output(
+    left_payload: &ffi::TableView,
+    right_payload: &ffi::TableView,
+    left_indices: &ffi::ColumnView,
+    right_indices: &ffi::ColumnView,
+) -> Result<CuDFTable, CuDFError> {
+    let left = CuDFTable::from_inner(ffi::gather(left_payload, left_indices)?);
+    let right = CuDFTable::from_inner(ffi::gather(right_payload, right_indices)?);
+    let mut columns = left.into_columns();
+    columns.extend(right.into_columns());
+    Ok(CuDFTable::from_columns(columns))
+}
+
 /// Reusable hash join built from a fixed build-side key table.
 ///
 /// The build-side table is kept alive for the lifetime of this object.
@@ -168,13 +181,17 @@ pub fn inner_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let result = ffi::inner_join_gather(
-        &left_keys,
-        &right_keys,
+    let mut indices = ffi::inner_join_indices(&left_keys, &right_keys)?;
+    let left_indices = indices.pin_mut().release_left();
+    let right_indices = indices.pin_mut().release_right();
+    let left_indices_view = left_indices.view();
+    let right_indices_view = right_indices.view();
+    gather_join_output(
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
         right_payload.as_ref().unwrap_or_else(|| right.inner()),
-    )?;
-    Ok(CuDFTable::from_inner(result))
+        &left_indices_view,
+        &right_indices_view,
+    )
 }
 
 /// Perform a left outer join on two tables.

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,6 +1,6 @@
 use crate::{CuDFError, CuDFRef, CuDFTable, CuDFTableView};
 use cxx::UniquePtr;
-use libcudf_sys::ffi;
+use libcudf_sys::{ffi, OutOfBoundsPolicy};
 use std::sync::Arc;
 
 fn select_cols(view: &CuDFTableView, cols: &[usize]) -> cxx::UniquePtr<ffi::TableView> {
@@ -13,12 +13,43 @@ fn gather_join_output(
     right_payload: &ffi::TableView,
     left_indices: &ffi::ColumnView,
     right_indices: &ffi::ColumnView,
+    left_policy: OutOfBoundsPolicy,
+    right_policy: OutOfBoundsPolicy,
 ) -> Result<CuDFTable, CuDFError> {
-    let left = CuDFTable::from_inner(ffi::gather(left_payload, left_indices)?);
-    let right = CuDFTable::from_inner(ffi::gather(right_payload, right_indices)?);
+    let left = CuDFTable::from_inner(ffi::gather_with_policy(
+        left_payload,
+        left_indices,
+        left_policy as i32,
+    )?);
+    let right = CuDFTable::from_inner(ffi::gather_with_policy(
+        right_payload,
+        right_indices,
+        right_policy as i32,
+    )?);
     let mut columns = left.into_columns();
     columns.extend(right.into_columns());
     Ok(CuDFTable::from_columns(columns))
+}
+
+fn gather_join_indices(
+    mut indices: UniquePtr<ffi::JoinIndices>,
+    left_payload: &ffi::TableView,
+    right_payload: &ffi::TableView,
+    left_policy: OutOfBoundsPolicy,
+    right_policy: OutOfBoundsPolicy,
+) -> Result<CuDFTable, CuDFError> {
+    let left_indices = indices.pin_mut().release_left();
+    let right_indices = indices.pin_mut().release_right();
+    let left_indices_view = left_indices.view();
+    let right_indices_view = right_indices.view();
+    gather_join_output(
+        left_payload,
+        right_payload,
+        &left_indices_view,
+        &right_indices_view,
+        left_policy,
+        right_policy,
+    )
 }
 
 /// Reusable hash join built from a fixed build-side key table.
@@ -181,16 +212,13 @@ pub fn inner_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let mut indices = ffi::inner_join_indices(&left_keys, &right_keys)?;
-    let left_indices = indices.pin_mut().release_left();
-    let right_indices = indices.pin_mut().release_right();
-    let left_indices_view = left_indices.view();
-    let right_indices_view = right_indices.view();
-    gather_join_output(
+    let indices = ffi::inner_join_indices(&left_keys, &right_keys)?;
+    gather_join_indices(
+        indices,
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
         right_payload.as_ref().unwrap_or_else(|| right.inner()),
-        &left_indices_view,
-        &right_indices_view,
+        OutOfBoundsPolicy::DontCheck,
+        OutOfBoundsPolicy::DontCheck,
     )
 }
 
@@ -211,13 +239,14 @@ pub fn left_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let result = ffi::left_join_gather(
-        &left_keys,
-        &right_keys,
+    let indices = ffi::left_join_indices(&left_keys, &right_keys)?;
+    gather_join_indices(
+        indices,
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
         right_payload.as_ref().unwrap_or_else(|| right.inner()),
-    )?;
-    Ok(CuDFTable::from_inner(result))
+        OutOfBoundsPolicy::DontCheck,
+        OutOfBoundsPolicy::Nullify,
+    )
 }
 
 /// Perform a full outer join on two tables.
@@ -237,13 +266,14 @@ pub fn full_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let result = ffi::full_join_gather(
-        &left_keys,
-        &right_keys,
+    let indices = ffi::full_join_indices(&left_keys, &right_keys)?;
+    gather_join_indices(
+        indices,
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
         right_payload.as_ref().unwrap_or_else(|| right.inner()),
-    )?;
-    Ok(CuDFTable::from_inner(result))
+        OutOfBoundsPolicy::Nullify,
+        OutOfBoundsPolicy::Nullify,
+    )
 }
 
 /// Perform a left semi join - return only left rows that have at least one match.
@@ -362,6 +392,49 @@ mod tests {
         )?;
         assert_eq!(result.num_rows(), 3); // key 2 matches, key 1 left-only, key 3 right-only
         assert_eq!(result.num_columns(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn test_full_join_column_subset_nulls() -> Result<(), Box<dyn std::error::Error>> {
+        let left = make_table(vec![1, 2], vec![10, 20]);
+        let right = make_table(vec![2, 3], vec![200, 300]);
+
+        let result = full_join(
+            &left.into_view(),
+            &right.into_view(),
+            &[0],
+            &[0],
+            Some(&[1]),
+            Some(&[1]),
+        )?;
+
+        assert_eq!(result.num_rows(), 3);
+        assert_eq!(result.num_columns(), 2);
+
+        let batch = result.into_view().to_arrow_host()?;
+        let left_vals = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let right_vals = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(
+            (0..left_vals.len())
+                .filter(|&i| left_vals.is_null(i))
+                .count(),
+            1
+        );
+        assert_eq!(
+            (0..right_vals.len())
+                .filter(|&i| right_vals.is_null(i))
+                .count(),
+            1
+        );
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,10 @@ pub use cudf_reference::CuDFRef;
 pub use device_pool::DevicePoolConfig;
 pub use errors::{CuDFError, Result};
 pub use group_by::*;
-pub use join::{cross_join, full_join, inner_join, left_anti_join, left_join, left_semi_join};
+pub use join::{
+    cross_join, full_join, inner_join, left_anti_join, left_join, left_semi_join, CuDFHashJoin,
+    CuDFNullEquality,
+};
 pub use operations::{apply_boolean_mask, cast, gather, slice_column};
 pub use pinned::{pin_record_batch, synchronize_default_stream, PinnedHostBuffer};
 pub use pinned_pool::PinnedPoolConfig;

--- a/src/table.rs
+++ b/src/table.rs
@@ -43,6 +43,15 @@ impl CuDFTable {
         Self { inner }
     }
 
+    pub(crate) fn from_columns(mut columns: Vec<CuDFColumn>) -> Self {
+        let ptrs: Vec<_> = columns
+            .iter_mut()
+            .map(|col| col.inner.as_mut_ptr())
+            .collect();
+        let inner = ffi::create_table_from_columns_move(&ptrs);
+        Self { inner }
+    }
+
     /// Read a table from a Parquet file
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary

This PR changes the cuDF hash-join path from whole-input join execution toward streamed probing over reusable build-side state. The goal is to reduce peak memory pressure/OOM risk for supported joins while keeping `libcudf-sys` thin and moving output assembly decisions into the high-level Rust layer.

Main changes:

- add `CuDFHashJoin`, a high-level reusable hash-join wrapper that builds cuDF hash state once and probes right-side batches incrementally
- stream supported DataFusion hash joins instead of collecting the full probe side before joining
- support streamed `Inner`, `Left`, and `Full` joins for `Partitioned` mode
- support streamed `Inner` joins for `CollectLeft`, and `Left`/`Full` for `CollectLeft` when the right side has one partition
- finalize unmatched build rows once at end-of-stream for streamed `Left` and `Full` joins
- track matched build rows with a build-side boolean mask instead of accumulating matched-index batches
- dedupe matched build indices before scatter so duplicate matches do not rely on undefined cuDF scatter behavior
- move join output assembly out of `libcudf-sys` and into `libcudf-rs`
- keep `libcudf-sys` closer to thin cuDF plumbing by exposing join index maps and small direct wrappers instead of semantic gather-combine helpers
- add join metrics/OOM diagnostics for build/probe batches, rows, bytes, join input bytes, build time, probe collect time, and join time
- make benchmark debug output print physical-plan metrics even when query execution returns an error

Still intentionally not routed to the GPU path in this PR:

- `PartitionMode::Auto`
- joins with filters
- joins with `null_equals = true`
- DataFusion semi/anti join routing
- `CollectLeft` `Left`/`Full` joins with multiple right partitions, which need a follow-up design to share one join state across all right partitions and finalize unmatched rows exactly once

## Implementation Notes

The old C++ sys helpers performed both cuDF join calls and semantic output assembly. This PR changes that boundary: `libcudf-sys` returns cuDF index maps or exposes direct primitives, and `libcudf-rs` handles projection, gather policy, null-padding, and unmatched-row finalization.

For streamed `Left` and `Full` joins, each probe batch records which build rows matched. At EOF, the executor gathers the build rows that never matched and emits them with null probe-side columns. The final implementation uses a boolean mask sized to the build table, not an ever-growing list of matched-index columns.

## Validation

- `cargo fmt --all`
- `cargo build -p libcudf-datafusion-benchmarks --release`
- `cargo test -p libcudf-rs join::tests:: --release`
- `cargo test -p libcudf-datafusion physical::hash_join::tests:: --release`
- `target/release/dfbench harness --dataset tpch_sf1 --iterations 3 --partitions 6 --run-id join-streaming-match-mask-sf1`
- `target/release/dfbench harness --dataset tpch_sf10 --iterations 3 --partitions 6 --run-id join-streaming-match-mask-sf10`

## Benchmark Summary

| Dataset | Paired successful queries | CPU total avg | GPU total avg | GPU speedup by total avg | Geomean speedup |
|---|---:|---:|---:|---:|---:|
| TPC-H SF1 | 22 | 4113.9 ms | 5240.3 ms | 0.79x | 0.75x |
| TPC-H SF10 | 22 | 48612.9 ms | 50522.8 ms | 0.96x | 0.89x |

All SF1 and SF10 query statuses were `ok`.

Queries where GPU beat CPU by raw average:

| Dataset | Query | CPU avg | GPU avg | Speedup |
|---|---:|---:|---:|---:|
| TPC-H SF1 | q7 | 295.5 ms | 268.3 ms | 1.10x |
| TPC-H SF1 | q17 | 305.8 ms | 191.3 ms | 1.60x |
| TPC-H SF10 | q2 | 862.1 ms | 794.8 ms | 1.08x |
| TPC-H SF10 | q3 | 1406.6 ms | 1400.0 ms | 1.00x |
| TPC-H SF10 | q7 | 3711.9 ms | 2547.9 ms | 1.46x |
| TPC-H SF10 | q11 | 435.4 ms | 398.4 ms | 1.09x |
| TPC-H SF10 | q13 | 3254.6 ms | 2670.5 ms | 1.22x |
| TPC-H SF10 | q16 | 360.5 ms | 309.6 ms | 1.16x |
| TPC-H SF10 | q17 | 4557.7 ms | 1796.2 ms | 2.54x |
| TPC-H SF10 | q18 | 6811.8 ms | 4875.7 ms | 1.40x |
| TPC-H SF10 | q21 | 5077.1 ms | 4847.9 ms | 1.05x |
| TPC-H SF10 | q22 | 393.7 ms | 387.1 ms | 1.02x |

Reports:

- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/join-streaming-match-mask-sf1/report.md`
- `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf10/join-streaming-match-mask-sf10/report.md`

Note: these benchmark reports were captured immediately before the final commit, so their metadata shows the previous commit with a dirty worktree. The committed source is the same code that was benchmarked.
