### PR TITLE
Complete binary operator enum parity

### DIFF
--- a/libcudf-sys/src/binaryop.cpp
+++ b/libcudf-sys/src/binaryop.cpp
@@ -6,6 +6,42 @@
 #include <cudf/types.hpp>
 
 namespace libcudf_bridge {
+    static_assert(static_cast<int32_t>(cudf::binary_operator::ADD) == 0);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::SUB) == 1);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::MUL) == 2);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::DIV) == 3);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::TRUE_DIV) == 4);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::FLOOR_DIV) == 5);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::MOD) == 6);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::PMOD) == 7);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::PYMOD) == 8);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::POW) == 9);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::INT_POW) == 10);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::LOG_BASE) == 11);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::ATAN2) == 12);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::SHIFT_LEFT) == 13);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::SHIFT_RIGHT) == 14);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::SHIFT_RIGHT_UNSIGNED) == 15);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::BITWISE_AND) == 16);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::BITWISE_OR) == 17);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::BITWISE_XOR) == 18);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::LOGICAL_AND) == 19);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::LOGICAL_OR) == 20);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::EQUAL) == 21);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NOT_EQUAL) == 22);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::LESS) == 23);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::GREATER) == 24);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::LESS_EQUAL) == 25);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::GREATER_EQUAL) == 26);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NULL_EQUALS) == 27);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NULL_NOT_EQUALS) == 28);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NULL_MAX) == 29);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NULL_MIN) == 30);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::GENERIC_BINARY) == 31);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NULL_LOGICAL_AND) == 32);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::NULL_LOGICAL_OR) == 33);
+    static_assert(static_cast<int32_t>(cudf::binary_operator::INVALID_BINARY) == 34);
+
     // Binary operation: column op column
     std::unique_ptr<Column> binary_operation_col_col(
         const ColumnView &lhs,

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -1026,6 +1026,22 @@ pub enum BinaryOperator {
     LessEqual = 25,
     /// Greater than or equal (>=)
     GreaterEqual = 26,
+    /// Null-aware equality.
+    NullEquals = 27,
+    /// Null-aware inequality.
+    NullNotEquals = 28,
+    /// Null-aware maximum.
+    NullMax = 29,
+    /// Null-aware minimum.
+    NullMin = 30,
+    /// Generic binary operation generated from PTX.
+    GenericBinary = 31,
+    /// Null-aware logical AND.
+    NullLogicalAnd = 32,
+    /// Null-aware logical OR.
+    NullLogicalOr = 33,
+    /// Invalid binary operation sentinel.
+    InvalidBinary = 34,
 }
 
 /// cuDF data type IDs
@@ -1491,10 +1507,51 @@ mod tests {
 
     #[test]
     fn test_binary_operators_enum() {
-        assert_eq!(BinaryOperator::Add as i32, 0);
-        assert_eq!(BinaryOperator::Sub as i32, 1);
-        assert_eq!(BinaryOperator::Mul as i32, 2);
-        assert_eq!(BinaryOperator::Div as i32, 3);
+        let rust_values = [
+            BinaryOperator::Add as i32,
+            BinaryOperator::Sub as i32,
+            BinaryOperator::Mul as i32,
+            BinaryOperator::Div as i32,
+            BinaryOperator::TrueDiv as i32,
+            BinaryOperator::FloorDiv as i32,
+            BinaryOperator::Mod as i32,
+            BinaryOperator::PMod as i32,
+            BinaryOperator::PyMod as i32,
+            BinaryOperator::Pow as i32,
+            BinaryOperator::IntPow as i32,
+            BinaryOperator::LogBase as i32,
+            BinaryOperator::Atan2 as i32,
+            BinaryOperator::ShiftLeft as i32,
+            BinaryOperator::ShiftRight as i32,
+            BinaryOperator::ShiftRightUnsigned as i32,
+            BinaryOperator::BitwiseAnd as i32,
+            BinaryOperator::BitwiseOr as i32,
+            BinaryOperator::BitwiseXor as i32,
+            BinaryOperator::LogicalAnd as i32,
+            BinaryOperator::LogicalOr as i32,
+            BinaryOperator::Equal as i32,
+            BinaryOperator::NotEqual as i32,
+            BinaryOperator::Less as i32,
+            BinaryOperator::Greater as i32,
+            BinaryOperator::LessEqual as i32,
+            BinaryOperator::GreaterEqual as i32,
+            BinaryOperator::NullEquals as i32,
+            BinaryOperator::NullNotEquals as i32,
+            BinaryOperator::NullMax as i32,
+            BinaryOperator::NullMin as i32,
+            BinaryOperator::GenericBinary as i32,
+            BinaryOperator::NullLogicalAnd as i32,
+            BinaryOperator::NullLogicalOr as i32,
+            BinaryOperator::InvalidBinary as i32,
+        ];
+
+        assert_eq!(
+            rust_values,
+            [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+            ]
+        );
     }
 
     #[test]

--- a/src/binary_op.rs
+++ b/src/binary_op.rs
@@ -81,6 +81,8 @@ pub enum CuDFBinaryOp {
     NullLogicalAnd = 32,
     /// operator || with Spark rules
     NullLogicalOr = 33,
+    /// invalid operation sentinel
+    InvalidBinary = 34,
 }
 
 pub fn cudf_binary_op(


### PR DESCRIPTION
## Summary
- complete `libcudf-sys::BinaryOperator` through `InvalidBinary`
- add compile-time C++ assertions that cuDF binary operator discriminants match the Rust enum values
- add the matching high-level `CuDFBinaryOp::InvalidBinary` variant

## Why
`libcudf-sys` should keep enums complete and numerically aligned with upstream cuDF. The previous enum stopped at `GreaterEqual`, leaving later cuDF variants unrepresented.

## Validation
- `cargo test -p libcudf-sys test_binary_operators_enum -- --nocapture`