### PR TITLE
Expose Arrow interop resources and load metrics

### DIFF
--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -6,8 +6,9 @@ use datafusion::common::{assert_eq_or_internal_err, exec_err, plan_err, ScalarVa
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
-use datafusion::physical_expr_common::metrics::MetricsSet;
-use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::physical_expr_common::metrics::{
+    Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet, Time,
+};
 use datafusion_physical_plan::stream::{
     RecordBatchReceiverStream, RecordBatchReceiverStreamBuilder,
 };
@@ -97,7 +98,7 @@ impl ExecutionPlan for CuDFLoadExec {
             inner: RecordBatchReceiverStream::builder(self.schema(), input_partitions),
             ctx: CuDFRecordBatchReceiverStreamBuilderCtx {
                 schema: self.schema(),
-                metrics: CuDFBaselineMetrics::new(&self.metrics, partition),
+                metrics: CuDFLoadMetrics::new(&self.metrics, partition),
             },
         };
 
@@ -125,7 +126,7 @@ struct CuDFRecordBatchReceiverStreamBuilder {
 #[derive(Clone)]
 struct CuDFRecordBatchReceiverStreamBuilderCtx {
     schema: SchemaRef,
-    metrics: CuDFBaselineMetrics,
+    metrics: CuDFLoadMetrics,
 }
 
 impl CuDFRecordBatchReceiverStreamBuilder {
@@ -133,31 +134,61 @@ impl CuDFRecordBatchReceiverStreamBuilder {
         let ctx = self.ctx.clone();
         let output = self.inner.tx();
         self.inner.spawn(async move {
-            while let Some(batch_or_err) = host_stream.next().await {
+            loop {
                 let ctx = ctx.clone();
-                let _timer_guard = ctx.metrics.elapsed_compute().timer();
+                let input_wait_timer = ctx.metrics.input_wait_time.timer();
+                let batch_or_err = host_stream.next().await;
+                input_wait_timer.done();
+
+                let Some(batch_or_err) = batch_or_err else {
+                    break;
+                };
+
+                let compute_timer = ctx.metrics.baseline.elapsed_compute().timer();
                 let batch = match batch_or_err {
-                    Ok(batch) => cast_to_target_schema(batch, Arc::clone(&ctx.schema))?,
+                    Ok(batch) => {
+                        let cast_timer = ctx.metrics.cast_time.timer();
+                        let batch = cast_to_target_schema(batch, Arc::clone(&ctx.schema))?;
+                        cast_timer.done();
+                        batch
+                    }
                     Err(err) => return Err(err),
                 };
 
                 if batch.columns().iter().any(|c| is_cudf_array(c)) {
                     return exec_err!("Cannot move RecordBatch from host to CuDF: a column is already a CuDF array");
                 }
+                ctx.metrics.record_input(&batch);
                 let schema = batch.schema();
+
+                let pin_timer = ctx.metrics.pin_time.timer();
                 let pinned_batch = pin_record_batch(batch).map_err(cudf_to_df)?;
+                pin_timer.done();
+
+                let import_timer = ctx.metrics.import_time.timer();
                 let table = CuDFTable::from_arrow_host(pinned_batch).map_err(cudf_to_df)?;
+                import_timer.done();
+
+                let sync_timer = ctx.metrics.sync_time.timer();
                 synchronize_default_stream().map_err(cudf_to_df)?;
+                sync_timer.done();
+
+                let output_batch_timer = ctx.metrics.output_batch_time.timer();
                 let num_rows = table.num_rows();
                 let cudf_cols: Vec<Arc<dyn Array>> = table
                     .into_columns()
                     .into_iter()
                     .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
                     .collect();
-                let batch =
-                    libcudf_rs::record_batch_with_schema(cudf_cols, &schema, num_rows)?;
-                ctx.metrics.record_output(&batch);
+                let batch = libcudf_rs::record_batch_with_schema(cudf_cols, &schema, num_rows)?;
+                output_batch_timer.done();
+
+                ctx.metrics.baseline.record_output(&batch);
+                compute_timer.done();
+
+                let send_timer = ctx.metrics.output_send_time.timer();
                 let send_result = output.send(Ok(batch)).await;
+                send_timer.done();
                 if send_result.is_err() {
                     break;
                 }
@@ -169,6 +200,100 @@ impl CuDFRecordBatchReceiverStreamBuilder {
 
     fn build(self) -> SendableRecordBatchStream {
         self.inner.build()
+    }
+}
+
+#[derive(Clone)]
+struct CuDFLoadMetrics {
+    baseline: CuDFBaselineMetrics,
+    input_wait_time: Time,
+    cast_time: Time,
+    pin_time: Time,
+    import_time: Time,
+    sync_time: Time,
+    output_batch_time: Time,
+    output_send_time: Time,
+    input_batches: Count,
+    input_rows: Count,
+    input_bytes: Count,
+    input_columns: Count,
+    bool_columns: Count,
+    numeric_columns: Count,
+    decimal_columns: Count,
+    string_columns: Count,
+    temporal_columns: Count,
+    other_columns: Count,
+}
+
+impl CuDFLoadMetrics {
+    fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        Self {
+            baseline: CuDFBaselineMetrics::new(metrics, partition),
+            input_wait_time: MetricBuilder::new(metrics).subset_time("input_wait_time", partition),
+            cast_time: MetricBuilder::new(metrics).subset_time("cast_time", partition),
+            pin_time: MetricBuilder::new(metrics).subset_time("pin_time", partition),
+            import_time: MetricBuilder::new(metrics).subset_time("import_time", partition),
+            sync_time: MetricBuilder::new(metrics).subset_time("sync_time", partition),
+            output_batch_time: MetricBuilder::new(metrics)
+                .subset_time("output_batch_time", partition),
+            output_send_time: MetricBuilder::new(metrics)
+                .subset_time("output_send_time", partition),
+            input_batches: MetricBuilder::new(metrics).counter("input_batches", partition),
+            input_rows: MetricBuilder::new(metrics).counter("input_rows", partition),
+            input_bytes: MetricBuilder::new(metrics).counter("input_bytes", partition),
+            input_columns: MetricBuilder::new(metrics).counter("input_columns", partition),
+            bool_columns: MetricBuilder::new(metrics).counter("bool_columns", partition),
+            numeric_columns: MetricBuilder::new(metrics).counter("numeric_columns", partition),
+            decimal_columns: MetricBuilder::new(metrics).counter("decimal_columns", partition),
+            string_columns: MetricBuilder::new(metrics).counter("string_columns", partition),
+            temporal_columns: MetricBuilder::new(metrics).counter("temporal_columns", partition),
+            other_columns: MetricBuilder::new(metrics).counter("other_columns", partition),
+        }
+    }
+
+    fn record_input(&self, batch: &RecordBatch) {
+        self.input_batches.add(1);
+        self.input_rows.add(batch.num_rows());
+        self.input_columns.add(batch.num_columns());
+        self.input_bytes.add(
+            batch
+                .columns()
+                .iter()
+                .map(|col| col.get_array_memory_size())
+                .sum::<usize>(),
+        );
+
+        for field in batch.schema().fields() {
+            match field.data_type() {
+                DataType::Boolean => self.bool_columns.add(1),
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float16
+                | DataType::Float32
+                | DataType::Float64 => self.numeric_columns.add(1),
+                DataType::Decimal32(_, _)
+                | DataType::Decimal64(_, _)
+                | DataType::Decimal128(_, _)
+                | DataType::Decimal256(_, _) => self.decimal_columns.add(1),
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+                    self.string_columns.add(1)
+                }
+                DataType::Date32
+                | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Timestamp(_, _)
+                | DataType::Duration(_)
+                | DataType::Interval(_) => self.temporal_columns.add(1),
+                _ => self.other_columns.add(1),
+            }
+        }
     }
 }
 

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -779,6 +779,8 @@ pub mod ffi {
         unsafe fn table_from_arrow_host(
             schema_ptr: *const u8,
             device_array_ptr: *const u8,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Convert an Arrow array to a cuDF column
@@ -789,6 +791,8 @@ pub mod ffi {
         unsafe fn column_from_arrow(
             schema_ptr: *const u8,
             array_ptr: *const u8,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Column>>;
 
         /// Cast a column to a different data type using GPU-native cudf::cast
@@ -1521,7 +1525,6 @@ mod tests {
 
     const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
     const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
-
     // Sorting tests
     #[test]
     fn test_sort_table_ascending() -> Result<(), Box<dyn std::error::Error>> {
@@ -2192,7 +2195,16 @@ mod tests {
 
         let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
-        Ok(unsafe { ffi::table_from_arrow_host(schema_ptr, device_array_ptr) }?)
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        Ok(unsafe {
+            ffi::table_from_arrow_host(
+                schema_ptr,
+                device_array_ptr,
+                stream.as_ref().expect("default stream should not be null"),
+                mr.as_ref().expect("device resource should not be null"),
+            )
+        }?)
     }
 
     fn table_from_nullable_i32_column(
@@ -2210,7 +2222,16 @@ mod tests {
 
         let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
-        Ok(unsafe { ffi::table_from_arrow_host(schema_ptr, device_array_ptr) }?)
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        Ok(unsafe {
+            ffi::table_from_arrow_host(
+                schema_ptr,
+                device_array_ptr,
+                stream.as_ref().expect("default stream should not be null"),
+                mr.as_ref().expect("device resource should not be null"),
+            )
+        }?)
     }
 
     fn table_from_decimal128_column(
@@ -2230,7 +2251,16 @@ mod tests {
 
         let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
-        Ok(unsafe { ffi::table_from_arrow_host(schema_ptr, device_array_ptr) }?)
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        Ok(unsafe {
+            ffi::table_from_arrow_host(
+                schema_ptr,
+                device_array_ptr,
+                stream.as_ref().expect("default stream should not be null"),
+                mr.as_ref().expect("device resource should not be null"),
+            )
+        }?)
     }
 
     fn pretty_table(table_view: &ffi::TableView) -> Result<impl Display + use<>, ArrowError> {

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -205,22 +205,30 @@ namespace libcudf_bridge {
     }
 
     // Arrow interop - convert Arrow data to cuDF table
-    std::unique_ptr<Table> table_from_arrow_host(uint8_t const *schema_ptr, uint8_t const *device_array_ptr) {
+    std::unique_ptr<Table> table_from_arrow_host(
+        uint8_t const *schema_ptr,
+        uint8_t const *device_array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         auto *schema = reinterpret_cast<const ArrowSchema *>(schema_ptr);
         auto *device_array = reinterpret_cast<const ArrowDeviceArray *>(device_array_ptr);
 
         auto result = std::make_unique<Table>();
-        result->inner = cudf::from_arrow_host(schema, device_array);
+        result->inner = cudf::from_arrow_host(schema, device_array, stream.inner, mr.inner);
         return result;
     }
 
     // Arrow interop - convert Arrow array to cuDF column
-    std::unique_ptr<Column> column_from_arrow(uint8_t const *schema_ptr, uint8_t const *array_ptr) {
+    std::unique_ptr<Column> column_from_arrow(
+        uint8_t const *schema_ptr,
+        uint8_t const *array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         auto *schema = reinterpret_cast<const ArrowSchema *>(schema_ptr);
         auto *array = reinterpret_cast<const ArrowArray *>(array_ptr);
 
         auto result = std::make_unique<Column>();
-        result->inner = cudf::from_arrow_column(schema, array);
+        result->inner = cudf::from_arrow_column(schema, array, stream.inner, mr.inner);
         return result;
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -6,6 +6,8 @@
 #include "table.h"
 #include "column.h"
 #include "scalar.h"
+#include "stream.h"
+#include "memory_resource.h"
 
 // Forward declarations of Arrow C ABI types
 struct ArrowSchema;
@@ -17,9 +19,17 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> apply_boolean_mask(const TableView &table, const ColumnView &boolean_mask);
 
     // Arrow interop - direct cuDF calls
-    std::unique_ptr<Table> table_from_arrow_host(uint8_t const *schema_ptr, uint8_t const *device_array_ptr);
+    std::unique_ptr<Table> table_from_arrow_host(
+        uint8_t const *schema_ptr,
+        uint8_t const *device_array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
-    std::unique_ptr<Column> column_from_arrow(uint8_t const *schema_ptr, uint8_t const *array_ptr);
+    std::unique_ptr<Column> column_from_arrow(
+        uint8_t const *schema_ptr,
+        uint8_t const *array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Table> concat_table_views(rust::Slice<const std::unique_ptr<TableView>> views);
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -5,6 +5,7 @@ use arrow::ffi::FFI_ArrowArray;
 use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::ArrowError;
 use cxx::UniquePtr;
+use libcudf_sys::ffi;
 use std::sync::Arc;
 
 /// A GPU-accelerated column (similar to an Arrow Array)
@@ -58,7 +59,16 @@ impl CuDFColumn {
         let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
         let array_ptr = &ffi_array as *const FFI_ArrowArray as *const u8;
 
-        let inner = unsafe { libcudf_sys::ffi::column_from_arrow(schema_ptr, array_ptr) }?;
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let inner = unsafe {
+            ffi::column_from_arrow(
+                schema_ptr,
+                array_ptr,
+                stream.as_ref().expect("default stream should not be null"),
+                mr.as_ref().expect("device resource should not be null"),
+            )
+        }?;
         Ok(Self { inner })
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -160,7 +160,16 @@ impl CuDFTable {
 
         let schema_ptr = &ffi_schema as *const FFI_ArrowSchema as *const u8;
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
-        let inner = unsafe { ffi::table_from_arrow_host(schema_ptr, device_array_ptr) }?;
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let inner = unsafe {
+            ffi::table_from_arrow_host(
+                schema_ptr,
+                device_array_ptr,
+                stream.as_ref().expect("default stream should not be null"),
+                mr.as_ref().expect("device resource should not be null"),
+            )
+        }?;
 
         Ok(Self { inner })
     }


### PR DESCRIPTION
## Summary
- expose explicit stream and device memory resource parameters on the sys Arrow interop bindings
- pass cuDF default stream and current device resource from the high-level table/column APIs
- add CuDFLoadExec metrics for cast, pin, import, sync, output construction, output send, input wait, and input batch shape/type counters

## Why
The local cuDF 26.02.01 headers define `from_arrow_host(schema, input, stream, mr)` and `from_arrow_column(schema, input, stream, mr)`. The sys crate should preserve those upstream parameters instead of silently relying on defaults.

The load operator is also the dominant bottleneck in our profiles, so this PR adds low-risk diagnostics that let us compare future experiments objectively without changing load behavior.

## Validation
- cargo fmt --check
- cargo check -p libcudf-datafusion
- cargo test -p libcudf-sys --lib
- cargo test -p libcudf-rs test_column_from_arrow --lib
- cargo test -p libcudf-rs table::tests::test_arrow_roundtrip_simple --lib