### PR TITLE
Align join index bindings with cuDF return shapes

### DIFF
--- a/libcudf-sys/src/join.cpp
+++ b/libcudf-sys/src/join.cpp
@@ -1,34 +1,104 @@
 #include "join.h"
+
 #include <cudf/column/column.hpp>
-#include <cudf/join/join.hpp>
 #include <cudf/join/filtered_join.hpp>
-#include <cudf/utilities/default_stream.hpp>
+#include <cudf/join/join.hpp>
 #include <cudf/utilities/span.hpp>
+
+#include <limits>
 #include <stdexcept>
+#include <type_traits>
 
 namespace libcudf_bridge {
+namespace {
+static_assert(std::is_same_v<cudf::size_type, int32_t>);
+static_assert(static_cast<int32_t>(cudf::JoinNoMatch) == std::numeric_limits<int32_t>::min());
+static_assert(static_cast<int32_t>(cudf::join_kind::INNER_JOIN) == 0);
+static_assert(static_cast<int32_t>(cudf::join_kind::LEFT_JOIN) == 1);
+static_assert(static_cast<int32_t>(cudf::join_kind::FULL_JOIN) == 2);
+static_assert(static_cast<int32_t>(cudf::join_kind::LEFT_SEMI_JOIN) == 3);
+static_assert(static_cast<int32_t>(cudf::join_kind::LEFT_ANTI_JOIN) == 4);
+static_assert(static_cast<int32_t>(cudf::null_equality::EQUAL) == 0);
+static_assert(static_cast<int32_t>(cudf::null_equality::UNEQUAL) == 1);
+static_assert(static_cast<int32_t>(cudf::set_as_build_table::LEFT) == 0);
+static_assert(static_cast<int32_t>(cudf::set_as_build_table::RIGHT) == 1);
 
-static std::unique_ptr<cudf::column> uvector_to_column(
+std::unique_ptr<DeviceIndexVector> make_device_index_vector(
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> vec)
 {
-    return std::make_unique<cudf::column>(std::move(*vec), rmm::device_buffer{}, 0);
-}
-
-static std::unique_ptr<Column> uvector_to_bridge_column(
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> vec)
-{
-    auto result = std::make_unique<Column>();
-    result->inner = uvector_to_column(std::move(vec));
+    auto result = std::make_unique<DeviceIndexVector>();
+    result->inner = std::move(vec);
     return result;
 }
 
-static std::unique_ptr<JoinIndices> make_join_indices(
+std::unique_ptr<JoinIndices> make_join_indices(
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_idx,
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> right_idx)
 {
     auto result = std::make_unique<JoinIndices>();
-    result->left = uvector_to_bridge_column(std::move(left_idx));
-    result->right = uvector_to_bridge_column(std::move(right_idx));
+    result->left = make_device_index_vector(std::move(left_idx));
+    result->right = make_device_index_vector(std::move(right_idx));
+    return result;
+}
+
+std::unique_ptr<HashJoinIndices> make_hash_join_indices(
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> probe_idx,
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> build_idx)
+{
+    auto result = std::make_unique<HashJoinIndices>();
+    result->probe = make_device_index_vector(std::move(probe_idx));
+    result->build = make_device_index_vector(std::move(build_idx));
+    return result;
+}
+
+cudf::device_span<cudf::size_type const> index_span(const DeviceIndexVector& indices)
+{
+    if (!indices.inner) {
+        throw std::runtime_error("Cannot use null device vector as join indices");
+    }
+    return cudf::device_span<cudf::size_type const>(indices.inner->data(), indices.inner->size());
+}
+
+cudf::hash_join const& require_hash_join(const HashJoin& join)
+{
+    if (!join.inner) {
+        throw std::runtime_error("Cannot use null hash join");
+    }
+    return *join.inner;
+}
+
+cudf::filtered_join const& require_filtered_join(const FilteredJoin& join)
+{
+    if (!join.inner) {
+        throw std::runtime_error("Cannot use null filtered join");
+    }
+    return *join.inner;
+}
+} // namespace
+
+DeviceIndexVector::DeviceIndexVector() = default;
+
+DeviceIndexVector::~DeviceIndexVector() = default;
+
+size_t DeviceIndexVector::size() const {
+    if (!inner) {
+        throw std::runtime_error("Cannot get size of null device index vector");
+    }
+    return inner->size();
+}
+
+std::unique_ptr<ColumnView> DeviceIndexVector::view() const {
+    if (!inner) {
+        throw std::runtime_error("Cannot view null device index vector");
+    }
+
+    auto result = std::make_unique<ColumnView>();
+    result->inner = std::make_unique<cudf::column_view>(
+        cudf::data_type{cudf::type_id::INT32},
+        static_cast<cudf::size_type>(inner->size()),
+        inner->data(),
+        nullptr,
+        0);
     return result;
 }
 
@@ -36,11 +106,11 @@ JoinIndices::JoinIndices() = default;
 
 JoinIndices::~JoinIndices() = default;
 
-std::unique_ptr<Column> JoinIndices::release_left() {
+std::unique_ptr<DeviceIndexVector> JoinIndices::release_left() {
     return std::move(left);
 }
 
-std::unique_ptr<Column> JoinIndices::release_right() {
+std::unique_ptr<DeviceIndexVector> JoinIndices::release_right() {
     return std::move(right);
 }
 
@@ -48,69 +118,83 @@ HashJoinIndices::HashJoinIndices() = default;
 
 HashJoinIndices::~HashJoinIndices() = default;
 
-std::unique_ptr<Column> HashJoinIndices::release_probe() {
+std::unique_ptr<DeviceIndexVector> HashJoinIndices::release_probe() {
     return std::move(probe);
 }
 
-std::unique_ptr<Column> HashJoinIndices::release_build() {
+std::unique_ptr<DeviceIndexVector> HashJoinIndices::release_build() {
     return std::move(build);
 }
 
-static std::unique_ptr<HashJoinIndices> make_hash_join_indices(
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> probe_idx,
-    std::unique_ptr<rmm::device_uvector<cudf::size_type>> build_idx)
-{
-    auto result = std::make_unique<HashJoinIndices>();
-    result->probe = uvector_to_bridge_column(std::move(probe_idx));
-    result->build = uvector_to_bridge_column(std::move(build_idx));
-    return result;
+HashJoin::HashJoin() = default;
+
+HashJoin::~HashJoin() = default;
+
+FilteredJoin::FilteredJoin() = default;
+
+FilteredJoin::~FilteredJoin() = default;
+
+int32_t join_no_match() {
+    return static_cast<int32_t>(cudf::JoinNoMatch);
 }
 
 std::unique_ptr<JoinIndices> inner_join_indices(
     const TableView& left_keys,
-    const TableView& right_keys)
+    const TableView& right_keys,
+    int32_t null_equality,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
-    auto [left_idx, right_idx] = cudf::inner_join(*left_keys.inner, *right_keys.inner);
+    auto [left_idx, right_idx] = cudf::inner_join(
+        *left_keys.inner,
+        *right_keys.inner,
+        static_cast<cudf::null_equality>(null_equality),
+        stream.inner,
+        mr.inner);
     return make_join_indices(std::move(left_idx), std::move(right_idx));
 }
 
 std::unique_ptr<JoinIndices> left_join_indices(
     const TableView& left_keys,
-    const TableView& right_keys)
+    const TableView& right_keys,
+    int32_t null_equality,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
-    auto [left_idx, right_idx] = cudf::left_join(*left_keys.inner, *right_keys.inner);
+    auto [left_idx, right_idx] = cudf::left_join(
+        *left_keys.inner,
+        *right_keys.inner,
+        static_cast<cudf::null_equality>(null_equality),
+        stream.inner,
+        mr.inner);
     return make_join_indices(std::move(left_idx), std::move(right_idx));
 }
 
 std::unique_ptr<JoinIndices> full_join_indices(
     const TableView& left_keys,
-    const TableView& right_keys)
+    const TableView& right_keys,
+    int32_t null_equality,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
-    auto [left_idx, right_idx] = cudf::full_join(*left_keys.inner, *right_keys.inner);
+    auto [left_idx, right_idx] = cudf::full_join(
+        *left_keys.inner,
+        *right_keys.inner,
+        static_cast<cudf::null_equality>(null_equality),
+        stream.inner,
+        mr.inner);
     return make_join_indices(std::move(left_idx), std::move(right_idx));
-}
-
-static cudf::device_span<cudf::size_type const> indices_span(const ColumnView& indices)
-{
-    if (!indices.inner) {
-        throw std::runtime_error("Cannot use null column view as join indices");
-    }
-    if (indices.inner->type().id() != cudf::type_id::INT32) {
-        throw std::runtime_error("Join indices must have cudf::size_type type");
-    }
-
-    return cudf::device_span<cudf::size_type const>(
-        indices.inner->begin<cudf::size_type>(),
-        indices.inner->size());
 }
 
 std::unique_ptr<JoinIndices> filter_join_indices(
     const TableView& left,
     const TableView& right,
-    const ColumnView& left_indices,
-    const ColumnView& right_indices,
+    const DeviceIndexVector& left_indices,
+    const DeviceIndexVector& right_indices,
     const AstExpressionTree& predicate,
-    int32_t join_kind)
+    int32_t join_kind,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
     if (predicate.inner.size() == 0) {
         throw std::runtime_error("Cannot filter join indices with an empty AST predicate");
@@ -119,63 +203,99 @@ std::unique_ptr<JoinIndices> filter_join_indices(
     auto [filtered_left, filtered_right] = cudf::filter_join_indices(
         *left.inner,
         *right.inner,
-        indices_span(left_indices),
-        indices_span(right_indices),
+        index_span(left_indices),
+        index_span(right_indices),
         predicate.inner.back(),
-        static_cast<cudf::join_kind>(join_kind));
+        static_cast<cudf::join_kind>(join_kind),
+        stream.inner,
+        mr.inner);
     return make_join_indices(std::move(filtered_left), std::move(filtered_right));
 }
 
-HashJoin::HashJoin() = default;
-
-HashJoin::~HashJoin() = default;
-
 std::unique_ptr<HashJoin> hash_join_create(
-    const TableView& build_keys, int32_t null_equality)
+    const TableView& build_keys,
+    int32_t null_equality,
+    const CudaStreamView& stream)
 {
     auto result = std::make_unique<HashJoin>();
-    auto compare_nulls = static_cast<cudf::null_equality>(null_equality);
-    result->inner = std::make_unique<cudf::hash_join>(*build_keys.inner, compare_nulls);
+    result->inner = std::make_unique<cudf::hash_join>(
+        *build_keys.inner,
+        static_cast<cudf::null_equality>(null_equality),
+        stream.inner);
     return result;
 }
 
 std::unique_ptr<HashJoinIndices> hash_join_inner_join_indices(
     const HashJoin& join,
-    const TableView& probe_keys)
+    const TableView& probe_keys,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
-    auto [probe_idx, build_idx] = join.inner->inner_join(*probe_keys.inner);
+    auto [probe_idx, build_idx] = require_hash_join(join).inner_join(
+        *probe_keys.inner,
+        {},
+        stream.inner,
+        mr.inner);
     return make_hash_join_indices(std::move(probe_idx), std::move(build_idx));
 }
 
 std::unique_ptr<HashJoinIndices> hash_join_left_join_indices(
     const HashJoin& join,
-    const TableView& probe_keys)
+    const TableView& probe_keys,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
-    auto [probe_idx, build_idx] = join.inner->left_join(*probe_keys.inner);
+    auto [probe_idx, build_idx] = require_hash_join(join).left_join(
+        *probe_keys.inner,
+        {},
+        stream.inner,
+        mr.inner);
     return make_hash_join_indices(std::move(probe_idx), std::move(build_idx));
 }
 
-std::unique_ptr<Column> left_semi_join_indices(
-    const TableView& left_keys,
-    const TableView& right_keys)
+std::unique_ptr<FilteredJoin> filtered_join_create(
+    const TableView& build_keys,
+    int32_t null_equality,
+    int32_t set_as_build_table,
+    const CudaStreamView& stream)
 {
-    cudf::filtered_join fj(*right_keys.inner, cudf::null_equality::EQUAL,
-                           cudf::set_as_build_table::RIGHT, cudf::get_default_stream());
-    return uvector_to_bridge_column(fj.semi_join(*left_keys.inner));
+    auto result = std::make_unique<FilteredJoin>();
+    result->inner = std::make_unique<cudf::filtered_join>(
+        *build_keys.inner,
+        static_cast<cudf::null_equality>(null_equality),
+        static_cast<cudf::set_as_build_table>(set_as_build_table),
+        stream.inner);
+    return result;
 }
 
-std::unique_ptr<Column> left_anti_join_indices(
-    const TableView& left_keys,
-    const TableView& right_keys)
+std::unique_ptr<DeviceIndexVector> filtered_join_semi_join(
+    const FilteredJoin& join,
+    const TableView& probe_keys,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
 {
-    cudf::filtered_join fj(*right_keys.inner, cudf::null_equality::EQUAL,
-                           cudf::set_as_build_table::RIGHT, cudf::get_default_stream());
-    return uvector_to_bridge_column(fj.anti_join(*left_keys.inner));
+    return make_device_index_vector(
+        require_filtered_join(join).semi_join(*probe_keys.inner, stream.inner, mr.inner));
 }
 
-std::unique_ptr<Table> cross_join(const TableView& left, const TableView& right) {
+std::unique_ptr<DeviceIndexVector> filtered_join_anti_join(
+    const FilteredJoin& join,
+    const TableView& probe_keys,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
+{
+    return make_device_index_vector(
+        require_filtered_join(join).anti_join(*probe_keys.inner, stream.inner, mr.inner));
+}
+
+std::unique_ptr<Table> cross_join(
+    const TableView& left,
+    const TableView& right,
+    const CudaStreamView& stream,
+    const DeviceAsyncResourceRef& mr)
+{
     auto result = std::make_unique<Table>();
-    result->inner = cudf::cross_join(*left.inner, *right.inner);
+    result->inner = cudf::cross_join(*left.inner, *right.inner, stream.inner, mr.inner);
     return result;
 }
 

--- a/libcudf-sys/src/join.h
+++ b/libcudf-sys/src/join.h
@@ -4,37 +4,54 @@
 #include <cstdint>
 #include "rust/cxx.h"
 #include "ast.h"
+#include "memory_resource.h"
+#include "stream.h"
 #include "table.h"
 #include "column.h"
+#include <cudf/join/filtered_join.hpp>
 #include <cudf/join/hash_join.hpp>
+#include <cudf/join/join.hpp>
 #include <cudf/column/column.hpp>
+#include <rmm/device_uvector.hpp>
 #include <vector>
 
 namespace libcudf_bridge {
+    struct DeviceIndexVector {
+        std::unique_ptr<rmm::device_uvector<cudf::size_type>> inner;
+
+        DeviceIndexVector();
+
+        ~DeviceIndexVector();
+
+        [[nodiscard]] size_t size() const;
+
+        [[nodiscard]] std::unique_ptr<ColumnView> view() const;
+    };
+
     struct JoinIndices {
-        std::unique_ptr<Column> left;
-        std::unique_ptr<Column> right;
+        std::unique_ptr<DeviceIndexVector> left;
+        std::unique_ptr<DeviceIndexVector> right;
 
         JoinIndices();
 
         ~JoinIndices();
 
-        std::unique_ptr<Column> release_left();
+        std::unique_ptr<DeviceIndexVector> release_left();
 
-        std::unique_ptr<Column> release_right();
+        std::unique_ptr<DeviceIndexVector> release_right();
     };
 
     struct HashJoinIndices {
-        std::unique_ptr<Column> probe;
-        std::unique_ptr<Column> build;
+        std::unique_ptr<DeviceIndexVector> probe;
+        std::unique_ptr<DeviceIndexVector> build;
 
         HashJoinIndices();
 
         ~HashJoinIndices();
 
-        std::unique_ptr<Column> release_probe();
+        std::unique_ptr<DeviceIndexVector> release_probe();
 
-        std::unique_ptr<Column> release_build();
+        std::unique_ptr<DeviceIndexVector> release_build();
     };
 
     struct HashJoin {
@@ -45,44 +62,85 @@ namespace libcudf_bridge {
         ~HashJoin();
     };
 
+    struct FilteredJoin {
+        std::unique_ptr<cudf::filtered_join> inner;
+
+        FilteredJoin();
+
+        ~FilteredJoin();
+    };
+
+    int32_t join_no_match();
+
     std::unique_ptr<HashJoin> hash_join_create(
-        const TableView& build_keys, int32_t null_equality);
+        const TableView& build_keys,
+        int32_t null_equality,
+        const CudaStreamView& stream);
 
     std::unique_ptr<HashJoinIndices> hash_join_inner_join_indices(
         const HashJoin& join,
-        const TableView& probe_keys);
+        const TableView& probe_keys,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
     std::unique_ptr<HashJoinIndices> hash_join_left_join_indices(
         const HashJoin& join,
-        const TableView& probe_keys);
+        const TableView& probe_keys,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
     std::unique_ptr<JoinIndices> inner_join_indices(
         const TableView& left_keys,
-        const TableView& right_keys);
+        const TableView& right_keys,
+        int32_t null_equality,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
     std::unique_ptr<JoinIndices> left_join_indices(
         const TableView& left_keys,
-        const TableView& right_keys);
+        const TableView& right_keys,
+        int32_t null_equality,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
     std::unique_ptr<JoinIndices> full_join_indices(
         const TableView& left_keys,
-        const TableView& right_keys);
+        const TableView& right_keys,
+        int32_t null_equality,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
     std::unique_ptr<JoinIndices> filter_join_indices(
         const TableView& left,
         const TableView& right,
-        const ColumnView& left_indices,
-        const ColumnView& right_indices,
+        const DeviceIndexVector& left_indices,
+        const DeviceIndexVector& right_indices,
         const AstExpressionTree& predicate,
-        int32_t join_kind);
+        int32_t join_kind,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
-    std::unique_ptr<Column> left_semi_join_indices(
-        const TableView& left_keys,
-        const TableView& right_keys);
+    std::unique_ptr<FilteredJoin> filtered_join_create(
+        const TableView& build_keys,
+        int32_t null_equality,
+        int32_t set_as_build_table,
+        const CudaStreamView& stream);
 
-    std::unique_ptr<Column> left_anti_join_indices(
-        const TableView& left_keys,
-        const TableView& right_keys);
+    std::unique_ptr<DeviceIndexVector> filtered_join_semi_join(
+        const FilteredJoin& join,
+        const TableView& probe_keys,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 
-    std::unique_ptr<Table> cross_join(const TableView& left, const TableView& right);
+    std::unique_ptr<DeviceIndexVector> filtered_join_anti_join(
+        const FilteredJoin& join,
+        const TableView& probe_keys,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+
+    std::unique_ptr<Table> cross_join(
+        const TableView& left,
+        const TableView& right,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -92,23 +92,35 @@ pub mod ffi {
         /// Builds a hash table once and probes it with subsequent join calls.
         type HashJoin;
 
+        /// Reusable cuDF filtered join object.
+        type FilteredJoin;
+
+        /// Owning device vector of cuDF row indices.
+        type DeviceIndexVector;
+
+        /// Return the number of row indices.
+        fn size(self: &DeviceIndexVector) -> usize;
+
+        /// View the row indices as a non-owning cuDF column view.
+        fn view(self: &DeviceIndexVector) -> UniquePtr<ColumnView>;
+
         /// Pair of cuDF join index maps.
         type JoinIndices;
 
         /// Take the left input indices from this join result.
-        fn release_left(self: Pin<&mut JoinIndices>) -> UniquePtr<Column>;
+        fn release_left(self: Pin<&mut JoinIndices>) -> UniquePtr<DeviceIndexVector>;
 
         /// Take the right input indices from this join result.
-        fn release_right(self: Pin<&mut JoinIndices>) -> UniquePtr<Column>;
+        fn release_right(self: Pin<&mut JoinIndices>) -> UniquePtr<DeviceIndexVector>;
 
         /// Pair of reusable hash-join probe/build index maps.
         type HashJoinIndices;
 
         /// Take the probe-side indices from this reusable hash join result.
-        fn release_probe(self: Pin<&mut HashJoinIndices>) -> UniquePtr<Column>;
+        fn release_probe(self: Pin<&mut HashJoinIndices>) -> UniquePtr<DeviceIndexVector>;
 
         /// Take the build-side indices from this reusable hash join result.
-        fn release_build(self: Pin<&mut HashJoinIndices>) -> UniquePtr<Column>;
+        fn release_build(self: Pin<&mut HashJoinIndices>) -> UniquePtr<DeviceIndexVector>;
 
         /// Create an empty cuDF AST expression tree.
         fn ast_expression_tree_create() -> UniquePtr<AstExpressionTree>;
@@ -560,66 +572,102 @@ pub mod ffi {
 
         // Join operations.
 
+        /// Sentinel row index cuDF uses for unmatched join rows.
+        fn join_no_match() -> i32;
+
         /// Create a reusable hash join object from build-side keys.
         fn hash_join_create(
             build_keys: &TableView,
             null_equality: i32,
+            stream: &CudaStreamView,
         ) -> Result<UniquePtr<HashJoin>>;
 
         /// Probe a reusable hash join object and return probe/build row indices.
         fn hash_join_inner_join_indices(
             join: &HashJoin,
             probe_keys: &TableView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<HashJoinIndices>>;
 
         /// Probe a reusable hash join object preserving probe rows.
         fn hash_join_left_join_indices(
             join: &HashJoin,
             probe_keys: &TableView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<HashJoinIndices>>;
 
         /// Inner join: return row index maps for the matching rows.
         fn inner_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
+            null_equality: i32,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<JoinIndices>>;
 
         /// Left join: return row index maps for the output rows.
         fn left_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
+            null_equality: i32,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<JoinIndices>>;
 
         /// Full join: return row index maps for the output rows.
         fn full_join_indices(
             left_keys: &TableView,
             right_keys: &TableView,
+            null_equality: i32,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<JoinIndices>>;
 
         /// Filter join index maps with a cuDF AST predicate.
         fn filter_join_indices(
             left: &TableView,
             right: &TableView,
-            left_indices: &ColumnView,
-            right_indices: &ColumnView,
+            left_indices: &DeviceIndexVector,
+            right_indices: &DeviceIndexVector,
             predicate: &AstExpressionTree,
             join_kind: i32,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<JoinIndices>>;
 
-        /// Left semi join: return row indices for matching left rows.
-        fn left_semi_join_indices(
-            left_keys: &TableView,
-            right_keys: &TableView,
-        ) -> Result<UniquePtr<Column>>;
+        /// Create a reusable filtered join object from build-side keys.
+        fn filtered_join_create(
+            build_keys: &TableView,
+            null_equality: i32,
+            set_as_build_table: i32,
+            stream: &CudaStreamView,
+        ) -> Result<UniquePtr<FilteredJoin>>;
 
-        /// Left anti join: return row indices for non-matching left rows.
-        fn left_anti_join_indices(
-            left_keys: &TableView,
-            right_keys: &TableView,
-        ) -> Result<UniquePtr<Column>>;
+        /// Return row indices for a filtered semi join.
+        fn filtered_join_semi_join(
+            join: &FilteredJoin,
+            probe_keys: &TableView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<DeviceIndexVector>>;
+
+        /// Return row indices for a filtered anti join.
+        fn filtered_join_anti_join(
+            join: &FilteredJoin,
+            probe_keys: &TableView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<DeviceIndexVector>>;
 
         /// Cross join: returns a full Cartesian product table
-        fn cross_join(left: &TableView, right: &TableView) -> Result<UniquePtr<Table>>;
+        fn cross_join(
+            left: &TableView,
+            right: &TableView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Table>>;
 
         // Aggregation factory functions - direct cuDF mappings (for reduce)
 
@@ -909,6 +957,16 @@ pub enum JoinKind {
     LeftSemi = 3,
     /// Left anti join.
     LeftAnti = 4,
+}
+
+/// Which table a reusable filtered join treats as its build table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum SetAsBuildTable {
+    /// The build table is the left table.
+    Left = 0,
+    /// The build table is the right table.
+    Right = 1,
 }
 
 /// cuDF AST table reference.
@@ -1397,6 +1455,15 @@ unsafe impl Sync for ffi::GroupBy {}
 /// SAFETY: HashJoin owns its cuDF state and is only moved across threads.
 unsafe impl Send for ffi::HashJoin {}
 
+/// SAFETY: FilteredJoin owns its cuDF state and is only moved across threads.
+unsafe impl Send for ffi::FilteredJoin {}
+
+/// SAFETY: DeviceIndexVector owns device memory and can be moved between threads.
+unsafe impl Send for ffi::DeviceIndexVector {}
+
+/// SAFETY: DeviceIndexVector exposes immutable views over owned device memory.
+unsafe impl Sync for ffi::DeviceIndexVector {}
+
 /// SAFETY: AggregationRequest configuration can be sent between threads.
 unsafe impl Send for ffi::AggregationRequest {}
 
@@ -1758,6 +1825,21 @@ mod tests {
     }
 
     #[test]
+    fn test_join_enum_parity() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(ffi::join_no_match(), i32::MIN);
+        assert_eq!(NullEquality::Equal as i32, 0);
+        assert_eq!(NullEquality::Unequal as i32, 1);
+        assert_eq!(JoinKind::Inner as i32, 0);
+        assert_eq!(JoinKind::Left as i32, 1);
+        assert_eq!(JoinKind::Full as i32, 2);
+        assert_eq!(JoinKind::LeftSemi as i32, 3);
+        assert_eq!(JoinKind::LeftAnti as i32, 4);
+        assert_eq!(SetAsBuildTable::Left as i32, 0);
+        assert_eq!(SetAsBuildTable::Right as i32, 1);
+        Ok(())
+    }
+
+    #[test]
     fn test_ast_filter_join_indices() -> Result<(), Box<dyn std::error::Error>> {
         let left =
             table_from_i32_columns(&[("key", vec![1, 2, 2, 3]), ("val", vec![10, 20, 25, 30])])?;
@@ -1766,9 +1848,20 @@ mod tests {
         let right_view = right.view();
         let left_keys = left_view.select(&[0]);
         let right_keys = right_view.select(&[0]);
-        let mut indices = ffi::inner_join_indices(&left_keys, &right_keys)?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let mut indices = ffi::inner_join_indices(
+            &left_keys,
+            &right_keys,
+            NullEquality::Equal as i32,
+            stream.as_ref().expect("default stream should not be null"),
+            resource
+                .as_ref()
+                .expect("current resource should not be null"),
+        )?;
         let left_indices = indices.pin_mut().release_left();
         let right_indices = indices.pin_mut().release_right();
+        let left_indices_view = left_indices.view();
 
         let mut predicate = ffi::ast_expression_tree_create();
         let left_val = ffi::ast_expression_tree_add_column_reference(
@@ -1793,15 +1886,24 @@ mod tests {
         let mut filtered = ffi::filter_join_indices(
             &left_values,
             &right_values,
-            &left_indices.view(),
-            &right_indices.view(),
+            left_indices
+                .as_ref()
+                .expect("left index vector should not be null"),
+            right_indices
+                .as_ref()
+                .expect("right index vector should not be null"),
             &predicate,
             JoinKind::Inner as i32,
+            stream.as_ref().expect("default stream should not be null"),
+            resource
+                .as_ref()
+                .expect("current resource should not be null"),
         )?;
         let filtered_left = filtered.pin_mut().release_left();
         let filtered_right = filtered.pin_mut().release_right();
 
         assert_eq!(left_indices.size(), 5);
+        assert_eq!(left_indices_view.size(), 5);
         assert_eq!(right_indices.size(), 5);
         assert_eq!(filtered_left.size(), 3);
         assert_eq!(filtered_right.size(), 3);

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,17 +1,16 @@
 use crate::data_type::arrow_type_to_cudf_data_type;
 use crate::{
-    CuDFAstExpression, CuDFColumn, CuDFError, CuDFRef, CuDFScalar, CuDFTable, CuDFTableView,
+    CuDFAstExpression, CuDFColumn, CuDFColumnView, CuDFError, CuDFRef, CuDFScalar, CuDFTable,
+    CuDFTableView,
 };
 use arrow::array::{BooleanArray, Int32Array, Scalar};
 use arrow_schema::DataType;
 use cxx::UniquePtr;
 use libcudf_sys::{
     ffi, BinaryOperator, DuplicateKeepOption, JoinKind, NanEquality, NullEquality,
-    OutOfBoundsPolicy,
+    OutOfBoundsPolicy, SetAsBuildTable,
 };
 use std::sync::Arc;
-
-const NULL_GATHER_INDEX: i32 = i32::MIN;
 
 /// Arguments for probing a reusable hash join with an AST predicate.
 ///
@@ -38,6 +37,85 @@ pub struct CuDFFilteredHashJoinArgs<'a> {
     pub build_out_cols: Option<&'a [usize]>,
     /// Optional probe payload columns to gather.
     pub probe_out_cols: Option<&'a [usize]>,
+}
+
+struct JoinIndexVector {
+    inner: UniquePtr<ffi::DeviceIndexVector>,
+}
+
+impl JoinIndexVector {
+    fn new(inner: UniquePtr<ffi::DeviceIndexVector>) -> Self {
+        Self { inner }
+    }
+
+    fn len(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn as_sys(&self) -> &ffi::DeviceIndexVector {
+        self.inner
+            .as_ref()
+            .expect("device index vector should not be null")
+    }
+
+    fn view(self: Arc<Self>) -> CuDFColumnView {
+        let view = self.inner.view();
+        CuDFColumnView::new_with_ref(view, Some(self))
+    }
+}
+
+impl CuDFRef for JoinIndexVector {}
+
+fn default_join_context() -> (
+    UniquePtr<ffi::CudaStreamView>,
+    UniquePtr<ffi::DeviceAsyncResourceRef>,
+) {
+    (
+        ffi::get_default_stream(),
+        ffi::get_current_device_resource_ref(),
+    )
+}
+
+fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> &ffi::CudaStreamView {
+    stream
+        .as_ref()
+        .expect("default CUDA stream view should not be null")
+}
+
+fn resource_ref(resource: &UniquePtr<ffi::DeviceAsyncResourceRef>) -> &ffi::DeviceAsyncResourceRef {
+    resource
+        .as_ref()
+        .expect("current device resource ref should not be null")
+}
+
+fn null_gather_index() -> i32 {
+    ffi::join_no_match()
+}
+
+fn sys_hash_join_inner_join_indices(
+    join: &ffi::HashJoin,
+    probe_keys: &ffi::TableView,
+) -> Result<UniquePtr<ffi::HashJoinIndices>, CuDFError> {
+    let (stream, resource) = default_join_context();
+    Ok(ffi::hash_join_inner_join_indices(
+        join,
+        probe_keys,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?)
+}
+
+fn sys_hash_join_left_join_indices(
+    join: &ffi::HashJoin,
+    probe_keys: &ffi::TableView,
+) -> Result<UniquePtr<ffi::HashJoinIndices>, CuDFError> {
+    let (stream, resource) = default_join_context();
+    Ok(ffi::hash_join_left_join_indices(
+        join,
+        probe_keys,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?)
 }
 
 fn select_cols(view: &CuDFTableView, cols: &[usize]) -> cxx::UniquePtr<ffi::TableView> {
@@ -75,15 +153,15 @@ fn gather_join_indices(
     left_policy: OutOfBoundsPolicy,
     right_policy: OutOfBoundsPolicy,
 ) -> Result<CuDFTable, CuDFError> {
-    let left_indices = indices.pin_mut().release_left();
-    let right_indices = indices.pin_mut().release_right();
-    let left_indices_view = left_indices.view();
-    let right_indices_view = right_indices.view();
+    let left_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_left()));
+    let right_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_right()));
+    let left_indices_view = Arc::clone(&left_indices).view();
+    let right_indices_view = Arc::clone(&right_indices).view();
     gather_join_output(
         left_payload,
         right_payload,
-        &left_indices_view,
-        &right_indices_view,
+        left_indices_view.inner(),
+        right_indices_view.inner(),
         left_policy,
         right_policy,
     )
@@ -95,9 +173,9 @@ fn gather_hash_join_indices(
     probe_payload: &ffi::TableView,
     build_policy: OutOfBoundsPolicy,
     probe_policy: OutOfBoundsPolicy,
-) -> Result<(CuDFTable, Arc<CuDFColumn>), CuDFError> {
-    let probe_indices = Arc::new(CuDFColumn::new(indices.pin_mut().release_probe()));
-    let build_indices = Arc::new(CuDFColumn::new(indices.pin_mut().release_build()));
+) -> Result<(CuDFTable, Arc<JoinIndexVector>), CuDFError> {
+    let probe_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_probe()));
+    let build_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_build()));
     let probe_indices_view = Arc::clone(&probe_indices).view();
     let build_indices_view = Arc::clone(&build_indices).view();
     let result = gather_join_output(
@@ -125,26 +203,29 @@ struct FilteredHashJoinIndicesArgs<'a> {
 fn gather_filtered_hash_join_indices(
     mut indices: UniquePtr<ffi::HashJoinIndices>,
     args: FilteredHashJoinIndicesArgs<'_>,
-) -> Result<(CuDFTable, Arc<CuDFColumn>, Arc<CuDFColumn>), CuDFError> {
+) -> Result<(CuDFTable, Arc<JoinIndexVector>, Arc<JoinIndexVector>), CuDFError> {
     // Hash join returns probe/build maps. cuDF filter_join_indices expects
     // left/right maps, so pass build as left and probe as right to preserve
     // the public `[build_cols | probe_cols]` output order.
-    let probe_indices = indices.pin_mut().release_probe();
-    let build_indices = indices.pin_mut().release_build();
-    let probe_indices_view = probe_indices.view();
-    let build_indices_view = build_indices.view();
+    let probe_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_probe()));
+    let build_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_build()));
+    let (stream, resource) = default_join_context();
     let mut filtered_indices = ffi::filter_join_indices(
         args.build_conditional,
         args.probe_conditional,
-        &build_indices_view,
-        &probe_indices_view,
+        build_indices.as_sys(),
+        probe_indices.as_sys(),
         args.predicate.inner(),
         args.join_kind as i32,
+        stream_ref(&stream),
+        resource_ref(&resource),
     )?;
-    let filtered_build_indices =
-        Arc::new(CuDFColumn::new(filtered_indices.pin_mut().release_left()));
-    let filtered_probe_indices =
-        Arc::new(CuDFColumn::new(filtered_indices.pin_mut().release_right()));
+    let filtered_build_indices = Arc::new(JoinIndexVector::new(
+        filtered_indices.pin_mut().release_left(),
+    ));
+    let filtered_probe_indices = Arc::new(JoinIndexVector::new(
+        filtered_indices.pin_mut().release_right(),
+    ));
     let filtered_build_indices_view = Arc::clone(&filtered_build_indices).view();
     let filtered_probe_indices_view = Arc::clone(&filtered_probe_indices).view();
     let result = gather_join_output(
@@ -168,19 +249,19 @@ fn concat_join_outputs(first: CuDFTable, second: CuDFTable) -> Result<CuDFTable,
     CuDFTable::concat(vec![first.into_view(), second.into_view()])
 }
 
-fn distinct_valid_indices(indices: Arc<CuDFColumn>) -> Result<Option<Arc<CuDFColumn>>, CuDFError> {
-    if indices.len() == 0 {
+fn distinct_valid_indices(indices: CuDFColumnView) -> Result<Option<Arc<CuDFColumn>>, CuDFError> {
+    if indices.inner().size() == 0 {
         return Ok(None);
     }
 
     let zero = int32_scalar(0)?;
     let valid_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
-        Arc::clone(&indices).view().inner(),
+        indices.inner(),
         zero.inner(),
         BinaryOperator::GreaterEqual as i32,
         &bool_data_type(),
     )?));
-    let indices_table = CuDFTableView::from_column_views(vec![Arc::clone(&indices).view()])?;
+    let indices_table = CuDFTableView::from_column_views(vec![indices])?;
     let valid_indices_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
         indices_table.inner(),
         Arc::clone(&valid_mask).view().inner(),
@@ -212,14 +293,15 @@ fn distinct_valid_indices(indices: Arc<CuDFColumn>) -> Result<Option<Arc<CuDFCol
 
 fn matched_row_mask(
     row_count: usize,
-    matched_indices: Arc<CuDFColumn>,
+    matched_indices: Arc<JoinIndexVector>,
 ) -> Result<Arc<CuDFColumn>, CuDFError> {
     let false_scalar = bool_scalar(false)?;
     let mask = Arc::new(CuDFColumn::new(ffi::make_column_from_scalar(
         false_scalar.inner(),
         row_count,
     )?));
-    let Some(distinct_indices) = distinct_valid_indices(matched_indices)? else {
+    let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&matched_indices).view())?
+    else {
         return Ok(mask);
     };
 
@@ -243,7 +325,7 @@ fn matched_row_mask(
 
 fn unmatched_indices_from_matches(
     row_count: usize,
-    matched_indices: Arc<CuDFColumn>,
+    matched_indices: Arc<JoinIndexVector>,
 ) -> Result<Arc<CuDFColumn>, CuDFError> {
     let all_indices = join_index_sequence(row_count, 0, 1)?;
     let matched_mask = matched_row_mask(row_count, matched_indices)?;
@@ -331,7 +413,12 @@ impl CuDFHashJoin {
         null_equality: CuDFNullEquality,
     ) -> Result<Self, CuDFError> {
         let build_keys = select_cols(build, build_on);
-        let inner = ffi::hash_join_create(&build_keys, null_equality.into_sys() as i32)?;
+        let stream = ffi::get_default_stream();
+        let inner = ffi::hash_join_create(
+            &build_keys,
+            null_equality.into_sys() as i32,
+            stream_ref(&stream),
+        )?;
         Ok(Self {
             inner,
             build_rows: build.num_rows(),
@@ -355,7 +442,7 @@ impl CuDFHashJoin {
         let probe_keys = select_cols(probe, probe_on);
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, _) = gather_hash_join_indices(
             indices,
             selected_build_payload
@@ -397,7 +484,7 @@ impl CuDFHashJoin {
         let selected_probe_payload = args
             .probe_out_cols
             .map(|c| select_cols(args.probe_payload, c));
-        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, _, _) = gather_filtered_hash_join_indices(
             indices,
             FilteredHashJoinIndicesArgs {
@@ -439,7 +526,7 @@ impl CuDFHashJoin {
         let selected_probe_payload = args
             .probe_out_cols
             .map(|c| select_cols(args.probe_payload, c));
-        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, build_indices, _) = gather_filtered_hash_join_indices(
             indices,
             FilteredHashJoinIndicesArgs {
@@ -474,7 +561,7 @@ impl CuDFHashJoin {
         let probe_keys = select_cols(probe, probe_on);
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, build_indices) = gather_hash_join_indices(
             indices,
             selected_build_payload
@@ -505,7 +592,7 @@ impl CuDFHashJoin {
         let probe_keys = select_cols(probe, probe_on);
         let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
-        let indices = ffi::hash_join_left_join_indices(&self.inner, &probe_keys)?;
+        let indices = sys_hash_join_left_join_indices(&self.inner, &probe_keys)?;
         let (result, build_indices) = gather_hash_join_indices(
             indices,
             selected_build_payload
@@ -549,7 +636,7 @@ impl CuDFHashJoin {
         let probe_payload = selected_probe_payload
             .as_ref()
             .unwrap_or_else(|| args.probe_payload.inner());
-        let indices = ffi::hash_join_inner_join_indices(&self.inner, &probe_keys)?;
+        let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (matched, build_indices, probe_indices) = gather_filtered_hash_join_indices(
             indices,
             FilteredHashJoinIndicesArgs {
@@ -568,7 +655,7 @@ impl CuDFHashJoin {
         let unmatched_probe_indices =
             unmatched_indices_from_matches(args.probe.num_rows(), probe_indices)?;
         let null_build_indices =
-            join_index_sequence(unmatched_probe_indices.len(), NULL_GATHER_INDEX, 0)?;
+            join_index_sequence(unmatched_probe_indices.len(), null_gather_index(), 0)?;
         let null_build_indices_view = Arc::clone(&null_build_indices).view();
         let unmatched_probe_indices_view = Arc::clone(&unmatched_probe_indices).view();
         let probe_only = gather_join_output(
@@ -595,7 +682,7 @@ impl CuDFHashJoin {
         let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
         let unmatched_build_indices = self.unmatched_build_indices()?;
         let null_probe_indices =
-            join_index_sequence(unmatched_build_indices.len(), NULL_GATHER_INDEX, 0)?;
+            join_index_sequence(unmatched_build_indices.len(), null_gather_index(), 0)?;
         let unmatched_build_indices_view = Arc::clone(&unmatched_build_indices).view();
         let null_probe_indices_view = Arc::clone(&null_probe_indices).view();
 
@@ -615,13 +702,14 @@ impl CuDFHashJoin {
 
     fn record_matched_build_indices(
         &mut self,
-        build_indices: Arc<CuDFColumn>,
+        build_indices: Arc<JoinIndexVector>,
     ) -> Result<(), CuDFError> {
         if self.build_rows == 0 || build_indices.len() == 0 {
             return Ok(());
         }
 
-        let Some(distinct_indices) = distinct_valid_indices(build_indices)? else {
+        let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&build_indices).view())?
+        else {
             return Ok(());
         };
 
@@ -703,7 +791,14 @@ pub fn inner_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let indices = ffi::inner_join_indices(&left_keys, &right_keys)?;
+    let (stream, resource) = default_join_context();
+    let indices = ffi::inner_join_indices(
+        &left_keys,
+        &right_keys,
+        NullEquality::Equal as i32,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?;
     gather_join_indices(
         indices,
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
@@ -730,7 +825,14 @@ pub fn left_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let indices = ffi::left_join_indices(&left_keys, &right_keys)?;
+    let (stream, resource) = default_join_context();
+    let indices = ffi::left_join_indices(
+        &left_keys,
+        &right_keys,
+        NullEquality::Equal as i32,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?;
     gather_join_indices(
         indices,
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
@@ -757,7 +859,14 @@ pub fn full_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let indices = ffi::full_join_indices(&left_keys, &right_keys)?;
+    let (stream, resource) = default_join_context();
+    let indices = ffi::full_join_indices(
+        &left_keys,
+        &right_keys,
+        NullEquality::Equal as i32,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?;
     gather_join_indices(
         indices,
         left_payload.as_ref().unwrap_or_else(|| left.inner()),
@@ -778,11 +887,23 @@ pub fn left_semi_join(
 ) -> Result<CuDFTable, CuDFError> {
     let left_keys = select_cols(left, left_on);
     let right_keys = select_cols(right, right_on);
-    let indices = ffi::left_semi_join_indices(&left_keys, &right_keys)?;
+    let (stream, resource) = default_join_context();
+    let join = ffi::filtered_join_create(
+        &right_keys,
+        NullEquality::Equal as i32,
+        SetAsBuildTable::Right as i32,
+        stream_ref(&stream),
+    )?;
+    let indices = Arc::new(JoinIndexVector::new(ffi::filtered_join_semi_join(
+        &join,
+        &left_keys,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?));
     let indices_view = indices.view();
     Ok(CuDFTable::from_inner(ffi::gather(
         left.inner(),
-        &indices_view,
+        indices_view.inner(),
     )?))
 }
 
@@ -797,11 +918,23 @@ pub fn left_anti_join(
 ) -> Result<CuDFTable, CuDFError> {
     let left_keys = select_cols(left, left_on);
     let right_keys = select_cols(right, right_on);
-    let indices = ffi::left_anti_join_indices(&left_keys, &right_keys)?;
+    let (stream, resource) = default_join_context();
+    let join = ffi::filtered_join_create(
+        &right_keys,
+        NullEquality::Equal as i32,
+        SetAsBuildTable::Right as i32,
+        stream_ref(&stream),
+    )?;
+    let indices = Arc::new(JoinIndexVector::new(ffi::filtered_join_anti_join(
+        &join,
+        &left_keys,
+        stream_ref(&stream),
+        resource_ref(&resource),
+    )?));
     let indices_view = indices.view();
     Ok(CuDFTable::from_inner(ffi::gather(
         left.inner(),
-        &indices_view,
+        indices_view.inner(),
     )?))
 }
 
@@ -809,9 +942,12 @@ pub fn left_anti_join(
 ///
 /// Returns all combinations of rows from both inputs.
 pub fn cross_join(left: &CuDFTableView, right: &CuDFTableView) -> Result<CuDFTable, CuDFError> {
+    let (stream, resource) = default_join_context();
     Ok(CuDFTable::from_inner(ffi::cross_join(
         left.inner(),
         right.inner(),
+        stream_ref(&stream),
+        resource_ref(&resource),
     )?))
 }
 


### PR DESCRIPTION
Summary:
- Preserve cuDF join index return shapes in libcudf-sys using DeviceIndexVector wrappers instead of converting join indices into columns.
- Thread cuDF stream and memory-resource parameters through the used join surfaces.
- Keep ergonomic defaults and gather plumbing in libcudf-rs while leaving sys thin and cuDF-shaped.

Testing:
- cargo fmt
- cargo check
- cargo test -p libcudf-sys join -- --test-threads=1
- cargo test -p libcudf-rs join::tests:: -- --test-threads=1
- git diff --check
- cargo build -p libcudf-datafusion-benchmarks --release
- target/release/dfbench harness --dataset tpch_sf10 --iterations 3 --partitions 4 --run-id join-return-parity-sf10

Notes:
- Left untracked docs/ out of this PR.
- SF10 paired run passed 22/22 CPU/GPU queries; no GPU regression signal versus existing SF10 artifacts.