### PR TITLE
Introduce stream and resource handles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,33 @@ Rules for `libcudf-sys`:
     - If cuDF has a free function (e.g., `cudf::reduce()`), expose as free function (e.g., `reduce()`)
     - Constructors become factory functions (e.g., `groupby::groupby()` → `groupby_create()`)
 
+Mandatory parity gate for every `libcudf-sys` change:
+
+1. Start from the exact local cuDF/RMM headers used by this build. Locate them with
+   `find target/ -type d -name "cudf-*" | grep -E "cudf-[0-9]+\.[0-9]+\.[0-9]+$" | head -1`.
+   Do not rely on memory, Python docs, Java docs, or older RAPIDS versions.
+2. Identify the upstream C++ declaration before writing Rust or bridge code. The sys API must preserve the upstream
+   shape: function vs method, overloads, parameter order, required parameters, defaulted parameters, enum values,
+   return type, ownership, metadata, null handling, stream arguments, memory-resource arguments, and error behavior.
+3. Do not drop upstream parameters in sys. If cuDF accepts an option, policy, stream, memory resource, output type,
+   initial value, metadata output, or predicate handle, sys must expose it. Default-only convenience belongs in
+   `libcudf-rs`, not in `libcudf-sys`.
+4. Do not collapse upstream return shapes. If cuDF returns a pair, vector, table-with-metadata, device vector, scalar,
+   or aggregation result, sys must preserve that shape as directly as `cxx` allows.
+5. If `cxx` cannot expose an upstream C++ type directly, add the smallest opaque wrapper or bridge container needed.
+   The wrapper must map directly to the upstream type's fields, ownership, and lifetime. It must not add filtering,
+   conversion, defaulting, aggregation, indexing policy, or other convenience behavior.
+6. RMM/CUDA support types in sys must also be upstream-shaped wrappers: streams, stream views, resource refs, and memory
+   resources. Do not invent lifecycle, pooling, synchronization, or allocation behavior unless it directly wraps an
+   upstream type or method.
+7. Every enum exposed by sys must be numerically aligned with the upstream enum. Add parity checks for enum surfaces
+   that are easy to drift.
+8. Tests should lock binding parity where drift is likely: enum discriminants, overload presence, omitted-parameter
+   risks, output shape/metadata preservation, and ownership/handle plumbing. Do not add tests that only restate a local
+   helper implementation.
+9. If a perfect upstream-shaped binding is impossible, document the `cxx` limitation in code and keep the deviation
+   minimal and mechanical. Any ergonomic API must be added in `libcudf-rs`.
+
 Example of what NOT to do:
 
 ```cpp
@@ -119,4 +146,3 @@ This is where you can:
 - Be careful of having multiple versions of the CUDA toolkit installed in the system
 - There's no need for prefixing commands with LD_LIBRARY_PATH=/path/to/something. If the LD_LIBRARY_PATH is needed it
   means there's something wrong with libcudf-sys/build.rs
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,33 @@ Rules for `libcudf-sys`:
     - If cuDF has a free function (e.g., `cudf::reduce()`), expose as free function (e.g., `reduce()`)
     - Constructors become factory functions (e.g., `groupby::groupby()` → `groupby_create()`)
 
+Mandatory parity gate for every `libcudf-sys` change:
+
+1. Start from the exact local cuDF/RMM headers used by this build. Locate them with
+   `find target/ -type d -name "cudf-*" | grep -E "cudf-[0-9]+\.[0-9]+\.[0-9]+$" | head -1`.
+   Do not rely on memory, Python docs, Java docs, or older RAPIDS versions.
+2. Identify the upstream C++ declaration before writing Rust or bridge code. The sys API must preserve the upstream
+   shape: function vs method, overloads, parameter order, required parameters, defaulted parameters, enum values,
+   return type, ownership, metadata, null handling, stream arguments, memory-resource arguments, and error behavior.
+3. Do not drop upstream parameters in sys. If cuDF accepts an option, policy, stream, memory resource, output type,
+   initial value, metadata output, or predicate handle, sys must expose it. Default-only convenience belongs in
+   `libcudf-rs`, not in `libcudf-sys`.
+4. Do not collapse upstream return shapes. If cuDF returns a pair, vector, table-with-metadata, device vector, scalar,
+   or aggregation result, sys must preserve that shape as directly as `cxx` allows.
+5. If `cxx` cannot expose an upstream C++ type directly, add the smallest opaque wrapper or bridge container needed.
+   The wrapper must map directly to the upstream type's fields, ownership, and lifetime. It must not add filtering,
+   conversion, defaulting, aggregation, indexing policy, or other convenience behavior.
+6. RMM/CUDA support types in sys must also be upstream-shaped wrappers: streams, stream views, resource refs, and memory
+   resources. Do not invent lifecycle, pooling, synchronization, or allocation behavior unless it directly wraps an
+   upstream type or method.
+7. Every enum exposed by sys must be numerically aligned with the upstream enum. Add parity checks for enum surfaces
+   that are easy to drift.
+8. Tests should lock binding parity where drift is likely: enum discriminants, overload presence, omitted-parameter
+   risks, output shape/metadata preservation, and ownership/handle plumbing. Do not add tests that only restate a local
+   helper implementation.
+9. If a perfect upstream-shaped binding is impossible, document the `cxx` limitation in code and keep the deviation
+   minimal and mechanical. Any ergonomic API must be added in `libcudf-rs`.
+
 Example of what NOT to do:
 
 ```cpp
@@ -118,4 +145,3 @@ This is where you can:
 - Be careful of having multiple versions of the CUDA toolkit installed in the system
 - There's no need for prefixing commands with LD_LIBRARY_PATH=/path/to/something. If the LD_LIBRARY_PATH is needed it
   means there's something wrong with libcudf-sys/build.rs
-

--- a/libcudf-sys/src/device_memory.h
+++ b/libcudf-sys/src/device_memory.h
@@ -7,9 +7,9 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 
 namespace libcudf_bridge {
-    /// 1:1 owning wrapper around `rmm::mr::cuda_memory_resource`. Allocates GPU
-    /// memory directly via `cudaMalloc` / `cudaFree`. Typically used as the
-    /// upstream for [`PoolMemoryResource`] rather than directly.
+    /// Owning wrapper around `rmm::mr::cuda_memory_resource`. Allocates GPU memory
+    /// directly via `cudaMalloc` / `cudaFree`. Typically used as the upstream for
+    /// [`PoolMemoryResource`] rather than directly.
     struct CudaMemoryResource {
         std::unique_ptr<rmm::mr::cuda_memory_resource> inner;
 
@@ -18,12 +18,12 @@ namespace libcudf_bridge {
         [[nodiscard]] rmm::mr::cuda_memory_resource* get() const;
     };
 
-    /// 1:1 with `rmm::mr::cuda_memory_resource()` constructor.
+    /// Construct an RMM CUDA memory resource.
     std::unique_ptr<CudaMemoryResource> make_cuda_memory_resource();
 
-    /// 1:1 owning wrapper around
-    /// `rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>`.
-    /// Sub-allocates from a single up-front `cudaMalloc` slab.
+    /// Owning wrapper around `rmm::mr::pool_memory_resource` backed by
+    /// `rmm::mr::cuda_memory_resource`. Sub-allocates from a single up-front
+    /// `cudaMalloc` slab.
     struct PoolMemoryResource {
         std::unique_ptr<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>> inner;
 
@@ -34,18 +34,16 @@ namespace libcudf_bridge {
         [[nodiscard]] rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>* get() const;
     };
 
-    /// 1:1 with the `rmm::mr::pool_memory_resource(upstream, initial, max)`
-    /// constructor. Borrows the upstream MR for the pool's lifetime.
+    /// Construct an RMM pool memory resource. Borrows the upstream resource for
+    /// the pool's lifetime.
     std::unique_ptr<PoolMemoryResource> make_pool_memory_resource(
         const CudaMemoryResource& upstream,
         std::size_t initial_size,
         std::size_t max_size);
 
-    /// 1:1 with `rmm::mr::set_current_device_resource`.
+    /// Install the pool as RMM's current device resource.
     void set_current_device_resource(const PoolMemoryResource& resource);
 
-    /// 1:1 with `rmm::available_device_memory()`. Returns total bytes of VRAM
-    /// on the current CUDA device. (RMM also returns the free amount; we only
-    /// expose total, which is what callers need for capacity-based sizing.)
+    /// Return total VRAM bytes on the current CUDA device.
     std::size_t total_device_memory();
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -33,6 +33,7 @@ pub mod ffi {
         include!("libcudf-sys/src/sorting.h");
         include!("libcudf-sys/src/join.h");
         include!("libcudf-sys/src/stream.h");
+        include!("libcudf-sys/src/memory_resource.h");
         include!("libcudf-sys/src/pinned_host.h");
         include!("libcudf-sys/src/device_memory.h");
 
@@ -143,6 +144,9 @@ pub mod ffi {
         /// Opaque owning wrapper for an RMM CUDA stream.
         type CudaStream;
 
+        /// Opaque non-owning wrapper for an RMM CUDA stream view.
+        type CudaStreamView;
+
         /// Return whether this wrapper still owns an underlying CUDA stream.
         ///
         /// In C++, you could do something like
@@ -155,6 +159,21 @@ pub mod ffi {
         /// However, there's no ffi API available right now to do this via rust, so there's no
         /// need to worry about invalidating a stream at the moment.
         fn is_valid(self: &CudaStream) -> bool;
+
+        /// Synchronize the owned CUDA stream.
+        fn synchronize(self: &CudaStream) -> Result<()>;
+
+        /// Return true if this is the CUDA legacy default stream.
+        fn is_default(self: &CudaStreamView) -> bool;
+
+        /// Return true if this is the CUDA per-thread default stream.
+        fn is_per_thread_default(self: &CudaStreamView) -> bool;
+
+        /// Synchronize the viewed CUDA stream.
+        fn synchronize(self: &CudaStreamView) -> Result<()>;
+
+        /// Opaque non-owning wrapper for an RMM device async resource reference.
+        type DeviceAsyncResourceRef;
 
         /// Request for groupby aggregation(s) to perform on a column
         ///
@@ -733,58 +752,81 @@ pub mod ffi {
         /// Get the version of the cuDF library
         fn get_cudf_version() -> String;
 
-        /// 1:1 with `cudf::config_default_pinned_memory_resource`.
+        /// Configure cuDF's default pinned-memory resource pool.
         fn config_default_pinned_memory_resource(pool_size_bytes: usize) -> bool;
 
-        /// 1:1 with `cudf::set_allocate_host_as_pinned_threshold`.
+        /// Set cuDF's host allocation threshold for pinned memory.
         fn set_allocate_host_as_pinned_threshold(threshold_bytes: usize);
 
         /// Create a CUDA stream using the default creation flag.
-        fn cuda_stream_create() -> UniquePtr<CudaStream>;
+        fn cuda_stream_create() -> Result<UniquePtr<CudaStream>>;
 
         /// Create a CUDA stream with explicit creation flags.
-        fn cuda_stream_create_with_flags(flags: u32) -> UniquePtr<CudaStream>;
+        fn cuda_stream_create_with_flags(flags: u32) -> Result<UniquePtr<CudaStream>>;
 
-        /// 1:1 wrapper around `rmm::host_device_async_resource_ref`.
+        /// Return a non-owning view for an owned CUDA stream.
+        fn cuda_stream_view(stream: &CudaStream) -> UniquePtr<CudaStreamView>;
+
+        /// Get cuDF's current default stream.
+        fn get_default_stream() -> UniquePtr<CudaStreamView>;
+
+        /// Check whether cuDF is using the CUDA per-thread default stream.
+        fn is_ptds_enabled() -> bool;
+
+        /// Return cuDF's current device memory resource reference.
+        fn get_current_device_resource_ref() -> UniquePtr<DeviceAsyncResourceRef>;
+
+        /// Set cuDF's current device memory resource reference.
+        fn set_current_device_resource_ref(
+            resource: &DeviceAsyncResourceRef,
+        ) -> UniquePtr<DeviceAsyncResourceRef>;
+
+        /// Reset cuDF's current device memory resource reference to the initial resource.
+        fn reset_current_device_resource_ref() -> UniquePtr<DeviceAsyncResourceRef>;
+
+        /// Compare two device async resource references.
+        fn device_async_resource_ref_equal(
+            lhs: &DeviceAsyncResourceRef,
+            rhs: &DeviceAsyncResourceRef,
+        ) -> bool;
+
+        /// Opaque wrapper around `rmm::host_device_async_resource_ref`.
         type HostDeviceAsyncResourceRef;
 
-        /// 1:1 with `host_device_async_resource_ref::allocate_sync`.
+        /// Allocate pinned host memory through the referenced resource.
         /// The returned pointer is encoded as `usize` because cxx does not
         /// currently expose `*mut u8` return values across the bridge.
         fn allocate_sync(self: &HostDeviceAsyncResourceRef, bytes: usize) -> Result<usize>;
 
-        /// 1:1 with `host_device_async_resource_ref::deallocate_sync`.
+        /// Deallocate pinned host memory through the referenced resource.
         fn deallocate_sync(self: &HostDeviceAsyncResourceRef, ptr: usize, bytes: usize);
 
-        /// 1:1 with `cudf::get_pinned_memory_resource()`.
+        /// Return cuDF's process-global pinned memory resource handle.
         fn get_pinned_memory_resource() -> UniquePtr<HostDeviceAsyncResourceRef>;
 
-        /// Block until all work on the CUDA default stream has completed.
+        /// Block until all work on cuDF's default stream has completed.
         fn cuda_default_stream_synchronize() -> Result<()>;
 
-        /// 1:1 owning wrapper around `rmm::mr::cuda_memory_resource`.
+        /// Opaque owning wrapper around `rmm::mr::cuda_memory_resource`.
         type CudaMemoryResource;
 
-        /// 1:1 with the `rmm::mr::cuda_memory_resource()` constructor.
+        /// Construct an RMM CUDA memory resource.
         fn make_cuda_memory_resource() -> UniquePtr<CudaMemoryResource>;
 
-        /// 1:1 owning wrapper around
-        /// `rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>`.
+        /// Opaque owning wrapper around an RMM pool memory resource.
         type PoolMemoryResource;
 
-        /// 1:1 with the `rmm::mr::pool_memory_resource(upstream, initial, max)`
-        /// constructor.
+        /// Construct an RMM pool memory resource.
         fn make_pool_memory_resource(
             upstream: &CudaMemoryResource,
             initial_size: usize,
             max_size: usize,
         ) -> UniquePtr<PoolMemoryResource>;
 
-        /// 1:1 with `rmm::mr::set_current_device_resource`.
+        /// Install the pool as RMM's current device resource.
         fn set_current_device_resource(resource: &PoolMemoryResource);
 
-        /// 1:1 with `rmm::available_device_memory().second`. Returns total
-        /// VRAM bytes on the current CUDA device.
+        /// Return total VRAM bytes on the current CUDA device.
         fn total_device_memory() -> usize;
     }
 }
@@ -1410,7 +1452,7 @@ mod tests {
     use std::fmt::Display;
     use std::sync::Arc;
 
-    const CUDA_STREAM_FLAG_BLOCKING: u32 = 1;
+    const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
     const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
 
     // Sorting tests
@@ -1947,21 +1989,73 @@ mod tests {
 
     // Test the various methods of creating streams. Assert that each method yields a valid stream.
     #[test]
-    fn test_cuda_stream_create() {
-        let stream = ffi::cuda_stream_create();
+    fn test_cuda_stream_create() -> Result<(), Box<dyn std::error::Error>> {
+        let stream = ffi::cuda_stream_create()?;
         assert!(stream.is_valid());
+        stream.synchronize()?;
 
-        let stream = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_BLOCKING);
+        let stream = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_SYNC_DEFAULT)?;
         assert!(stream.is_valid());
+        stream.synchronize()?;
 
-        let stream = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING);
+        let stream = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING)?;
         assert!(stream.is_valid());
+        stream.synchronize()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cuda_stream_view_bindings() -> Result<(), Box<dyn std::error::Error>> {
+        let stream = ffi::cuda_stream_create()?;
+        let view = ffi::cuda_stream_view(stream.as_ref().expect("CudaStream should not be null"));
+        view.synchronize()?;
+
+        let default_view = ffi::get_default_stream();
+        if ffi::is_ptds_enabled() {
+            assert!(default_view.is_per_thread_default());
+        } else {
+            assert!(default_view.is_default());
+        }
+        default_view.synchronize()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_device_async_resource_ref_bindings() -> Result<(), Box<dyn std::error::Error>> {
+        let current = ffi::get_current_device_resource_ref();
+        let previous = ffi::set_current_device_resource_ref(
+            current
+                .as_ref()
+                .expect("DeviceAsyncResourceRef should not be null"),
+        );
+        let after = ffi::get_current_device_resource_ref();
+
+        assert!(ffi::device_async_resource_ref_equal(
+            current
+                .as_ref()
+                .expect("DeviceAsyncResourceRef should not be null"),
+            previous
+                .as_ref()
+                .expect("DeviceAsyncResourceRef should not be null"),
+        ));
+        assert!(ffi::device_async_resource_ref_equal(
+            current
+                .as_ref()
+                .expect("DeviceAsyncResourceRef should not be null"),
+            after
+                .as_ref()
+                .expect("DeviceAsyncResourceRef should not be null"),
+        ));
+
+        Ok(())
     }
 
     // Test that streams are Send and Sync.
     #[test]
-    fn test_cuda_stream_send_sync() {
-        let stream = Arc::new(ffi::cuda_stream_create());
+    fn test_cuda_stream_send_sync() -> Result<(), Box<dyn std::error::Error>> {
+        let stream = Arc::new(ffi::cuda_stream_create()?);
 
         let handle = std::thread::spawn({
             let stream = Arc::clone(&stream);
@@ -1970,6 +2064,8 @@ mod tests {
 
         assert!(handle.join().expect("moved stream should be valid"));
         assert!(stream.is_valid());
+
+        Ok(())
     }
 
     fn table_from_i32_columns(

--- a/libcudf-sys/src/memory_resource.cpp
+++ b/libcudf-sys/src/memory_resource.cpp
@@ -1,0 +1,28 @@
+#include "memory_resource.h"
+
+namespace libcudf_bridge {
+    DeviceAsyncResourceRef::DeviceAsyncResourceRef(rmm::device_async_resource_ref resource)
+        : inner(resource) {}
+
+    DeviceAsyncResourceRef::~DeviceAsyncResourceRef() = default;
+
+    std::unique_ptr<DeviceAsyncResourceRef> get_current_device_resource_ref() {
+        return std::make_unique<DeviceAsyncResourceRef>(cudf::get_current_device_resource_ref());
+    }
+
+    std::unique_ptr<DeviceAsyncResourceRef> set_current_device_resource_ref(
+        const DeviceAsyncResourceRef& resource) {
+        return std::make_unique<DeviceAsyncResourceRef>(
+            cudf::set_current_device_resource_ref(resource.inner));
+    }
+
+    std::unique_ptr<DeviceAsyncResourceRef> reset_current_device_resource_ref() {
+        return std::make_unique<DeviceAsyncResourceRef>(cudf::reset_current_device_resource_ref());
+    }
+
+    bool device_async_resource_ref_equal(
+        const DeviceAsyncResourceRef& lhs,
+        const DeviceAsyncResourceRef& rhs) {
+        return lhs.inner == rhs.inner;
+    }
+} // namespace libcudf_bridge

--- a/libcudf-sys/src/memory_resource.h
+++ b/libcudf-sys/src/memory_resource.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+
+#include <cudf/utilities/memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+namespace libcudf_bridge {
+    /// Non-owning wrapper for an RMM device async resource reference.
+    struct DeviceAsyncResourceRef {
+        rmm::device_async_resource_ref inner;
+
+        explicit DeviceAsyncResourceRef(rmm::device_async_resource_ref resource);
+
+        ~DeviceAsyncResourceRef();
+    };
+
+    /// Return cuDF's current device memory resource reference.
+    std::unique_ptr<DeviceAsyncResourceRef> get_current_device_resource_ref();
+
+    /// Set cuDF's current device memory resource reference.
+    std::unique_ptr<DeviceAsyncResourceRef> set_current_device_resource_ref(
+        const DeviceAsyncResourceRef& resource);
+
+    /// Reset cuDF's current device memory resource reference to the initial resource.
+    std::unique_ptr<DeviceAsyncResourceRef> reset_current_device_resource_ref();
+
+    /// Compare two device async resource references.
+    bool device_async_resource_ref_equal(
+        const DeviceAsyncResourceRef& lhs,
+        const DeviceAsyncResourceRef& rhs);
+} // namespace libcudf_bridge

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -98,7 +98,7 @@ namespace libcudf_bridge {
         return result;
     }
 
-    // Direct cuDF operations - 1:1 mappings
+    // Direct cuDF operations exposed through bridge-owned return types.
     std::unique_ptr<Table> apply_boolean_mask(const TableView &table, const ColumnView &boolean_mask) {
         auto result = std::make_unique<Table>();
         result->inner = cudf::apply_boolean_mask(*table.inner, *boolean_mask.inner);

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -13,7 +13,7 @@ struct ArrowDeviceArray;
 struct ArrowArray;
 
 namespace libcudf_bridge {
-    // Direct cuDF operations - 1:1 mappings
+    // Direct cuDF operations exposed through bridge-owned return types.
     std::unique_ptr<Table> apply_boolean_mask(const TableView &table, const ColumnView &boolean_mask);
 
     // Arrow interop - direct cuDF calls
@@ -55,9 +55,9 @@ namespace libcudf_bridge {
     // Utility functions
     rust::String get_cudf_version();
 
-    // 1:1 with `cudf::config_default_pinned_memory_resource`.
+    // Configure cuDF's default pinned-memory resource pool.
     bool config_default_pinned_memory_resource(size_t pool_size_bytes);
 
-    // 1:1 with `cudf::set_allocate_host_as_pinned_threshold`.
+    // Set cuDF's host allocation threshold for pinned memory.
     void set_allocate_host_as_pinned_threshold(size_t threshold_bytes);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/pinned_host.cpp
+++ b/libcudf-sys/src/pinned_host.cpp
@@ -1,6 +1,7 @@
 #include "pinned_host.h"
 
-#include <cuda_runtime.h>
+#include <cudf/utilities/default_stream.hpp>
+
 #include <utility>
 
 namespace libcudf_bridge {
@@ -20,6 +21,6 @@ namespace libcudf_bridge {
     }
 
     void cuda_default_stream_synchronize() {
-        cudaStreamSynchronize(nullptr);
+        cudf::get_default_stream().synchronize();
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/pinned_host.h
+++ b/libcudf-sys/src/pinned_host.h
@@ -26,18 +26,17 @@ namespace libcudf_bridge {
 
         explicit HostDeviceAsyncResourceRef(rmm::host_device_async_resource_ref ref);
 
-        /// 1:1 with `host_device_async_resource_ref::allocate_sync`. Returned
-        /// as `size_t` because cxx does not currently expose `*mut u8` across
-        /// the bridge.
+        /// Allocate pinned host memory through the referenced resource. Returned
+        /// as `size_t` because cxx does not expose `*mut u8` across the bridge.
         [[nodiscard]] size_t allocate_sync(size_t bytes) const;
 
-        /// 1:1 with `host_device_async_resource_ref::deallocate_sync`.
+        /// Deallocate pinned host memory through the referenced resource.
         void deallocate_sync(size_t ptr, size_t bytes) const;
     };
 
-    /// 1:1 with `cudf::get_pinned_memory_resource()`.
+    /// Return cuDF's process-global pinned memory resource handle.
     std::unique_ptr<HostDeviceAsyncResourceRef> get_pinned_memory_resource();
 
-    /// 1:1 with `cudaStreamSynchronize(0)` (the default stream).
+    /// Block until all work on cuDF's default stream has completed.
     void cuda_default_stream_synchronize();
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/stream.cpp
+++ b/libcudf-sys/src/stream.cpp
@@ -7,18 +7,33 @@ namespace libcudf_bridge {
         constexpr uint32_t kCudaStreamFlagSyncDefault = 0;
         constexpr uint32_t kCudaStreamFlagNonBlocking = 1;
 
-        // Map our flags to [`rmm::cuda_stream::flags`].
-        [[nodiscard]] rmm::cuda_stream::flags to_rmm_flags(const uint32_t flags) {
-            switch (flags) {
-                case kCudaStreamFlagSyncDefault:
-                    return rmm::cuda_stream::flags::sync_default;
-                case kCudaStreamFlagNonBlocking:
-                    return rmm::cuda_stream::flags::non_blocking;
-            }
+        static_assert(
+            static_cast<uint32_t>(rmm::cuda_stream::flags::sync_default) ==
+            kCudaStreamFlagSyncDefault);
+        static_assert(
+            static_cast<uint32_t>(rmm::cuda_stream::flags::non_blocking) ==
+            kCudaStreamFlagNonBlocking);
 
-            throw std::invalid_argument("Unsupported CUDA stream flags");
+        [[nodiscard]] rmm::cuda_stream::flags to_rmm_flags(const uint32_t flags) {
+            return static_cast<rmm::cuda_stream::flags>(flags);
         }
     } // namespace
+
+    CudaStreamView::CudaStreamView(rmm::cuda_stream_view stream) : inner(stream) {}
+
+    CudaStreamView::~CudaStreamView() = default;
+
+    bool CudaStreamView::is_default() const {
+        return inner.is_default();
+    }
+
+    bool CudaStreamView::is_per_thread_default() const {
+        return inner.is_per_thread_default();
+    }
+
+    void CudaStreamView::synchronize() const {
+        inner.synchronize();
+    }
 
     /// By default, create a stream that synchronizes with the default stream
     /// (ie. this uses [`rmm::cuda_stream::flags::sync_default`]).
@@ -42,11 +57,30 @@ namespace libcudf_bridge {
         return inner->view();
     }
 
+    void CudaStream::synchronize() const {
+        if (!inner) {
+            throw std::runtime_error("Cannot synchronize null CUDA stream");
+        }
+        inner->synchronize();
+    }
+
     std::unique_ptr<CudaStream> cuda_stream_create() {
         return std::make_unique<CudaStream>();
     }
 
     std::unique_ptr<CudaStream> cuda_stream_create_with_flags(const uint32_t flags) {
         return std::make_unique<CudaStream>(flags);
+    }
+
+    std::unique_ptr<CudaStreamView> cuda_stream_view(const CudaStream& stream) {
+        return std::make_unique<CudaStreamView>(stream.view());
+    }
+
+    std::unique_ptr<CudaStreamView> get_default_stream() {
+        return std::make_unique<CudaStreamView>(cudf::get_default_stream());
+    }
+
+    bool is_ptds_enabled() {
+        return cudf::is_ptds_enabled();
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/stream.h
+++ b/libcudf-sys/src/stream.h
@@ -2,10 +2,29 @@
 
 #include <cstdint>
 #include <memory>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace libcudf_bridge {
+    /// Non-owning wrapper for an RMM CUDA stream view.
+    struct CudaStreamView {
+        rmm::cuda_stream_view inner;
+
+        explicit CudaStreamView(rmm::cuda_stream_view stream);
+
+        ~CudaStreamView();
+
+        /// Return true if this is the CUDA legacy default stream.
+        [[nodiscard]] bool is_default() const;
+
+        /// Return true if this is the CUDA per-thread default stream.
+        [[nodiscard]] bool is_per_thread_default() const;
+
+        /// Synchronize the viewed CUDA stream.
+        void synchronize() const;
+    };
+
     /// Owning wrapper for an RMM CUDA stream.
     struct CudaStream {
         std::unique_ptr<rmm::cuda_stream> inner;
@@ -26,6 +45,9 @@ namespace libcudf_bridge {
 
         /// Return a non-owning stream view for passing into cuDF APIs.
         [[nodiscard]] rmm::cuda_stream_view view() const;
+
+        /// Synchronize the owned CUDA stream.
+        void synchronize() const;
     };
 
     /// Create a CUDA stream using the default sync-default creation flag.
@@ -33,4 +55,13 @@ namespace libcudf_bridge {
 
     /// Create a CUDA stream with an explicit raw flag value.
     std::unique_ptr<CudaStream> cuda_stream_create_with_flags(uint32_t flags);
+
+    /// Return a non-owning view for an owned CUDA stream.
+    std::unique_ptr<CudaStreamView> cuda_stream_view(const CudaStream& stream);
+
+    /// Get cuDF's current default stream.
+    std::unique_ptr<CudaStreamView> get_default_stream();
+
+    /// Check whether cuDF is using the CUDA per-thread default stream.
+    bool is_ptds_enabled();
 } // namespace libcudf_bridge

--- a/src/pinned.rs
+++ b/src/pinned.rs
@@ -67,7 +67,7 @@ impl Drop for PinnedHostBuffer {
     }
 }
 
-/// Block until all GPU work submitted to the CUDA default stream has
+/// Block until all GPU work submitted to cuDF's default stream has
 /// completed.
 ///
 /// Required after issuing an asynchronous upload from a pinned source if the

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,23 +1,20 @@
 use cxx::UniquePtr;
 
+use crate::Result;
+
 /// Stream creation flags for CUDA stream-backed cuDF execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
 pub enum CuDFStreamFlags {
     /// Create a stream that synchronizes with the default stream.
-    SyncDefault,
+    SyncDefault = 0,
     /// Create a non-blocking stream that does not synchronize with the default stream.
-    NonBlocking,
+    NonBlocking = 1,
 }
-
-const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
-const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
 
 impl From<CuDFStreamFlags> for u32 {
     fn from(value: CuDFStreamFlags) -> Self {
-        match value {
-            CuDFStreamFlags::SyncDefault => CUDA_STREAM_FLAG_SYNC_DEFAULT,
-            CuDFStreamFlags::NonBlocking => CUDA_STREAM_FLAG_NON_BLOCKING,
-        }
+        value as u32
     }
 }
 
@@ -37,18 +34,34 @@ pub struct CuDFStream {
 }
 
 impl CuDFStream {
+    /// Try to create a stream using the sync-default creation flag.
+    pub fn try_new() -> Result<Self> {
+        Ok(Self {
+            inner: libcudf_sys::ffi::cuda_stream_create()?,
+        })
+    }
+
     /// Create a stream using the sync-default creation flag.
     pub fn new() -> Self {
-        Self {
-            inner: libcudf_sys::ffi::cuda_stream_create(),
-        }
+        Self::try_new().expect("failed to create CUDA stream")
+    }
+
+    /// Try to create a stream with explicit creation flags.
+    pub fn try_with_flags(flags: CuDFStreamFlags) -> Result<Self> {
+        Ok(Self {
+            inner: libcudf_sys::ffi::cuda_stream_create_with_flags(flags.into())?,
+        })
     }
 
     /// Create a stream with explicit creation flags.
     pub fn with_flags(flags: CuDFStreamFlags) -> Self {
-        Self {
-            inner: libcudf_sys::ffi::cuda_stream_create_with_flags(flags.into()),
-        }
+        Self::try_with_flags(flags).expect("failed to create CUDA stream")
+    }
+
+    /// Block until all work submitted to this stream has completed.
+    pub fn synchronize(&self) -> Result<()> {
+        self.inner().synchronize()?;
+        Ok(())
     }
 
     /// Get a reference to the underlying FFI stream handle.


### PR DESCRIPTION
## Summary

Adds explicit stream and memory-resource handle bindings at the `libcudf-sys` layer so later API work can accept cuDF/RMM stream and resource parameters without inventing new ownership semantics.

This PR:
- exposes owning `CudaStream` creation/synchronization as fallible sys bindings
- adds a non-owning `CudaStreamView` bridge for owned streams and cuDF default stream access
- adds a `DeviceAsyncResourceRef` bridge for cuDF current/set/reset resource-ref operations
- updates default-stream synchronization to use `cudf::get_default_stream()` instead of raw CUDA stream 0
- keeps root-crate conveniences on `CuDFStream`, including fallible constructors and `synchronize()`
- removes vague "1:1" wording from related bridge comments
- updates `AGENTS.md` and `CLAUDE.md` with a firm package-wide parity gate for all future `libcudf-sys` work

## Why

cuDF APIs commonly accept `rmm::cuda_stream_view` and `rmm::device_async_resource_ref`. Before threading those parameters through individual operations, the bindings need explicit, minimal handles with clear ownership boundaries.

The agent guidance now makes the broader sys rule operational: future `libcudf-sys` changes must start from the local cuDF/RMM headers, preserve upstream signatures, parameters, overloads, return shapes, enums, metadata, and ownership, and keep ergonomic/defaulting APIs in the root crate.

## Validation

- `cargo fmt --all --check`
- `cargo test -p libcudf-sys cuda_stream -- --nocapture`
- `cargo test -p libcudf-sys device_async_resource_ref -- --nocapture`
- `cargo check -p libcudf-rs`
- `git diff --check origin/main...HEAD`
