### PR TITLE
[codex] Cache cuDF literal scalars

### DIFF
--- a/libcudf-datafusion/src/expr/literal.rs
+++ b/libcudf-datafusion/src/expr/literal.rs
@@ -9,16 +9,38 @@ use delegate::delegate;
 use libcudf_rs::CuDFScalar;
 use std::any::Any;
 use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub struct CuDFLiteral {
     inner: Literal,
+    scalar: Arc<CuDFScalar>,
+}
+
+impl PartialEq for CuDFLiteral {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl Eq for CuDFLiteral {}
+
+impl Hash for CuDFLiteral {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
+    }
 }
 
 impl CuDFLiteral {
-    pub fn from_host(inner: Literal) -> Self {
-        Self { inner }
+    pub fn from_host(inner: Literal) -> datafusion::common::Result<Self> {
+        let value = normalize_scalar_for_cudf(inner.value().clone());
+        let host_scalar = value.to_scalar()?;
+        let scalar = CuDFScalar::from_arrow_host(host_scalar).map_err(cudf_to_df)?;
+        Ok(Self {
+            inner,
+            scalar: Arc::new(scalar),
+        })
     }
 }
 
@@ -35,11 +57,8 @@ impl PhysicalExpr for CuDFLiteral {
     }
 
     fn evaluate(&self, _: &RecordBatch) -> datafusion::common::Result<ColumnarValue> {
-        let value = normalize_scalar_for_cudf(self.inner.value().clone());
-        let host_scalar = value.to_scalar()?;
-        Ok(ColumnarValue::Array(Arc::new(
-            CuDFScalar::from_arrow_host(host_scalar).map_err(cudf_to_df)?,
-        )))
+        let scalar: Arc<dyn arrow::array::Array> = self.scalar.clone();
+        Ok(ColumnarValue::Array(scalar))
     }
 
     fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {

--- a/libcudf-datafusion/src/expr/mod.rs
+++ b/libcudf-datafusion/src/expr/mod.rs
@@ -53,7 +53,7 @@ pub(crate) fn expr_to_cudf_expr(
         return Ok(Arc::new(CuDFColumnExpr::from_host(column_expr.clone())));
     };
     if let Some(literal) = any.downcast_ref::<Literal>() {
-        return Ok(Arc::new(CuDFLiteral::from_host(literal.clone())));
+        return Ok(Arc::new(CuDFLiteral::from_host(literal.clone())?));
     }
 
     not_impl_err!("Expression {expr} not supported in CuDF")


### PR DESCRIPTION
## Summary

Cache cuDF literal scalars when DataFusion literals are lowered into cuDF expressions. Per-batch literal evaluation now returns the cached scalar through an `Arc` instead of rebuilding/uploading the scalar every time.

## Why

The q19 profile showed repeated literal scalar uploads and scalar extraction during filter predicate evaluation. This change removes that repeated host-to-cuDF conversion while preserving equality and hashing semantics based on the original DataFusion literal.

## Profile impact

Profiled with `target/release/dfbench harness --dataset tpch_sf10 --query q19 --iterations 3 --partitions 6 --gpu-execution-batch-size 131072 --warmup --plan-query q19 --profile-query q19 --run-id main-q19-literal-cache-arc-rerun`.

Compared with `main-q19-profile-fc5f3fe`:

- `from_arrow_column`: 8,280 -> 38
- `get_element`: 8,280 -> 38
- `cudaMemcpyAsync`: 103,964 -> 73,750
- `cudaEventRecord`: 149,044 -> 99,600
- `cudaLaunchKernel`: 40,480 -> 32,238
- `cudaMemsetAsync`: 27,602 -> 13,864
- <=64B memcpy calls: 82,804 -> 55,336

Driver-level `cudaMalloc` / `cudaHostAlloc` counts stayed at one each, which matches the RMM pool behavior; the improvement is fewer repeated cuDF scalar/column construction operations and fewer small control transfers.

## Validation

- `cargo check -p libcudf-datafusion`
- `cargo test -p libcudf-datafusion expr::literal --lib`
- `git diff --check`
- q19 profile rerun listed above
