### PR TITLE
Align reduce and aggregation wrappers with cuDF

### DIFF
--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -185,7 +185,7 @@ impl CuDFAggregateStream {
 
         let (chunk_keys, chunk_results) = {
             let _timer = self.group_by_metrics.aggregation_time.timer();
-            group_by.aggregate(&requests).map_err(cudf_to_df)?
+            group_by.aggregate(requests).map_err(cudf_to_df)?
         };
         let mut chunk_state_columns = chunk_results.into_iter().flatten().collect();
 
@@ -290,7 +290,7 @@ impl CuDFAggregateStream {
         let group_by = CuDFGroupBy::from_table_view(combined_keys.into_view());
         let (merged_keys, merged_results) = {
             let _timer = self.group_by_metrics.aggregation_time.timer();
-            group_by.aggregate(&requests).map_err(cudf_to_df)?
+            group_by.aggregate(requests).map_err(cudf_to_df)?
         };
         let merged_state_columns = merged_results.into_iter().flatten().collect();
 

--- a/libcudf-sys/src/aggregation.cpp
+++ b/libcudf-sys/src/aggregation.cpp
@@ -11,112 +11,126 @@
 #include <stdexcept>
 
 namespace libcudf_bridge {
+    ReduceAggregation::ReduceAggregation() : inner(nullptr) {
+    }
+
+    ReduceAggregation::~ReduceAggregation() = default;
+
+    GroupByAggregation::GroupByAggregation() : inner(nullptr) {
+    }
+
+    GroupByAggregation::~GroupByAggregation() = default;
+
     // Aggregation factory functions - direct cuDF mappings (for reduce)
-    std::unique_ptr<Aggregation> make_sum_aggregation() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_sum_aggregation() {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_min_aggregation() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_min_aggregation() {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_min_aggregation<cudf::reduce_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_max_aggregation() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_max_aggregation() {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_max_aggregation<cudf::reduce_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_mean_aggregation() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_mean_aggregation() {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_mean_aggregation<cudf::reduce_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_count_aggregation() {
-        auto result = std::make_unique<Aggregation>();
-        result->inner = cudf::make_count_aggregation<cudf::reduce_aggregation>();
+    std::unique_ptr<ReduceAggregation> make_count_aggregation(int32_t null_handling) {
+        auto result = std::make_unique<ReduceAggregation>();
+        result->inner = cudf::make_count_aggregation<cudf::reduce_aggregation>(
+            static_cast<cudf::null_policy>(null_handling));
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_variance_aggregation(int32_t ddof) {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_variance_aggregation(int32_t ddof) {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_variance_aggregation<cudf::reduce_aggregation>(ddof);
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_std_aggregation(int32_t ddof) {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_std_aggregation(int32_t ddof) {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_std_aggregation<cudf::reduce_aggregation>(ddof);
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_nunique_aggregation() {
-        auto result = std::make_unique<Aggregation>();
-        result->inner = cudf::make_nunique_aggregation<cudf::reduce_aggregation>();
+    std::unique_ptr<ReduceAggregation> make_nunique_aggregation(int32_t null_handling) {
+        auto result = std::make_unique<ReduceAggregation>();
+        result->inner = cudf::make_nunique_aggregation<cudf::reduce_aggregation>(
+            static_cast<cudf::null_policy>(null_handling));
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_median_aggregation() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<ReduceAggregation> make_median_aggregation() {
+        auto result = std::make_unique<ReduceAggregation>();
         result->inner = cudf::make_median_aggregation<cudf::reduce_aggregation>();
         return result;
     }
 
     // Aggregation factory functions - direct cuDF mappings (for groupby)
-    std::unique_ptr<Aggregation> make_sum_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_sum_aggregation_groupby() {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_min_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_min_aggregation_groupby() {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_min_aggregation<cudf::groupby_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_max_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_max_aggregation_groupby() {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_max_aggregation<cudf::groupby_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_mean_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_mean_aggregation_groupby() {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_count_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
-        result->inner = cudf::make_count_aggregation<cudf::groupby_aggregation>();
+    std::unique_ptr<GroupByAggregation> make_count_aggregation_groupby(int32_t null_handling) {
+        auto result = std::make_unique<GroupByAggregation>();
+        result->inner = cudf::make_count_aggregation<cudf::groupby_aggregation>(
+            static_cast<cudf::null_policy>(null_handling));
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_variance_aggregation_groupby(int32_t ddof) {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_variance_aggregation_groupby(int32_t ddof) {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_variance_aggregation<cudf::groupby_aggregation>(ddof);
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_std_aggregation_groupby(int32_t ddof) {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_std_aggregation_groupby(int32_t ddof) {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_std_aggregation<cudf::groupby_aggregation>(ddof);
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_nunique_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
-        result->inner = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
+    std::unique_ptr<GroupByAggregation> make_nunique_aggregation_groupby(int32_t null_handling) {
+        auto result = std::make_unique<GroupByAggregation>();
+        result->inner = cudf::make_nunique_aggregation<cudf::groupby_aggregation>(
+            static_cast<cudf::null_policy>(null_handling));
         return result;
     }
 
-    std::unique_ptr<Aggregation> make_median_aggregation_groupby() {
-        auto result = std::make_unique<Aggregation>();
+    std::unique_ptr<GroupByAggregation> make_median_aggregation_groupby() {
+        auto result = std::make_unique<GroupByAggregation>();
         result->inner = cudf::make_median_aggregation<cudf::groupby_aggregation>();
         return result;
     }
@@ -125,46 +139,24 @@ namespace libcudf_bridge {
     // Reduction - direct cuDF mapping
     std::unique_ptr<Scalar> reduce(
         const ColumnView &col,
-        const Aggregation &agg,
+        const ReduceAggregation &agg,
         const DataType &output_type) {
         auto result = std::make_unique<Scalar>();
-        auto *reduce_agg = dynamic_cast<cudf::reduce_aggregation const *>(agg.inner.get());
-        if (reduce_agg == nullptr) {
-            throw std::runtime_error("Aggregation is not a reduce aggregation");
-        }
-        result->inner = cudf::reduce(*col.inner, *reduce_agg, output_type.inner);
+        result->inner = cudf::reduce(*col.inner, *agg.inner, output_type.inner);
         return result;
     }
 
     std::unique_ptr<Scalar> reduce_with_init(
         const ColumnView &col,
-        const Aggregation &agg,
+        const ReduceAggregation &agg,
         const DataType &output_type,
         const Scalar &init) {
         auto result = std::make_unique<Scalar>();
-        auto *reduce_agg = dynamic_cast<cudf::reduce_aggregation const *>(agg.inner.get());
-        if (reduce_agg == nullptr) {
-            throw std::runtime_error("Aggregation is not a reduce aggregation");
-        }
         result->inner = cudf::reduce(
             *col.inner,
-            *reduce_agg,
+            *agg.inner,
             output_type.inner,
             std::cref(*init.inner));
-        return result;
-    }
-
-    // GroupBy factory
-    std::unique_ptr<GroupBy> groupby_create(const TableView &keys) {
-        auto result = std::make_unique<GroupBy>();
-        result->inner = std::make_unique<cudf::groupby::groupby>(*keys.inner);
-        return result;
-    }
-
-    // AggregationRequest factory
-    std::unique_ptr<AggregationRequest> aggregation_request_create(const ColumnView &values) {
-        auto result = std::make_unique<AggregationRequest>();
-        result->inner->values = *values.inner;
         return result;
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/aggregation.cpp
+++ b/libcudf-sys/src/aggregation.cpp
@@ -7,6 +7,9 @@
 #include <cudf/reduction.hpp>
 #include <cudf/groupby.hpp>
 
+#include <functional>
+#include <stdexcept>
+
 namespace libcudf_bridge {
     // Aggregation factory functions - direct cuDF mappings (for reduce)
     std::unique_ptr<Aggregation> make_sum_aggregation() {
@@ -120,11 +123,34 @@ namespace libcudf_bridge {
 
 
     // Reduction - direct cuDF mapping
-    std::unique_ptr<Scalar> reduce(const Column &col, const Aggregation &agg, int32_t output_type_id) {
+    std::unique_ptr<Scalar> reduce(
+        const ColumnView &col,
+        const Aggregation &agg,
+        const DataType &output_type) {
         auto result = std::make_unique<Scalar>();
-        const auto output_type = cudf::data_type{static_cast<cudf::type_id>(output_type_id)};
         auto *reduce_agg = dynamic_cast<cudf::reduce_aggregation const *>(agg.inner.get());
-        result->inner = cudf::reduce(col.inner->view(), *reduce_agg, output_type);
+        if (reduce_agg == nullptr) {
+            throw std::runtime_error("Aggregation is not a reduce aggregation");
+        }
+        result->inner = cudf::reduce(*col.inner, *reduce_agg, output_type.inner);
+        return result;
+    }
+
+    std::unique_ptr<Scalar> reduce_with_init(
+        const ColumnView &col,
+        const Aggregation &agg,
+        const DataType &output_type,
+        const Scalar &init) {
+        auto result = std::make_unique<Scalar>();
+        auto *reduce_agg = dynamic_cast<cudf::reduce_aggregation const *>(agg.inner.get());
+        if (reduce_agg == nullptr) {
+            throw std::runtime_error("Aggregation is not a reduce aggregation");
+        }
+        result->inner = cudf::reduce(
+            *col.inner,
+            *reduce_agg,
+            output_type.inner,
+            std::cref(*init.inner));
         return result;
     }
 

--- a/libcudf-sys/src/aggregation.h
+++ b/libcudf-sys/src/aggregation.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include "rust/cxx.h"
 #include "column.h"
+#include "data_type.h"
 #include "scalar.h"
 #include <cudf/aggregation.hpp>
 
@@ -40,5 +41,14 @@ namespace libcudf_bridge {
     std::unique_ptr<Aggregation> make_median_aggregation_groupby();
 
     // Reduction - direct cuDF mapping
-    std::unique_ptr<Scalar> reduce(const Column &col, const Aggregation &agg, int32_t output_type_id);
+    std::unique_ptr<Scalar> reduce(
+        const ColumnView &col,
+        const Aggregation &agg,
+        const DataType &output_type);
+
+    std::unique_ptr<Scalar> reduce_with_init(
+        const ColumnView &col,
+        const Aggregation &agg,
+        const DataType &output_type,
+        const Scalar &init);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/aggregation.h
+++ b/libcudf-sys/src/aggregation.h
@@ -10,45 +10,53 @@
 
 namespace libcudf_bridge {
 
-    // Opaque wrapper for cuDF aggregation
-    struct Aggregation {
-        std::unique_ptr<cudf::aggregation> inner;
+    // Opaque wrapper for cuDF reduce_aggregation
+    struct ReduceAggregation {
+        std::unique_ptr<cudf::reduce_aggregation> inner;
 
-        Aggregation();
-        ~Aggregation();
+        ReduceAggregation();
+        ~ReduceAggregation();
+    };
+
+    // Opaque wrapper for cuDF groupby_aggregation
+    struct GroupByAggregation {
+        std::unique_ptr<cudf::groupby_aggregation> inner;
+
+        GroupByAggregation();
+        ~GroupByAggregation();
     };
 
     // Aggregation factory functions - direct cuDF mappings (for reduce)
-    std::unique_ptr<Aggregation> make_sum_aggregation();
-    std::unique_ptr<Aggregation> make_min_aggregation();
-    std::unique_ptr<Aggregation> make_max_aggregation();
-    std::unique_ptr<Aggregation> make_mean_aggregation();
-    std::unique_ptr<Aggregation> make_count_aggregation();
-    std::unique_ptr<Aggregation> make_variance_aggregation(int32_t ddof);
-    std::unique_ptr<Aggregation> make_std_aggregation(int32_t ddof);
-    std::unique_ptr<Aggregation> make_nunique_aggregation();
-    std::unique_ptr<Aggregation> make_median_aggregation();
+    std::unique_ptr<ReduceAggregation> make_sum_aggregation();
+    std::unique_ptr<ReduceAggregation> make_min_aggregation();
+    std::unique_ptr<ReduceAggregation> make_max_aggregation();
+    std::unique_ptr<ReduceAggregation> make_mean_aggregation();
+    std::unique_ptr<ReduceAggregation> make_count_aggregation(int32_t null_handling);
+    std::unique_ptr<ReduceAggregation> make_variance_aggregation(int32_t ddof);
+    std::unique_ptr<ReduceAggregation> make_std_aggregation(int32_t ddof);
+    std::unique_ptr<ReduceAggregation> make_nunique_aggregation(int32_t null_handling);
+    std::unique_ptr<ReduceAggregation> make_median_aggregation();
 
     // Aggregation factory functions - direct cuDF mappings (for groupby)
-    std::unique_ptr<Aggregation> make_sum_aggregation_groupby();
-    std::unique_ptr<Aggregation> make_min_aggregation_groupby();
-    std::unique_ptr<Aggregation> make_max_aggregation_groupby();
-    std::unique_ptr<Aggregation> make_mean_aggregation_groupby();
-    std::unique_ptr<Aggregation> make_count_aggregation_groupby();
-    std::unique_ptr<Aggregation> make_variance_aggregation_groupby(int32_t ddof);
-    std::unique_ptr<Aggregation> make_std_aggregation_groupby(int32_t ddof);
-    std::unique_ptr<Aggregation> make_nunique_aggregation_groupby();
-    std::unique_ptr<Aggregation> make_median_aggregation_groupby();
+    std::unique_ptr<GroupByAggregation> make_sum_aggregation_groupby();
+    std::unique_ptr<GroupByAggregation> make_min_aggregation_groupby();
+    std::unique_ptr<GroupByAggregation> make_max_aggregation_groupby();
+    std::unique_ptr<GroupByAggregation> make_mean_aggregation_groupby();
+    std::unique_ptr<GroupByAggregation> make_count_aggregation_groupby(int32_t null_handling);
+    std::unique_ptr<GroupByAggregation> make_variance_aggregation_groupby(int32_t ddof);
+    std::unique_ptr<GroupByAggregation> make_std_aggregation_groupby(int32_t ddof);
+    std::unique_ptr<GroupByAggregation> make_nunique_aggregation_groupby(int32_t null_handling);
+    std::unique_ptr<GroupByAggregation> make_median_aggregation_groupby();
 
     // Reduction - direct cuDF mapping
     std::unique_ptr<Scalar> reduce(
         const ColumnView &col,
-        const Aggregation &agg,
+        const ReduceAggregation &agg,
         const DataType &output_type);
 
     std::unique_ptr<Scalar> reduce_with_init(
         const ColumnView &col,
-        const Aggregation &agg,
+        const ReduceAggregation &agg,
         const DataType &output_type,
         const Scalar &init);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/groupby.cpp
+++ b/libcudf-sys/src/groupby.cpp
@@ -4,6 +4,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/aggregation.hpp>
+#include <cudf/types.hpp>
 
 namespace libcudf_bridge {
     // ColumnVectorHelper implementation
@@ -26,34 +27,14 @@ namespace libcudf_bridge {
         return std::make_unique<Column>(std::move(columns[index]));
     }
 
-    // Aggregation implementation
-    Aggregation::Aggregation() : inner(nullptr) {
-    }
-
-    Aggregation::~Aggregation() = default;
-
     // GroupBy implementation
     GroupBy::GroupBy() : inner(nullptr) {
     }
 
     GroupBy::~GroupBy() = default;
 
-    // TODO: this is big, there are clones... I'm not sure if this is right.
-    std::unique_ptr<GroupByResult> GroupBy::aggregate(rust::Slice<const AggregationRequest * const> requests) const {
-        std::vector<cudf::groupby::aggregation_request> cudf_requests;
-        cudf_requests.reserve(requests.size());
-        for (auto *req: requests) {
-            cudf::groupby::aggregation_request cudf_req;
-            cudf_req.values = req->inner->values;
-            for (auto &agg: req->inner->aggregations) {
-                auto cloned = agg->clone();
-                auto *groupby_agg = dynamic_cast<cudf::groupby_aggregation *>(cloned.release());
-                cudf_req.aggregations.push_back(std::unique_ptr<cudf::groupby_aggregation>(groupby_agg));
-            }
-            cudf_requests.push_back(std::move(cudf_req));
-        }
-
-        auto aggregate_result = inner->aggregate(cudf_requests);
+    std::unique_ptr<GroupByResult> GroupBy::aggregate(const AggregationRequests &requests) const {
+        auto aggregate_result = inner->aggregate(requests.inner);
 
         auto group_by_result = std::make_unique<GroupByResult>();
         group_by_result->keys.inner = std::move(aggregate_result.first);
@@ -76,9 +57,16 @@ namespace libcudf_bridge {
 
     AggregationRequest::~AggregationRequest() = default;
 
-    void AggregationRequest::add(std::unique_ptr<Aggregation> agg) const {
-        auto *groupby_agg = dynamic_cast<cudf::groupby_aggregation *>(agg->inner.release());
-        inner->aggregations.push_back(std::unique_ptr<cudf::groupby_aggregation>(groupby_agg));
+    void AggregationRequest::add(std::unique_ptr<GroupByAggregation> agg) const {
+        inner->aggregations.push_back(std::move(agg->inner));
+    }
+
+    AggregationRequests::AggregationRequests() = default;
+
+    AggregationRequests::~AggregationRequests() = default;
+
+    void AggregationRequests::add(std::unique_ptr<AggregationRequest> request) {
+        inner.push_back(std::move(*request->inner));
     }
 
     // GroupByResult implementation
@@ -107,5 +95,43 @@ namespace libcudf_bridge {
         auto helper = std::make_unique<ColumnVectorHelper>();
         helper->columns = std::move(results[index]);
         return helper;
+    }
+
+    std::unique_ptr<GroupBy> groupby_create(
+        const TableView &keys,
+        int32_t null_handling,
+        int32_t keys_are_sorted,
+        rust::Slice<const int32_t> column_order,
+        rust::Slice<const int32_t> null_precedence) {
+        std::vector<cudf::order> orders;
+        orders.reserve(column_order.size());
+        for (auto ord: column_order) {
+            orders.push_back(static_cast<cudf::order>(ord));
+        }
+
+        std::vector<cudf::null_order> null_orders;
+        null_orders.reserve(null_precedence.size());
+        for (auto null_ord: null_precedence) {
+            null_orders.push_back(static_cast<cudf::null_order>(null_ord));
+        }
+
+        auto result = std::make_unique<GroupBy>();
+        result->inner = std::make_unique<cudf::groupby::groupby>(
+            *keys.inner,
+            static_cast<cudf::null_policy>(null_handling),
+            static_cast<cudf::sorted>(keys_are_sorted),
+            orders,
+            null_orders);
+        return result;
+    }
+
+    std::unique_ptr<AggregationRequest> aggregation_request_create(const ColumnView &values) {
+        auto result = std::make_unique<AggregationRequest>();
+        result->inner->values = *values.inner;
+        return result;
+    }
+
+    std::unique_ptr<AggregationRequests> aggregation_requests_create() {
+        return std::make_unique<AggregationRequests>();
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/groupby.h
+++ b/libcudf-sys/src/groupby.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include "rust/cxx.h"
@@ -48,7 +49,18 @@ namespace libcudf_bridge {
         ~AggregationRequest();
 
         // Direct cuDF method (adds aggregation to the request)
-        void add(std::unique_ptr<Aggregation> agg) const;
+        void add(std::unique_ptr<GroupByAggregation> agg) const;
+    };
+
+    // FFI storage for the contiguous host_span expected by groupby::aggregate
+    struct AggregationRequests {
+        std::vector<cudf::groupby::aggregation_request> inner;
+
+        AggregationRequests();
+
+        ~AggregationRequests();
+
+        void add(std::unique_ptr<AggregationRequest> request);
     };
 
     // Opaque wrapper for cuDF groupby
@@ -61,11 +73,18 @@ namespace libcudf_bridge {
 
         // Direct cuDF method
         [[nodiscard]] std::unique_ptr<GroupByResult> aggregate(
-            rust::Slice<const AggregationRequest * const> requests) const;
+            const AggregationRequests &requests) const;
     };
 
     // GroupBy operations - direct cuDF mappings
-    std::unique_ptr<GroupBy> groupby_create(const TableView &keys);
+    std::unique_ptr<GroupBy> groupby_create(
+        const TableView &keys,
+        int32_t null_handling,
+        int32_t keys_are_sorted,
+        rust::Slice<const int32_t> column_order,
+        rust::Slice<const int32_t> null_precedence);
 
     std::unique_ptr<AggregationRequest> aggregation_request_create(const ColumnView &values);
+
+    std::unique_ptr<AggregationRequests> aggregation_requests_create();
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -663,9 +663,17 @@ pub mod ffi {
         /// This function does not detect overflows in reductions. Any null values are skipped
         /// for the operation. If the reduction fails, the output scalar returns with `is_valid()==false`.
         fn reduce(
-            col: &Column,
+            col: &ColumnView,
             agg: &Aggregation,
-            output_type_id: i32,
+            output_type: &DataType,
+        ) -> Result<UniquePtr<Scalar>>;
+
+        /// Computes a reduction with an initial scalar value.
+        fn reduce_with_init(
+            col: &ColumnView,
+            agg: &Aggregation,
+            output_type: &DataType,
+            init: &Scalar,
         ) -> Result<UniquePtr<Scalar>>;
 
         // GroupBy operations - direct cuDF mappings
@@ -1325,7 +1333,7 @@ unsafe impl Sync for ffi::CudaStream {}
 mod tests {
     use super::*;
     use crate::ffi::ColumnView;
-    use arrow::array::{make_array, Array, Int32Array, RecordBatch, StructArray};
+    use arrow::array::{make_array, Array, Decimal128Array, Int32Array, RecordBatch, StructArray};
     use arrow::ffi::{from_ffi, from_ffi_and_data_type, FFI_ArrowArray};
     use arrow::util::pretty::{pretty_format_batches, pretty_format_columns};
     use arrow_schema::ffi::FFI_ArrowSchema;
@@ -1560,6 +1568,45 @@ mod tests {
         assert_eq!(TypeId::Int32 as i32, 3);
         assert_eq!(TypeId::Float32 as i32, 9);
         assert_eq!(TypeId::Float64 as i32, 10);
+    }
+
+    #[test]
+    fn test_reduce_uses_full_output_data_type() -> Result<(), Box<dyn std::error::Error>> {
+        let table = table_from_decimal128_column("amount", vec![12345, 67890], 2)?;
+        let column = table.view().column(0);
+        let output_type = ffi::new_data_type_with_scale(TypeId::Decimal128 as i32, -2);
+
+        let result = ffi::reduce(&column, &ffi::make_sum_aggregation(), &output_type)?;
+        let result_type = result.data_type();
+
+        assert!(result.is_valid());
+        assert_eq!(result_type.id(), TypeId::Decimal128 as i32);
+        assert_eq!(result_type.scale(), -2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_with_init() -> Result<(), Box<dyn std::error::Error>> {
+        let table = table_from_i32_columns(&[("values", vec![1, 2, 3])])?;
+        let values = table.view().column(0);
+        let init_table = table_from_i32_columns(&[("init", vec![10])])?;
+        let init = ffi::get_element(&init_table.view().column(0), 0);
+        let output_type = ffi::new_data_type(TypeId::Int32 as i32);
+
+        let result =
+            ffi::reduce_with_init(&values, &ffi::make_sum_aggregation(), &output_type, &init)?;
+        let result_column = ffi::make_column_from_scalar(&result, 1)?;
+
+        assert_snapshot!(pretty_column(&result_column.view(), DataType::Int32)?, @r"
+        +------+
+        | test |
+        +------+
+        | 16   |
+        +------+
+        ");
+
+        Ok(())
     }
 
     #[test]
@@ -1815,6 +1862,26 @@ mod tests {
             .map(|(_, values)| Arc::new(Int32Array::from(values.clone())) as _)
             .collect();
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), arrays)?;
+        let struct_array = StructArray::from(batch);
+        let array_data = struct_array.into_data();
+        let ffi_array = FFI_ArrowArray::new(&array_data);
+        let ffi_schema = FFI_ArrowSchema::try_from(schema)?;
+        let device_array = ArrowDeviceArray::new_cpu().with_array(ffi_array);
+
+        let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
+        let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
+        Ok(unsafe { ffi::table_from_arrow_host(schema_ptr, device_array_ptr) }?)
+    }
+
+    fn table_from_decimal128_column(
+        name: &str,
+        values: Vec<i128>,
+        scale: i8,
+    ) -> Result<cxx::UniquePtr<ffi::Table>, Box<dyn std::error::Error>> {
+        let data_type = DataType::Decimal128(38, scale);
+        let schema = Schema::new(vec![Field::new(name, data_type.clone(), false)]);
+        let array = Decimal128Array::from(values).with_precision_and_scale(38, scale)?;
+        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(array)])?;
         let struct_array = StructArray::from(batch);
         let array_data = struct_array.into_data();
         let ffi_array = FFI_ArrowArray::new(&array_data);

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -76,11 +76,11 @@ pub mod ffi {
         /// Owning cuDF AST expression tree.
         type AstExpressionTree;
 
-        /// Abstract base class for specifying aggregation operations
-        ///
-        /// Represents the desired aggregation in an aggregation_request. Different aggregation
-        /// types (SUM, MIN, MAX, MEAN, COUNT, etc.) are created using factory functions.
-        type Aggregation;
+        /// Aggregation operation accepted by cuDF reductions.
+        type ReduceAggregation;
+
+        /// Aggregation operation accepted by cuDF groupby aggregation requests.
+        type GroupByAggregation;
 
         /// Groups values by keys and computes aggregations on those groups
         ///
@@ -158,6 +158,16 @@ pub mod ffi {
         /// need to worry about invalidating a stream at the moment.
         fn is_valid(self: &CudaStream) -> bool;
 
+        /// Request for groupby aggregation(s) to perform on a column
+        ///
+        /// The group membership of each value is determined by the corresponding row
+        /// in the original order of keys used to construct the groupby. Contains a column
+        /// of values to aggregate and a set of aggregations to perform on those elements.
+        type AggregationRequest;
+
+        /// Contiguous storage for groupby aggregation requests.
+        type AggregationRequests;
+
         // GroupBy methods - direct cuDF class methods
 
         /// Performs grouped aggregations on the specified values
@@ -166,20 +176,16 @@ pub mod ffi {
         /// `values[j]` where rows `i` and `j` in `keys` are equivalent.
         fn aggregate(
             self: &GroupBy,
-            requests: &[*const AggregationRequest],
+            requests: &AggregationRequests,
         ) -> Result<UniquePtr<GroupByResult>>;
-
-        /// Request for groupby aggregation(s) to perform on a column
-        ///
-        /// The group membership of each value is determined by the corresponding row
-        /// in the original order of keys used to construct the groupby. Contains a column
-        /// of values to aggregate and a set of aggregations to perform on those elements.
-        type AggregationRequest;
 
         // AggregationRequest methods
 
         /// Add an aggregation to this request
-        fn add(self: &AggregationRequest, agg: UniquePtr<Aggregation>);
+        fn add(self: &AggregationRequest, agg: UniquePtr<GroupByAggregation>);
+
+        /// Add an aggregation request to the request span.
+        fn add(self: Pin<&mut AggregationRequests>, request: UniquePtr<AggregationRequest>);
 
         /// Helper to extract columns from a vector by moving them
         type ColumnVectorHelper;
@@ -601,60 +607,60 @@ pub mod ffi {
         // Aggregation factory functions - direct cuDF mappings (for reduce)
 
         /// Create a SUM aggregation
-        fn make_sum_aggregation() -> UniquePtr<Aggregation>;
+        fn make_sum_aggregation() -> UniquePtr<ReduceAggregation>;
 
         /// Create a MIN aggregation
-        fn make_min_aggregation() -> UniquePtr<Aggregation>;
+        fn make_min_aggregation() -> UniquePtr<ReduceAggregation>;
 
         /// Create a MAX aggregation
-        fn make_max_aggregation() -> UniquePtr<Aggregation>;
+        fn make_max_aggregation() -> UniquePtr<ReduceAggregation>;
 
         /// Create a MEAN aggregation
-        fn make_mean_aggregation() -> UniquePtr<Aggregation>;
+        fn make_mean_aggregation() -> UniquePtr<ReduceAggregation>;
 
         /// Create a COUNT aggregation
-        fn make_count_aggregation() -> UniquePtr<Aggregation>;
+        fn make_count_aggregation(null_handling: i32) -> UniquePtr<ReduceAggregation>;
 
         /// Create a VARIANCE aggregation
-        fn make_variance_aggregation(ddof: i32) -> UniquePtr<Aggregation>;
+        fn make_variance_aggregation(ddof: i32) -> UniquePtr<ReduceAggregation>;
 
         /// Create a STD aggregation
-        fn make_std_aggregation(ddof: i32) -> UniquePtr<Aggregation>;
+        fn make_std_aggregation(ddof: i32) -> UniquePtr<ReduceAggregation>;
 
         /// Create a NUNIQUE aggregation
-        fn make_nunique_aggregation() -> UniquePtr<Aggregation>;
+        fn make_nunique_aggregation(null_handling: i32) -> UniquePtr<ReduceAggregation>;
 
         /// Create a MEDIAN aggregation
-        fn make_median_aggregation() -> UniquePtr<Aggregation>;
+        fn make_median_aggregation() -> UniquePtr<ReduceAggregation>;
 
         // Aggregation factory functions - direct cuDF mappings (for groupby)
 
         /// Create a SUM aggregation for groupby operations
-        fn make_sum_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_sum_aggregation_groupby() -> UniquePtr<GroupByAggregation>;
 
         /// Create a MIN aggregation for groupby operations
-        fn make_min_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_min_aggregation_groupby() -> UniquePtr<GroupByAggregation>;
 
         /// Create a MAX aggregation for groupby operations
-        fn make_max_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_max_aggregation_groupby() -> UniquePtr<GroupByAggregation>;
 
         /// Create a MEAN aggregation for groupby operations
-        fn make_mean_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_mean_aggregation_groupby() -> UniquePtr<GroupByAggregation>;
 
         /// Create a COUNT aggregation for groupby operations
-        fn make_count_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_count_aggregation_groupby(null_handling: i32) -> UniquePtr<GroupByAggregation>;
 
         /// Create a VARIANCE aggregation for groupby operations
-        fn make_variance_aggregation_groupby(ddof: i32) -> UniquePtr<Aggregation>;
+        fn make_variance_aggregation_groupby(ddof: i32) -> UniquePtr<GroupByAggregation>;
 
         /// Create a STD aggregation for groupby operations
-        fn make_std_aggregation_groupby(ddof: i32) -> UniquePtr<Aggregation>;
+        fn make_std_aggregation_groupby(ddof: i32) -> UniquePtr<GroupByAggregation>;
 
         /// Create a NUNIQUE aggregation for groupby operations
-        fn make_nunique_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_nunique_aggregation_groupby(null_handling: i32) -> UniquePtr<GroupByAggregation>;
 
         /// Create a MEDIAN aggregation for groupby operations
-        fn make_median_aggregation_groupby() -> UniquePtr<Aggregation>;
+        fn make_median_aggregation_groupby() -> UniquePtr<GroupByAggregation>;
 
         // Reduction - direct cuDF mapping
 
@@ -664,14 +670,14 @@ pub mod ffi {
         /// for the operation. If the reduction fails, the output scalar returns with `is_valid()==false`.
         fn reduce(
             col: &ColumnView,
-            agg: &Aggregation,
+            agg: &ReduceAggregation,
             output_type: &DataType,
         ) -> Result<UniquePtr<Scalar>>;
 
         /// Computes a reduction with an initial scalar value.
         fn reduce_with_init(
             col: &ColumnView,
-            agg: &Aggregation,
+            agg: &ReduceAggregation,
             output_type: &DataType,
             init: &Scalar,
         ) -> Result<UniquePtr<Scalar>>;
@@ -681,13 +687,22 @@ pub mod ffi {
         /// Construct a groupby object with the specified keys
         ///
         /// The groupby object groups values by keys and computes aggregations on those groups.
-        fn groupby_create(keys: &TableView) -> UniquePtr<GroupBy>;
+        fn groupby_create(
+            keys: &TableView,
+            null_handling: i32,
+            keys_are_sorted: i32,
+            column_order: &[i32],
+            null_precedence: &[i32],
+        ) -> UniquePtr<GroupBy>;
 
         /// Create an aggregation request for a column of values
         ///
         /// The group membership of each `value[i]` is determined by the corresponding row `i`
         /// in the original order of `keys` used to construct the groupby.
         fn aggregation_request_create(values: &ColumnView) -> UniquePtr<AggregationRequest>;
+
+        /// Create contiguous storage for groupby aggregation requests.
+        fn aggregation_requests_create() -> UniquePtr<AggregationRequests>;
 
         // Arrow interop - direct cuDF calls
 
@@ -793,6 +808,26 @@ pub enum NullOrder {
     After = 0,
     /// Nulls appear before all other values
     Before = 1,
+}
+
+/// Null handling policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum NullPolicy {
+    /// Exclude null elements.
+    Exclude = 0,
+    /// Include null elements.
+    Include = 1,
+}
+
+/// Whether values are known to be sorted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum Sorted {
+    /// Values are not known to be sorted.
+    No = 0,
+    /// Values are known to be sorted.
+    Yes = 1,
 }
 
 /// Policy for out-of-bounds gather indices.
@@ -1296,11 +1331,17 @@ unsafe impl Send for ffi::AstExpressionTree {}
 /// SAFETY: AstExpressionTree can be safely accessed from multiple threads after construction.
 unsafe impl Sync for ffi::AstExpressionTree {}
 
-/// SAFETY: Aggregation is a configuration object with no thread-local state.
-unsafe impl Send for ffi::Aggregation {}
+/// SAFETY: ReduceAggregation is a configuration object with no thread-local state.
+unsafe impl Send for ffi::ReduceAggregation {}
 
-/// SAFETY: Aggregation can be safely accessed from multiple threads.
-unsafe impl Sync for ffi::Aggregation {}
+/// SAFETY: ReduceAggregation can be safely accessed from multiple threads.
+unsafe impl Sync for ffi::ReduceAggregation {}
+
+/// SAFETY: GroupByAggregation is a configuration object with no thread-local state.
+unsafe impl Send for ffi::GroupByAggregation {}
+
+/// SAFETY: GroupByAggregation can be safely accessed from multiple threads.
+unsafe impl Sync for ffi::GroupByAggregation {}
 
 /// SAFETY: GroupBy configuration can be sent between threads.
 unsafe impl Send for ffi::GroupBy {}
@@ -1316,6 +1357,12 @@ unsafe impl Send for ffi::AggregationRequest {}
 
 /// SAFETY: AggregationRequest configuration can be accessed from multiple threads.
 unsafe impl Sync for ffi::AggregationRequest {}
+
+/// SAFETY: AggregationRequests owns request configuration and can be sent between threads.
+unsafe impl Send for ffi::AggregationRequests {}
+
+/// SAFETY: AggregationRequests can be safely accessed from multiple threads during aggregation.
+unsafe impl Sync for ffi::AggregationRequests {}
 
 /// SAFETY: GroupByResult contains GPU data that can be sent between threads.
 unsafe impl Send for ffi::GroupByResult {}
@@ -1610,6 +1657,44 @@ mod tests {
     }
 
     #[test]
+    fn test_count_aggregation_respects_null_policy() -> Result<(), Box<dyn std::error::Error>> {
+        let table = table_from_nullable_i32_column("values", vec![Some(1), None, Some(3), None])?;
+        let values = table.view().column(0);
+        let output_type = ffi::new_data_type(TypeId::Int32 as i32);
+
+        let exclude = ffi::reduce(
+            &values,
+            &ffi::make_count_aggregation(NullPolicy::Exclude as i32),
+            &output_type,
+        )?;
+        let include = ffi::reduce(
+            &values,
+            &ffi::make_count_aggregation(NullPolicy::Include as i32),
+            &output_type,
+        )?;
+
+        let exclude_column = ffi::make_column_from_scalar(&exclude, 1)?;
+        let include_column = ffi::make_column_from_scalar(&include, 1)?;
+
+        assert_snapshot!(pretty_column(&exclude_column.view(), DataType::Int32)?, @r"
+        +------+
+        | test |
+        +------+
+        | 2    |
+        +------+
+        ");
+        assert_snapshot!(pretty_column(&include_column.view(), DataType::Int32)?, @r"
+        +------+
+        | test |
+        +------+
+        | 4    |
+        +------+
+        ");
+
+        Ok(())
+    }
+
+    #[test]
     fn test_ast_filter_join_indices() -> Result<(), Box<dyn std::error::Error>> {
         let left =
             table_from_i32_columns(&[("key", vec![1, 2, 2, 3]), ("val", vec![10, 20, 25, 30])])?;
@@ -1695,14 +1780,23 @@ mod tests {
         let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
-        let groupby = ffi::groupby_create(&table_view.select(&[21]));
+        let column_order: &[i32] = &[];
+        let null_precedence: &[i32] = &[];
+        let groupby = ffi::groupby_create(
+            &table_view.select(&[21]),
+            NullPolicy::Exclude as i32,
+            Sorted::No as i32,
+            column_order,
+            null_precedence,
+        );
 
         let value_column = table_view.column(1);
         let mut request = ffi::aggregation_request_create(&value_column);
         request.pin_mut().add(ffi::make_max_aggregation_groupby());
 
-        let agg_requests = &[&*request as *const ffi::AggregationRequest];
-        let mut groupby_result = groupby.aggregate(agg_requests)?;
+        let mut agg_requests = ffi::aggregation_requests_create();
+        agg_requests.pin_mut().add(request);
+        let mut groupby_result = groupby.aggregate(&agg_requests)?;
 
         let mut aggregation_result = groupby_result.pin_mut().release_result(0);
         let keys = groupby_result.pin_mut().release_keys();
@@ -1722,7 +1816,15 @@ mod tests {
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0]);
-        let groupby = ffi::groupby_create(&keys_view);
+        let column_order: &[i32] = &[];
+        let null_precedence: &[i32] = &[];
+        let groupby = ffi::groupby_create(
+            &keys_view,
+            NullPolicy::Exclude as i32,
+            Sorted::No as i32,
+            column_order,
+            null_precedence,
+        );
 
         let value_column = table_view.column(1);
         let mut agg_request = ffi::aggregation_request_create(&value_column);
@@ -1736,8 +1838,9 @@ mod tests {
             .pin_mut()
             .add(ffi::make_max_aggregation_groupby());
 
-        let requests = &[&*agg_request as *const ffi::AggregationRequest];
-        let mut groupby_result = groupby.aggregate(requests)?;
+        let mut requests = ffi::aggregation_requests_create();
+        requests.pin_mut().add(agg_request);
+        let mut groupby_result = groupby.aggregate(&requests)?;
 
         assert_eq!(groupby_result.len(), 1);
         let mut agg_result = groupby_result.pin_mut().release_result(0);
@@ -1862,6 +1965,24 @@ mod tests {
             .map(|(_, values)| Arc::new(Int32Array::from(values.clone())) as _)
             .collect();
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), arrays)?;
+        let struct_array = StructArray::from(batch);
+        let array_data = struct_array.into_data();
+        let ffi_array = FFI_ArrowArray::new(&array_data);
+        let ffi_schema = FFI_ArrowSchema::try_from(schema)?;
+        let device_array = ArrowDeviceArray::new_cpu().with_array(ffi_array);
+
+        let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
+        let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
+        Ok(unsafe { ffi::table_from_arrow_host(schema_ptr, device_array_ptr) }?)
+    }
+
+    fn table_from_nullable_i32_column(
+        name: &str,
+        values: Vec<Option<i32>>,
+    ) -> Result<cxx::UniquePtr<ffi::Table>, Box<dyn std::error::Error>> {
+        let schema = Schema::new(vec![Field::new(name, DataType::Int32, true)]);
+        let array = Int32Array::from(values);
+        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(array)])?;
         let struct_array = StructArray::from(batch);
         let array_data = struct_array.into_data();
         let ffi_array = FFI_ArrowArray::new(&array_data);

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -4,11 +4,12 @@ use crate::table_view::CuDFTableView;
 use crate::{CuDFColumn, CuDFColumnView, CuDFTable};
 use cxx::UniquePtr;
 use libcudf_sys::ffi::{
-    self, aggregation_request_create, make_count_aggregation_groupby, make_max_aggregation_groupby,
-    make_mean_aggregation_groupby, make_median_aggregation_groupby, make_min_aggregation_groupby,
-    make_nunique_aggregation_groupby, make_std_aggregation_groupby, make_sum_aggregation_groupby,
-    make_variance_aggregation_groupby,
+    self, aggregation_request_create, aggregation_requests_create, make_count_aggregation_groupby,
+    make_max_aggregation_groupby, make_mean_aggregation_groupby, make_median_aggregation_groupby,
+    make_min_aggregation_groupby, make_nunique_aggregation_groupby, make_std_aggregation_groupby,
+    make_sum_aggregation_groupby, make_variance_aggregation_groupby,
 };
+use libcudf_sys::{NullPolicy, Sorted};
 use std::sync::Arc;
 
 /// A group-by operation builder
@@ -27,7 +28,15 @@ impl CuDFGroupBy {
     /// The keys determine how rows are grouped. Rows with matching key
     /// values will be grouped together for aggregation.
     pub fn from_table_view(view: CuDFTableView) -> Self {
-        let inner = ffi::groupby_create(view.inner());
+        let column_order: &[i32] = &[];
+        let null_precedence: &[i32] = &[];
+        let inner = ffi::groupby_create(
+            view.inner(),
+            NullPolicy::Exclude as i32,
+            Sorted::No as i32,
+            column_order,
+            null_precedence,
+        );
         Self {
             _ref: Some(Arc::new(view)),
             inner,
@@ -39,19 +48,18 @@ impl CuDFGroupBy {
     /// Each request specifies a column to aggregate and the aggregations
     /// to perform on it. Returns the unique group keys and aggregation
     /// results for each group.
-    pub fn aggregate(
-        &self,
-        requests: &[AggregationRequest],
-    ) -> Result<(CuDFTable, Vec<Vec<CuDFColumn>>)> {
-        let mut _refs = Vec::with_capacity(requests.len());
-        let requests = requests
-            .iter()
-            .map(|x| {
-                _refs.push(x._ref.clone());
-                x.inner.as_ptr()
-            })
-            .collect::<Vec<_>>();
-        let mut gby_result = self.inner.aggregate(&requests)?;
+    pub fn aggregate<I>(&self, requests: I) -> Result<(CuDFTable, Vec<Vec<CuDFColumn>>)>
+    where
+        I: IntoIterator<Item = AggregationRequest>,
+    {
+        let mut _refs = Vec::new();
+        let mut requests_inner = aggregation_requests_create();
+        for request in requests {
+            _refs.push(request._ref.clone());
+            requests_inner.pin_mut().add(request.inner);
+        }
+
+        let mut gby_result = self.inner.aggregate(&requests_inner)?;
         let keys = gby_result.pin_mut().release_keys();
         let keys = CuDFTable::from_ptr(keys);
 
@@ -96,25 +104,28 @@ impl AggregationRequest {
     ///
     /// Multiple aggregations can be added to aggregate the same column
     /// in different ways (e.g., both SUM and COUNT).
-    pub fn add(&mut self, aggregation: Aggregation) {
+    pub fn add(&mut self, aggregation: GroupByAggregation) {
         self.inner.add(aggregation.inner);
     }
 }
 
-/// An aggregation operation specification
+/// A groupby aggregation operation specification
 ///
 /// Specifies how to aggregate values within each group. Created using
 /// factory methods from `AggregationOp`.
-pub struct Aggregation {
-    inner: UniquePtr<ffi::Aggregation>,
+pub struct GroupByAggregation {
+    inner: UniquePtr<ffi::GroupByAggregation>,
 }
 
-impl Aggregation {
-    /// Create an aggregation from a cuDF aggregation pointer
-    pub fn new(inner: UniquePtr<ffi::Aggregation>) -> Self {
+impl GroupByAggregation {
+    /// Create a groupby aggregation from a cuDF aggregation pointer
+    pub fn new(inner: UniquePtr<ffi::GroupByAggregation>) -> Self {
         Self { inner }
     }
 }
+
+/// Backwards-compatible alias for groupby aggregations.
+pub type Aggregation = GroupByAggregation;
 
 /// Types of aggregation operations
 ///
@@ -157,18 +168,22 @@ impl AggregationOp {
     /// let sum_agg = AggregationOp::SUM.group_by();
     /// let count_agg = AggregationOp::COUNT.group_by();
     /// ```
-    pub fn group_by(&self) -> Aggregation {
+    pub fn group_by(&self) -> GroupByAggregation {
         use AggregationOp::*;
         match self {
-            SUM => Aggregation::new(make_sum_aggregation_groupby()),
-            MIN => Aggregation::new(make_min_aggregation_groupby()),
-            MAX => Aggregation::new(make_max_aggregation_groupby()),
-            MEAN => Aggregation::new(make_mean_aggregation_groupby()),
-            COUNT => Aggregation::new(make_count_aggregation_groupby()),
-            VARIANCE { ddof } => Aggregation::new(make_variance_aggregation_groupby(*ddof)),
-            STD { ddof } => Aggregation::new(make_std_aggregation_groupby(*ddof)),
-            NUNIQUE => Aggregation::new(make_nunique_aggregation_groupby()),
-            MEDIAN => Aggregation::new(make_median_aggregation_groupby()),
+            SUM => GroupByAggregation::new(make_sum_aggregation_groupby()),
+            MIN => GroupByAggregation::new(make_min_aggregation_groupby()),
+            MAX => GroupByAggregation::new(make_max_aggregation_groupby()),
+            MEAN => GroupByAggregation::new(make_mean_aggregation_groupby()),
+            COUNT => {
+                GroupByAggregation::new(make_count_aggregation_groupby(NullPolicy::Exclude as i32))
+            }
+            VARIANCE { ddof } => GroupByAggregation::new(make_variance_aggregation_groupby(*ddof)),
+            STD { ddof } => GroupByAggregation::new(make_std_aggregation_groupby(*ddof)),
+            NUNIQUE => GroupByAggregation::new(make_nunique_aggregation_groupby(
+                NullPolicy::Exclude as i32,
+            )),
+            MEDIAN => GroupByAggregation::new(make_median_aggregation_groupby()),
         }
     }
 }
@@ -298,7 +313,7 @@ mod tests {
         let mut request = AggregationRequest::from_column_view(values_col.into_view());
         request.add(AggregationOp::SUM.group_by());
 
-        let (result_keys, results) = groupby.aggregate(&[request])?;
+        let (result_keys, results) = groupby.aggregate([request])?;
 
         assert_eq!(result_keys.num_rows(), 2);
 
@@ -350,7 +365,7 @@ mod tests {
         let mut request = AggregationRequest::from_column_view(values_col.into_view());
         request.add(agg_op.group_by());
 
-        let (_result_keys, results) = groupby.aggregate(&[request])?;
+        let (_result_keys, results) = groupby.aggregate([request])?;
         let result_col = results
             .into_iter()
             .next()


### PR DESCRIPTION
## Summary

- align libcudf-sys reduce wrappers with cuDF's full data_type output signature and init overload
- split aggregation wrappers into reduce and groupby-specific types so the sys layer no longer erases them into cudf::aggregation
- expose cuDF groupby constructor arguments and count/nunique null_policy parameters for the wrapped factories
- move groupby aggregation requests into the contiguous request storage expected by cuDF, avoiding aggregation clone/downcast plumbing
- update libcudf-datafusion call sites for the owned request flow

## Scope

This intentionally does not add streams or full aggregation factory parity. It keeps the PR focused on the reduce/groupby aggregation APIs currently wrapped here.

## Validation

- cargo fmt --all --check
- git diff --check
- cargo test -p libcudf-sys count_aggregation -- --nocapture
- cargo test -p libcudf-sys groupby -- --nocapture
- cargo test -p libcudf-rs group_by -- --nocapture
- cargo test -p libcudf-datafusion
