### PR TITLE
  libcudf-sys: add stream and device memory resource parameters

### DIFF
--- a/libcudf-datafusion/src/errors.rs
+++ b/libcudf-datafusion/src/errors.rs
@@ -5,5 +5,6 @@ pub(crate) fn cudf_to_df(err: CuDFError) -> DataFusionError {
     match err {
         CuDFError::CuDFError(err) => DataFusionError::External(Box::new(err)),
         CuDFError::ArrowError(err) => DataFusionError::ArrowError(Box::new(err), None),
+        err @ CuDFError::NullHandle(_) => DataFusionError::External(Box::new(err)),
     }
 }

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -203,6 +203,9 @@ impl CuDFRecordBatchReceiverStreamBuilder {
                     import_timer.done();
 
                     let sync_timer = ctx.metrics.sync_time.timer();
+                    // Beware: `CuDFTable::from_arrow_host` internally uses the default stream.
+                    // If we ever migrate that to a different stream, this call should 
+                    // be updated to synchronize that stream.
                     synchronize_default_stream().map_err(cudf_to_df)?;
                     sync_timer.done();
 

--- a/libcudf-sys/src/aggregation.cpp
+++ b/libcudf-sys/src/aggregation.cpp
@@ -140,9 +140,11 @@ namespace libcudf_bridge {
     std::unique_ptr<Scalar> reduce(
         const ColumnView &col,
         const ReduceAggregation &agg,
-        const DataType &output_type) {
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         auto result = std::make_unique<Scalar>();
-        result->inner = cudf::reduce(*col.inner, *agg.inner, output_type.inner);
+        result->inner = cudf::reduce(*col.inner, *agg.inner, output_type.inner, stream.inner, mr.inner);
         return result;
     }
 
@@ -150,13 +152,17 @@ namespace libcudf_bridge {
         const ColumnView &col,
         const ReduceAggregation &agg,
         const DataType &output_type,
-        const Scalar &init) {
+        const Scalar &init,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         auto result = std::make_unique<Scalar>();
         result->inner = cudf::reduce(
             *col.inner,
             *agg.inner,
             output_type.inner,
-            std::cref(*init.inner));
+            std::cref(*init.inner),
+            stream.inner,
+            mr.inner);
         return result;
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/aggregation.h
+++ b/libcudf-sys/src/aggregation.h
@@ -6,6 +6,8 @@
 #include "column.h"
 #include "data_type.h"
 #include "scalar.h"
+#include "stream.h"
+#include "memory_resource.h"
 #include <cudf/aggregation.hpp>
 
 namespace libcudf_bridge {
@@ -52,11 +54,15 @@ namespace libcudf_bridge {
     std::unique_ptr<Scalar> reduce(
         const ColumnView &col,
         const ReduceAggregation &agg,
-        const DataType &output_type);
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Scalar> reduce_with_init(
         const ColumnView &col,
         const ReduceAggregation &agg,
         const DataType &output_type,
-        const Scalar &init);
+        const Scalar &init,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/binaryop.cpp
+++ b/libcudf-sys/src/binaryop.cpp
@@ -47,14 +47,18 @@ namespace libcudf_bridge {
         const ColumnView &lhs,
         const ColumnView &rhs,
         int32_t op,
-        const DataType &output_type) {
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         const auto binary_op = static_cast<cudf::binary_operator>(op);
 
         auto result_col = cudf::binary_operation(
             *lhs.inner,
             *rhs.inner,
             binary_op,
-            output_type.inner
+            output_type.inner,
+            stream.inner,
+            mr.inner
         );
 
         return std::make_unique<Column>(column_from_unique_ptr(std::move(result_col)));
@@ -65,14 +69,18 @@ namespace libcudf_bridge {
         const ColumnView &lhs,
         const Scalar &rhs,
         int32_t op,
-        const DataType &output_type) {
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         const auto binary_op = static_cast<cudf::binary_operator>(op);
 
         auto result_col = cudf::binary_operation(
             *lhs.inner,
             *rhs.inner,
             binary_op,
-            output_type.inner
+            output_type.inner,
+            stream.inner,
+            mr.inner
         );
 
         return std::make_unique<Column>(column_from_unique_ptr(std::move(result_col)));
@@ -83,14 +91,18 @@ namespace libcudf_bridge {
         const Scalar &lhs,
         const ColumnView &rhs,
         int32_t op,
-        const DataType &output_type) {
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         const auto binary_op = static_cast<cudf::binary_operator>(op);
 
         auto result_col = cudf::binary_operation(
             *lhs.inner,
             *rhs.inner,
             binary_op,
-            output_type.inner
+            output_type.inner,
+            stream.inner,
+            mr.inner
         );
 
         return std::make_unique<Column>(column_from_unique_ptr(std::move(result_col)));

--- a/libcudf-sys/src/binaryop.h
+++ b/libcudf-sys/src/binaryop.h
@@ -6,6 +6,8 @@
 #include "column.h"
 #include "scalar.h"
 #include "data_type.h"
+#include "stream.h"
+#include "memory_resource.h"
 
 namespace libcudf_bridge {
 
@@ -14,17 +16,23 @@ namespace libcudf_bridge {
         const ColumnView &lhs,
         const ColumnView &rhs,
         int32_t op,
-        const DataType &output_type);
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Column> binary_operation_col_scalar(
         const ColumnView &lhs,
         const Scalar &rhs,
         int32_t op,
-        const DataType &output_type);
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Column> binary_operation_scalar_col(
         const Scalar &lhs,
         const ColumnView &rhs,
         int32_t op,
-        const DataType &output_type);
+        const DataType &output_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -13,7 +13,6 @@
 #include <cudf/copying.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <memory>
@@ -37,11 +36,14 @@ namespace libcudf_bridge {
     }
 
     // Get the column's data as an FFI Arrow Array
-    void ColumnView::to_arrow_array(uint8_t *out_array_ptr) const {
+    void ColumnView::to_arrow_array(
+        uint8_t *out_array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) const {
         if (!inner) {
             throw std::runtime_error("Cannot convert null column view to arrow array");
         }
-        auto device_array_unique = cudf::to_arrow_host(*this->inner);
+        auto device_array_unique = cudf::to_arrow_host(*this->inner, stream.inner, mr.inner);
         auto *out_array = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
         *out_array = *device_array_unique.get();
         device_array_unique.release();
@@ -98,18 +100,18 @@ namespace libcudf_bridge {
     }
 
     // Helper functions for memory size calculations
-    size_t calculate_buffer_memory_size(const cudf::column_view& view) {
+    size_t calculate_buffer_memory_size(const cudf::column_view& view, const CudaStreamView& stream) {
         size_t data_size = 0;
         if (cudf::is_fixed_width(view.type())) {
             data_size = cudf::size_of(view.type()) * view.size();
         } else if (view.type().id() == cudf::type_id::STRING) {
             auto const strings = cudf::strings_column_view(view);
             data_size = ((view.size() + 1) * sizeof(cudf::size_type)) +
-                        static_cast<size_t>(strings.chars_size(cudf::get_default_stream()));
+                        static_cast<size_t>(strings.chars_size(stream.inner));
         } else {
             // For nested types recursively add child buffer sizes.
             for (cudf::size_type i = 0; i < view.num_children(); ++i) {
-                data_size += calculate_buffer_memory_size(view.child(i));
+                data_size += calculate_buffer_memory_size(view.child(i), stream);
             }
         }
 
@@ -130,24 +132,24 @@ namespace libcudf_bridge {
         return size;
     }
 
-    size_t calculate_array_memory_size(const cudf::column_view& view) {
-        return calculate_buffer_memory_size(view) + calculate_null_mask_size(view);
+    size_t calculate_array_memory_size(const cudf::column_view& view, const CudaStreamView& stream) {
+        return calculate_buffer_memory_size(view, stream) + calculate_null_mask_size(view);
     }
 
     // Get buffer memory size (data + offsets, no null mask)
-    [[nodiscard]] size_t ColumnView::get_buffer_memory_size() const {
+    [[nodiscard]] size_t ColumnView::get_buffer_memory_size(const CudaStreamView &stream) const {
         if (!inner) {
             return 0;
         }
-        return calculate_buffer_memory_size(*inner);
+        return calculate_buffer_memory_size(*inner, stream);
     }
 
     // Get total array memory size (data + offsets + null mask + children)
-    [[nodiscard]] size_t ColumnView::get_array_memory_size() const {
+    [[nodiscard]] size_t ColumnView::get_array_memory_size(const CudaStreamView &stream) const {
         if (!inner) {
             return 0;
         }
-        return calculate_array_memory_size(*inner);
+        return calculate_array_memory_size(*inner, stream);
     }
 
     // Transfer the null buffer
@@ -232,17 +234,25 @@ namespace libcudf_bridge {
     }
 
     // Cast a column to a different data type
-    std::unique_ptr<Column> cast_column(const ColumnView &input, const DataType &target_type) {
+    std::unique_ptr<Column> cast_column(
+        const ColumnView &input,
+        const DataType &target_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         if (!input.inner) {
             throw std::runtime_error("Cannot cast null column view");
         }
         auto result = std::make_unique<Column>();
-        result->inner = cudf::cast(*input.inner, target_type.inner);
+        result->inner = cudf::cast(*input.inner, target_type.inner, stream.inner, mr.inner);
         return result;
     }
 
     // Extract a scalar from a column at the specified index
-    std::unique_ptr<Scalar> get_element(const ColumnView &column, size_t index) {
+    std::unique_ptr<Scalar> get_element(
+        const ColumnView &column,
+        size_t index,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         if (!column.inner) {
             throw std::runtime_error("Cannot get element from null column view");
         }
@@ -250,7 +260,11 @@ namespace libcudf_bridge {
             throw std::out_of_range("Index out of bounds for get_element");
         }
         auto result = std::make_unique<Scalar>();
-        result->inner = cudf::get_element(*column.inner, static_cast<cudf::size_type>(index));
+        result->inner = cudf::get_element(
+            *column.inner,
+            static_cast<cudf::size_type>(index),
+            stream.inner,
+            mr.inner);
         return result;
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -4,6 +4,8 @@
 
 #include "cudf/types.hpp"
 #include "rust/cxx.h"
+#include "stream.h"
+#include "memory_resource.h"
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/scalar/scalar.hpp>
@@ -12,9 +14,9 @@ namespace libcudf_bridge {
     struct DataType;
 
     // Helper functions for memory size calculations
-    size_t calculate_buffer_memory_size(const cudf::column_view& view);
+    size_t calculate_buffer_memory_size(const cudf::column_view& view, const CudaStreamView& stream);
     size_t calculate_null_mask_size(const cudf::column_view& view);
-    size_t calculate_array_memory_size(const cudf::column_view& view);
+    size_t calculate_array_memory_size(const cudf::column_view& view, const CudaStreamView& stream);
 
     // Opaque wrapper for cuDF column_view
     struct ColumnView {
@@ -28,7 +30,10 @@ namespace libcudf_bridge {
         [[nodiscard]] size_t size() const;
 
         // Get the column's data as an FFI Arrow Array
-        void to_arrow_array(uint8_t *out_array_ptr) const;
+        void to_arrow_array(
+            uint8_t *out_array_ptr,
+            const CudaStreamView &stream,
+            const DeviceAsyncResourceRef &mr) const;
 
         // Get the raw device pointer to the column view's data
         [[nodiscard]] uint64_t data_ptr() const;
@@ -46,10 +51,10 @@ namespace libcudf_bridge {
         [[nodiscard]] int32_t null_count() const;
 
         // Get buffer memory size (data + offsets, no null mask)
-        [[nodiscard]] size_t get_buffer_memory_size() const;
+        [[nodiscard]] size_t get_buffer_memory_size(const CudaStreamView &stream) const;
 
         // Get total array memory size (data + offsets + null mask + children)
-        [[nodiscard]] size_t get_array_memory_size() const;
+        [[nodiscard]] size_t get_array_memory_size(const CudaStreamView &stream) const;
 
         // Transfer the null buffer
         [[nodiscard]] rust::Vec<uint8_t> get_null_buffer() const;
@@ -89,9 +94,17 @@ namespace libcudf_bridge {
     Column column_from_unique_ptr(std::unique_ptr<cudf::column> col);
 
     // Extract a scalar from a column at the specified index
-    std::unique_ptr<Scalar> get_element(const ColumnView &column, size_t index);
+    std::unique_ptr<Scalar> get_element(
+        const ColumnView &column,
+        size_t index,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     // Cast a column to a different data type
-    std::unique_ptr<Column> cast_column(const ColumnView &input, const DataType &target_type);
+    std::unique_ptr<Column> cast_column(
+        const ColumnView &input,
+        const DataType &target_type,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/groupby.cpp
+++ b/libcudf-sys/src/groupby.cpp
@@ -33,8 +33,11 @@ namespace libcudf_bridge {
 
     GroupBy::~GroupBy() = default;
 
-    std::unique_ptr<GroupByResult> GroupBy::aggregate(const AggregationRequests &requests) const {
-        auto aggregate_result = inner->aggregate(requests.inner);
+    std::unique_ptr<GroupByResult> GroupBy::aggregate(
+        const AggregationRequests &requests,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) const {
+        auto aggregate_result = inner->aggregate(requests.inner, stream.inner, mr.inner);
 
         auto group_by_result = std::make_unique<GroupByResult>();
         group_by_result->keys.inner = std::move(aggregate_result.first);

--- a/libcudf-sys/src/groupby.h
+++ b/libcudf-sys/src/groupby.h
@@ -7,6 +7,8 @@
 #include "table.h"
 #include "column.h"
 #include "aggregation.h"
+#include "stream.h"
+#include "memory_resource.h"
 #include <cudf/groupby.hpp>
 
 namespace libcudf_bridge {
@@ -73,7 +75,9 @@ namespace libcudf_bridge {
 
         // Direct cuDF method
         [[nodiscard]] std::unique_ptr<GroupByResult> aggregate(
-            const AggregationRequests &requests) const;
+            const AggregationRequests &requests,
+            const CudaStreamView &stream,
+            const DeviceAsyncResourceRef &mr) const;
     };
 
     // GroupBy operations - direct cuDF mappings

--- a/libcudf-sys/src/io.cpp
+++ b/libcudf-sys/src/io.cpp
@@ -5,22 +5,28 @@
 
 namespace libcudf_bridge {
     // Parquet I/O
-    std::unique_ptr<Table> read_parquet(rust::Str filename) {
+    std::unique_ptr<Table> read_parquet(
+        rust::Str filename,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::string filename_str(filename.data(), filename.size());
         auto options = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filename_str});
-        auto [tbl, metadata] = cudf::io::read_parquet(options.build());
+        auto [tbl, metadata] = cudf::io::read_parquet(options.build(), stream.inner, mr.inner);
 
         auto table = std::make_unique<Table>();
         table->inner = std::move(tbl);
         return table;
     }
 
-    void write_parquet(const TableView &table, const rust::Str filename) {
+    void write_parquet(
+        const TableView &table,
+        const rust::Str filename,
+        const CudaStreamView &stream) {
         const std::string filename_str(filename.data(), filename.size());
         auto options = cudf::io::parquet_writer_options::builder(
             cudf::io::sink_info{filename_str},
             *table.inner
         );
-        cudf::io::write_parquet(options.build());
+        cudf::io::write_parquet(options.build(), stream.inner);
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/io.h
+++ b/libcudf-sys/src/io.h
@@ -3,10 +3,15 @@
 #include <memory>
 #include "rust/cxx.h"
 #include "table.h"
+#include "stream.h"
+#include "memory_resource.h"
 
 namespace libcudf_bridge {
 
     // Parquet I/O
-    std::unique_ptr<Table> read_parquet(rust::Str filename);
-    void write_parquet(const TableView &table, rust::Str filename);
+    std::unique_ptr<Table> read_parquet(
+        rust::Str filename,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
+    void write_parquet(const TableView &table, rust::Str filename, const CudaStreamView &stream);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -1620,13 +1620,11 @@ mod tests {
     const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
     const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
 
-    type CxxResult<T> = std::result::Result<T, cxx::Exception>;
-
-    fn stream_ref(stream: &cxx::UniquePtr<ffi::CudaStreamView>) -> &ffi::CudaStreamView {
+    fn expect_stream(stream: &cxx::UniquePtr<ffi::CudaStreamView>) -> &ffi::CudaStreamView {
         stream.as_ref().expect("default stream should not be null")
     }
 
-    fn resource_ref(
+    fn expect_resource(
         resource: &cxx::UniquePtr<ffi::DeviceAsyncResourceRef>,
     ) -> &ffi::DeviceAsyncResourceRef {
         resource
@@ -1634,215 +1632,31 @@ mod tests {
             .expect("current device resource should not be null")
     }
 
-    fn read_parquet(filename: &str) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::read_parquet(filename, stream_ref(&stream), resource_ref(&resource))
-    }
-
-    fn sort_table(
-        input: &ffi::TableView,
-        column_order: &[i32],
-        null_precedence: &[i32],
-    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::sort_table(
-            input,
-            column_order,
-            null_precedence,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn stable_sort_table(
-        input: &ffi::TableView,
-        column_order: &[i32],
-        null_precedence: &[i32],
-    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::stable_sort_table(
-            input,
-            column_order,
-            null_precedence,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn sorted_order(
-        input: &ffi::TableView,
-        column_order: &[i32],
-        null_precedence: &[i32],
-    ) -> CxxResult<cxx::UniquePtr<ffi::Column>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::sorted_order(
-            input,
-            column_order,
-            null_precedence,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn is_sorted(
-        input: &ffi::TableView,
-        column_order: &[i32],
-        null_precedence: &[i32],
-    ) -> CxxResult<bool> {
-        let stream = ffi::get_default_stream();
-        ffi::is_sorted(input, column_order, null_precedence, stream_ref(&stream))
-    }
-
-    fn sort_by_key(
-        values: &ffi::TableView,
-        keys: &ffi::TableView,
-        column_order: &[i32],
-        null_precedence: &[i32],
-    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::sort_by_key(
-            values,
-            keys,
-            column_order,
-            null_precedence,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn stable_sort_by_key(
-        values: &ffi::TableView,
-        keys: &ffi::TableView,
-        column_order: &[i32],
-        null_precedence: &[i32],
-    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::stable_sort_by_key(
-            values,
-            keys,
-            column_order,
-            null_precedence,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn binary_operation_col_col(
-        lhs: &ffi::ColumnView,
-        rhs: &ffi::ColumnView,
-        op: i32,
-        output_type: &ffi::DataType,
-    ) -> CxxResult<cxx::UniquePtr<ffi::Column>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::binary_operation_col_col(
-            lhs,
-            rhs,
-            op,
-            output_type,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn reduce(
-        col: &ffi::ColumnView,
-        agg: &ffi::ReduceAggregation,
-        output_type: &ffi::DataType,
-    ) -> CxxResult<cxx::UniquePtr<ffi::Scalar>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::reduce(
-            col,
-            agg,
-            output_type,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn reduce_with_init(
-        col: &ffi::ColumnView,
-        agg: &ffi::ReduceAggregation,
-        output_type: &ffi::DataType,
-        init: &ffi::Scalar,
-    ) -> CxxResult<cxx::UniquePtr<ffi::Scalar>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::reduce_with_init(
-            col,
-            agg,
-            output_type,
-            init,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn get_element(column: &ffi::ColumnView, index: usize) -> cxx::UniquePtr<ffi::Scalar> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::get_element(column, index, stream_ref(&stream), resource_ref(&resource))
-    }
-
-    fn make_column_from_scalar(
-        scalar: &ffi::Scalar,
-        size: usize,
-    ) -> CxxResult<cxx::UniquePtr<ffi::Column>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::make_column_from_scalar(scalar, size, stream_ref(&stream), resource_ref(&resource))
-    }
-
-    fn apply_boolean_mask(
-        table: &ffi::TableView,
-        boolean_mask: &ffi::ColumnView,
-    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        ffi::apply_boolean_mask(
-            table,
-            boolean_mask,
-            stream_ref(&stream),
-            resource_ref(&resource),
-        )
-    }
-
-    fn aggregate(
-        groupby: &ffi::GroupBy,
-        requests: &ffi::AggregationRequests,
-    ) -> CxxResult<cxx::UniquePtr<ffi::GroupByResult>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        groupby.aggregate(requests, stream_ref(&stream), resource_ref(&resource))
-    }
-
-    fn slice_column(
-        column: &ffi::ColumnView,
-        offset: usize,
-        length: usize,
-    ) -> CxxResult<cxx::UniquePtr<ffi::ColumnView>> {
-        let stream = ffi::get_default_stream();
-        ffi::slice_column(column, offset, length, stream_ref(&stream))
-    }
-
     // Sorting tests
     #[test]
     fn test_sort_table_ascending() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let sorted_table = sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = ffi::sort_table(
+            &table_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1853,14 +1667,28 @@ mod tests {
 
     #[test]
     fn test_sort_table_descending() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Descending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::After as i32; num_cols];
 
-        let sorted_table = sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = ffi::sort_table(
+            &table_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1871,14 +1699,28 @@ mod tests {
 
     #[test]
     fn test_stable_sort_table() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let sorted_table = stable_sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = ffi::stable_sort_table(
+            &table_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1889,14 +1731,28 @@ mod tests {
 
     #[test]
     fn test_sorted_order() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let indices = sorted_order(&table_view, &column_order, &null_precedence)?;
+        let indices = ffi::sorted_order(
+            &table_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(indices.size(), table.num_rows());
         assert_snapshot!(pretty_column(&indices.view(), DataType::Int32)?);
@@ -1906,17 +1762,31 @@ mod tests {
 
     #[test]
     fn test_is_sorted() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let sorted_table = sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = ffi::sort_table(
+            &table_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
         let sorted_view = sorted_table.view();
 
-        let is_sorted = is_sorted(&sorted_view, &column_order, &null_precedence)?;
+        let is_sorted = ffi::is_sorted(&sorted_view, &column_order, &null_precedence, stream_view)?;
         assert!(is_sorted, "Table should be sorted after calling sort_table");
 
         Ok(())
@@ -1924,7 +1794,15 @@ mod tests {
 
     #[test]
     fn test_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0]);
@@ -1932,7 +1810,14 @@ mod tests {
         let column_order = vec![Order::Ascending as i32];
         let null_precedence = vec![NullOrder::Before as i32];
 
-        let sorted_table = sort_by_key(&table_view, &keys_view, &column_order, &null_precedence)?;
+        let sorted_table = ffi::sort_by_key(
+            &table_view,
+            &keys_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1943,7 +1828,15 @@ mod tests {
 
     #[test]
     fn test_stable_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0, 1]);
@@ -1951,8 +1844,14 @@ mod tests {
         let column_order = vec![Order::Ascending as i32, Order::Descending as i32];
         let null_precedence = vec![NullOrder::Before as i32, NullOrder::After as i32];
 
-        let sorted_table =
-            stable_sort_by_key(&table_view, &keys_view, &column_order, &null_precedence)?;
+        let sorted_table = ffi::stable_sort_by_key(
+            &table_view,
+            &keys_view,
+            &column_order,
+            &null_precedence,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1964,15 +1863,29 @@ mod tests {
     // Binary operation tests
     #[test]
     fn test_binary_op_col_col_add() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let col1 = table_view.column(1);
         let col2 = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
-        let result =
-            binary_operation_col_col(&col1, &col2, BinaryOperator::Add as i32, &output_type)?;
+        let result = ffi::binary_operation_col_col(
+            &col1,
+            &col2,
+            BinaryOperator::Add as i32,
+            &output_type,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(result.size(), col1.size());
         assert_eq!(result.size(), col2.size());
@@ -1983,15 +1896,29 @@ mod tests {
 
     #[test]
     fn test_binary_op_col_col_multiply() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let col1 = table_view.column(1);
         let col2 = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
-        let result =
-            binary_operation_col_col(&col1, &col2, BinaryOperator::Mul as i32, &output_type)?;
+        let result = ffi::binary_operation_col_col(
+            &col1,
+            &col2,
+            BinaryOperator::Mul as i32,
+            &output_type,
+            stream_view,
+            resource_ref,
+        )?;
 
         assert_eq!(result.size(), col1.size());
         assert_snapshot!(pretty_column(&result.view(), DataType::Float64)?);
@@ -2061,8 +1988,16 @@ mod tests {
         let table = table_from_decimal128_column("amount", vec![12345, 67890], 2)?;
         let column = table.view().column(0);
         let output_type = ffi::new_data_type_with_scale(TypeId::Decimal128 as i32, -2);
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
 
-        let result = reduce(&column, &ffi::make_sum_aggregation(), &output_type)?;
+        let result = ffi::reduce(
+            &column,
+            &ffi::make_sum_aggregation(),
+            &output_type,
+            expect_stream(&stream),
+            expect_resource(&resource),
+        )?;
         let result_type = result.data_type();
 
         assert!(result.is_valid());
@@ -2077,11 +2012,22 @@ mod tests {
         let table = table_from_i32_columns(&[("values", vec![1, 2, 3])])?;
         let values = table.view().column(0);
         let init_table = table_from_i32_columns(&[("init", vec![10])])?;
-        let init = get_element(&init_table.view().column(0), 0);
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let init = ffi::get_element(&init_table.view().column(0), 0, stream_view, resource_ref);
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
 
-        let result = reduce_with_init(&values, &ffi::make_sum_aggregation(), &output_type, &init)?;
-        let result_column = make_column_from_scalar(&result, 1)?;
+        let result = ffi::reduce_with_init(
+            &values,
+            &ffi::make_sum_aggregation(),
+            &output_type,
+            &init,
+            stream_view,
+            resource_ref,
+        )?;
+        let result_column = ffi::make_column_from_scalar(&result, 1, stream_view, resource_ref)?;
 
         assert_snapshot!(pretty_column(&result_column.view(), DataType::Int32)?, @r"
         +------+
@@ -2099,20 +2045,28 @@ mod tests {
         let table = table_from_nullable_i32_column("values", vec![Some(1), None, Some(3), None])?;
         let values = table.view().column(0);
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
 
-        let exclude = reduce(
+        let exclude = ffi::reduce(
             &values,
             &ffi::make_count_aggregation(NullPolicy::Exclude as i32),
             &output_type,
+            stream_view,
+            resource_ref,
         )?;
-        let include = reduce(
+        let include = ffi::reduce(
             &values,
             &ffi::make_count_aggregation(NullPolicy::Include as i32),
             &output_type,
+            stream_view,
+            resource_ref,
         )?;
 
-        let exclude_column = make_column_from_scalar(&exclude, 1)?;
-        let include_column = make_column_from_scalar(&include, 1)?;
+        let exclude_column = ffi::make_column_from_scalar(&exclude, 1, stream_view, resource_ref)?;
+        let include_column = ffi::make_column_from_scalar(&include, 1, stream_view, resource_ref)?;
 
         assert_snapshot!(pretty_column(&exclude_column.view(), DataType::Int32)?, @r"
         +------+
@@ -2162,10 +2116,8 @@ mod tests {
             &left_keys,
             &right_keys,
             NullEquality::Equal as i32,
-            stream.as_ref().expect("default stream should not be null"),
-            resource
-                .as_ref()
-                .expect("current resource should not be null"),
+            expect_stream(&stream),
+            expect_resource(&resource),
         )?;
         let left_indices = indices.pin_mut().release_left();
         let right_indices = indices.pin_mut().release_right();
@@ -2202,10 +2154,8 @@ mod tests {
                 .expect("right index vector should not be null"),
             &predicate,
             JoinKind::Inner as i32,
-            stream.as_ref().expect("default stream should not be null"),
-            resource
-                .as_ref()
-                .expect("current resource should not be null"),
+            expect_stream(&stream),
+            expect_resource(&resource),
         )?;
         let filtered_left = filtered.pin_mut().release_left();
         let filtered_right = filtered.pin_mut().release_right();
@@ -2221,21 +2171,32 @@ mod tests {
     // Filter tests
     #[test]
     fn test_apply_boolean_mask() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let min_temp = table_view.column(1);
         let max_temp = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Bool8 as i32);
-        let boolean_mask = binary_operation_col_col(
+        let boolean_mask = ffi::binary_operation_col_col(
             &min_temp,
             &max_temp,
             BinaryOperator::Less as i32,
             &output_type,
+            stream_view,
+            resource_ref,
         )?;
 
-        let filtered_table = apply_boolean_mask(&table_view, &boolean_mask.view())?;
+        let filtered_table =
+            ffi::apply_boolean_mask(&table_view, &boolean_mask.view(), stream_view, resource_ref)?;
 
         assert!(filtered_table.num_rows() < table.num_rows());
         assert_eq!(filtered_table.num_columns(), table.num_columns());
@@ -2250,7 +2211,15 @@ mod tests {
     // GroupBy tests
     #[test]
     fn test_groupby_sum() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let column_order: &[i32] = &[];
@@ -2269,7 +2238,7 @@ mod tests {
 
         let mut agg_requests = ffi::aggregation_requests_create();
         agg_requests.pin_mut().add(request);
-        let mut groupby_result = aggregate(&groupby, &agg_requests)?;
+        let mut groupby_result = groupby.aggregate(&agg_requests, stream_view, resource_ref)?;
 
         let mut aggregation_result = groupby_result.pin_mut().release_result(0);
         let keys = groupby_result.pin_mut().release_keys();
@@ -2285,7 +2254,15 @@ mod tests {
 
     #[test]
     fn test_groupby_multiple_aggregations() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000001.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000001.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0]);
@@ -2313,7 +2290,7 @@ mod tests {
 
         let mut requests = ffi::aggregation_requests_create();
         requests.pin_mut().add(agg_request);
-        let mut groupby_result = aggregate(&groupby, &requests)?;
+        let mut groupby_result = groupby.aggregate(&requests, stream_view, resource_ref)?;
 
         assert_eq!(groupby_result.len(), 1);
         let mut agg_result = groupby_result.pin_mut().release_result(0);
@@ -2336,14 +2313,22 @@ mod tests {
     // Slice tests
     #[test]
     fn test_slice_column_basic() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
         let original_col = table_view.column(1);
 
         let original_size = original_col.size();
         assert!(original_size > 10, "Need at least 10 rows for testing");
 
-        let sliced_col = slice_column(&original_col, 5, 5)?;
+        let sliced_col = ffi::slice_column(&original_col, 5, 5, stream_view)?;
 
         assert_eq!(sliced_col.size(), 5);
 
@@ -2368,11 +2353,19 @@ mod tests {
 
     #[test]
     fn test_slice_column_from_start() -> Result<(), Box<dyn std::error::Error>> {
-        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        let stream_view = expect_stream(&stream);
+        let resource_ref = expect_resource(&resource);
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_view,
+            resource_ref,
+        )?;
         let table_view = table.view();
         let original_col = table_view.column(2);
 
-        let sliced_col = slice_column(&original_col, 0, 10)?;
+        let sliced_col = ffi::slice_column(&original_col, 0, 10, stream_view)?;
 
         assert_eq!(sliced_col.size(), 10);
         assert_snapshot!(pretty_column(&sliced_col, DataType::Float64)?, @r"
@@ -2438,8 +2431,8 @@ mod tests {
         let resource = get_current_device_resource_ref();
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
-            stream_ref(&stream),
-            resource_ref(&resource),
+            expect_stream(&stream),
+            expect_resource(&resource),
         )?;
 
         assert!(table.num_rows() > 0);
@@ -2491,8 +2484,8 @@ mod tests {
             ffi::table_from_arrow_host(
                 schema_ptr,
                 device_array_ptr,
-                stream.as_ref().expect("default stream should not be null"),
-                mr.as_ref().expect("device resource should not be null"),
+                expect_stream(&stream),
+                expect_resource(&mr),
             )
         }?)
     }
@@ -2518,8 +2511,8 @@ mod tests {
             ffi::table_from_arrow_host(
                 schema_ptr,
                 device_array_ptr,
-                stream.as_ref().expect("default stream should not be null"),
-                mr.as_ref().expect("device resource should not be null"),
+                expect_stream(&stream),
+                expect_resource(&mr),
             )
         }?)
     }
@@ -2547,8 +2540,8 @@ mod tests {
             ffi::table_from_arrow_host(
                 schema_ptr,
                 device_array_ptr,
-                stream.as_ref().expect("default stream should not be null"),
-                mr.as_ref().expect("device resource should not be null"),
+                expect_stream(&stream),
+                expect_resource(&mr),
             )
         }?)
     }
@@ -2562,8 +2555,8 @@ mod tests {
         let data = unsafe {
             table_view.to_arrow_array(
                 &mut array as *mut FFI_ArrowArray as *mut u8,
-                stream_ref(&stream),
-                resource_ref(&resource),
+                expect_stream(&stream),
+                expect_resource(&resource),
             );
             table_view.to_arrow_schema(&mut schema as *mut FFI_ArrowSchema as *mut u8);
 
@@ -2586,8 +2579,8 @@ mod tests {
         let data = unsafe {
             column_view.to_arrow_array(
                 &mut array as *mut FFI_ArrowArray as *mut u8,
-                stream_ref(&stream),
-                resource_ref(&resource),
+                expect_stream(&stream),
+                expect_resource(&resource),
             );
 
             from_ffi_and_data_type(array, data_type).expect("ffi data should be valid")

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -206,6 +206,8 @@ pub mod ffi {
         fn aggregate(
             self: &GroupBy,
             requests: &AggregationRequests,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<GroupByResult>>;
 
         // AggregationRequest methods
@@ -291,7 +293,12 @@ pub mod ffi {
         /// # Safety
         ///
         /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
-        unsafe fn to_arrow_array(self: &TableView, out_array_ptr: *mut u8);
+        unsafe fn to_arrow_array(
+            self: &TableView,
+            out_array_ptr: *mut u8,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        );
 
         /// Clone this table view
         ///
@@ -319,7 +326,12 @@ pub mod ffi {
         /// # Safety
         ///
         /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
-        unsafe fn to_arrow_array(self: &ColumnView, out_array_ptr: *mut u8);
+        unsafe fn to_arrow_array(
+            self: &ColumnView,
+            out_array_ptr: *mut u8,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        );
 
         /// Get the raw device pointer to the column view's data
         fn data_ptr(self: &ColumnView) -> u64;
@@ -341,10 +353,10 @@ pub mod ffi {
         fn null_count(self: &ColumnView) -> i32;
 
         /// Get buffer memory size (data + offsets, no null mask)
-        fn get_buffer_memory_size(self: &ColumnView) -> usize;
+        fn get_buffer_memory_size(self: &ColumnView, stream: &CudaStreamView) -> usize;
 
         /// Get total array memory size (data + offsets + null mask + children)
-        fn get_array_memory_size(self: &ColumnView) -> usize;
+        fn get_array_memory_size(self: &ColumnView, stream: &CudaStreamView) -> usize;
 
         /// Transfer the null buffer
         fn get_null_buffer(self: &ColumnView) -> Vec<u8>;
@@ -362,7 +374,12 @@ pub mod ffi {
         /// # Safety
         ///
         /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
-        unsafe fn to_arrow_array(self: &Scalar, out_array_ptr: *mut u8);
+        unsafe fn to_arrow_array(
+            self: &Scalar,
+            out_array_ptr: *mut u8,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        );
 
         /// Check if the scalar is valid (not null)
         fn is_valid(self: &Scalar) -> bool;
@@ -393,16 +410,35 @@ pub mod ffi {
         fn create_table_from_columns_move(columns: &[*mut Column]) -> UniquePtr<Table>;
 
         /// Create a table from vertically concatenating TableView together
-        fn concat_table_views(views: &[UniquePtr<TableView>]) -> Result<UniquePtr<Table>>;
+        fn concat_table_views(
+            views: &[UniquePtr<TableView>],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Table>>;
 
         /// Create a table from vertically concatenating ColumnView together
-        fn concat_column_views(views: &[UniquePtr<ColumnView>]) -> Result<UniquePtr<Column>>;
+        fn concat_column_views(
+            views: &[UniquePtr<ColumnView>],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Column>>;
 
         /// Create a column by repeating a scalar value.
-        fn make_column_from_scalar(scalar: &Scalar, size: usize) -> Result<UniquePtr<Column>>;
+        fn make_column_from_scalar(
+            scalar: &Scalar,
+            size: usize,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Column>>;
 
         /// Fill a column with a sequence starting at `init` and stepping by `step`.
-        fn sequence(size: usize, init: &Scalar, step: &Scalar) -> Result<UniquePtr<Column>>;
+        fn sequence(
+            size: usize,
+            init: &Scalar,
+            step: &Scalar,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Column>>;
 
         /// Create a TableView from a set of ColumnView pointers (non-owning)
         fn create_table_view_from_column_views(
@@ -412,10 +448,14 @@ pub mod ffi {
         // Parquet I/O
 
         /// Read a Parquet file into a table
-        fn read_parquet(filename: &str) -> Result<UniquePtr<Table>>;
+        fn read_parquet(
+            filename: &str,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Table>>;
 
         /// Write a table to a Parquet file
-        fn write_parquet(table: &TableView, filename: &str) -> Result<()>;
+        fn write_parquet(table: &TableView, filename: &str, stream: &CudaStreamView) -> Result<()>;
 
         // Direct cuDF operations
 
@@ -427,19 +467,28 @@ pub mod ffi {
         fn apply_boolean_mask(
             table: &TableView,
             boolean_mask: &ColumnView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Gather rows from a table based on a gather map (column of indices)
         ///
         /// Reorders the rows of `source_table` according to the indices in `gather_map`.
         /// The resulting table will have the same number of rows as `gather_map` has elements.
-        fn gather(source_table: &TableView, gather_map: &ColumnView) -> Result<UniquePtr<Table>>;
+        fn gather(
+            source_table: &TableView,
+            gather_map: &ColumnView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Table>>;
 
         /// Gather rows from a table using an explicit out-of-bounds policy.
         fn gather_with_policy(
             source_table: &TableView,
             gather_map: &ColumnView,
             out_of_bounds_policy: i32,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Scatter scalar rows into a copy of a target table.
@@ -447,6 +496,8 @@ pub mod ffi {
             source: &[*const Scalar],
             indices: &ColumnView,
             target: &TableView,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Create a table without duplicate rows.
@@ -456,6 +507,8 @@ pub mod ffi {
             keep: i32,
             nulls_equal: i32,
             nans_equal: i32,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Create a sliced view of a column
@@ -465,6 +518,7 @@ pub mod ffi {
             column: &ColumnView,
             offset: usize,
             length: usize,
+            stream: &CudaStreamView,
         ) -> Result<UniquePtr<ColumnView>>;
 
         // Binary operations - direct cuDF mappings
@@ -478,6 +532,8 @@ pub mod ffi {
             rhs: &ColumnView,
             op: i32,
             output_type: &DataType,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Column>>;
 
         /// Perform a binary operation between a column and a scalar
@@ -489,6 +545,8 @@ pub mod ffi {
             rhs: &Scalar,
             op: i32,
             output_type: &DataType,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Column>>;
 
         /// Perform a binary operation between a scalar and a column
@@ -500,6 +558,8 @@ pub mod ffi {
             rhs: &ColumnView,
             op: i32,
             output_type: &DataType,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Column>>;
 
         // Sorting operations - direct cuDF mappings
@@ -511,6 +571,8 @@ pub mod ffi {
             input: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Stable sort a table in lexicographic order
@@ -520,6 +582,8 @@ pub mod ffi {
             input: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Get the indices that would sort a table
@@ -529,6 +593,8 @@ pub mod ffi {
             input: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Column>>;
 
         /// Get the indices that would stably sort a table
@@ -538,6 +604,8 @@ pub mod ffi {
             input: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Column>>;
 
         /// Check if a table is sorted
@@ -547,6 +615,7 @@ pub mod ffi {
             input: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
         ) -> Result<bool>;
 
         /// Sort values table based on keys table
@@ -558,6 +627,8 @@ pub mod ffi {
             keys: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         /// Stable sort values table based on keys table
@@ -568,6 +639,8 @@ pub mod ffi {
             keys: &TableView,
             column_order: &[i32],
             null_precedence: &[i32],
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Table>>;
 
         // Join operations.
@@ -737,6 +810,8 @@ pub mod ffi {
             col: &ColumnView,
             agg: &ReduceAggregation,
             output_type: &DataType,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Scalar>>;
 
         /// Computes a reduction with an initial scalar value.
@@ -745,6 +820,8 @@ pub mod ffi {
             agg: &ReduceAggregation,
             output_type: &DataType,
             init: &Scalar,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<Scalar>>;
 
         // GroupBy operations - direct cuDF mappings
@@ -796,10 +873,20 @@ pub mod ffi {
         ) -> Result<UniquePtr<Column>>;
 
         /// Cast a column to a different data type using GPU-native cudf::cast
-        fn cast_column(input: &ColumnView, target_type: &DataType) -> Result<UniquePtr<Column>>;
+        fn cast_column(
+            input: &ColumnView,
+            target_type: &DataType,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<Column>>;
 
         /// Extract a scalar from a column at the specified index
-        fn get_element(column: &ColumnView, index: usize) -> UniquePtr<Scalar>;
+        fn get_element(
+            column: &ColumnView,
+            index: usize,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> UniquePtr<Scalar>;
 
         /// Get the version of the cuDF library
         fn get_cudf_version() -> String;
@@ -856,9 +943,6 @@ pub mod ffi {
         /// Return cuDF's process-global pinned memory resource handle.
         fn get_pinned_memory_resource() -> UniquePtr<HostDeviceAsyncResourceRef>;
 
-        /// Block until all work on cuDF's default stream has completed.
-        fn cuda_default_stream_synchronize() -> Result<()>;
-
         /// Opaque owning wrapper around `rmm::mr::cuda_memory_resource`.
         type CudaMemoryResource;
 
@@ -881,6 +965,16 @@ pub mod ffi {
         /// Return total VRAM bytes on the current CUDA device.
         fn total_device_memory() -> usize;
     }
+}
+
+/// Return cuDF's current default stream as an explicit stream-view handle.
+pub fn get_default_stream() -> cxx::UniquePtr<ffi::CudaStreamView> {
+    ffi::get_default_stream()
+}
+
+/// Return cuDF's current device memory resource reference.
+pub fn get_current_device_resource_ref() -> cxx::UniquePtr<ffi::DeviceAsyncResourceRef> {
+    ffi::get_current_device_resource_ref()
 }
 
 /// Sort order for columns
@@ -1525,17 +1619,230 @@ mod tests {
 
     const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
     const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
+
+    type CxxResult<T> = std::result::Result<T, cxx::Exception>;
+
+    fn stream_ref(stream: &cxx::UniquePtr<ffi::CudaStreamView>) -> &ffi::CudaStreamView {
+        stream.as_ref().expect("default stream should not be null")
+    }
+
+    fn resource_ref(
+        resource: &cxx::UniquePtr<ffi::DeviceAsyncResourceRef>,
+    ) -> &ffi::DeviceAsyncResourceRef {
+        resource
+            .as_ref()
+            .expect("current device resource should not be null")
+    }
+
+    fn read_parquet(filename: &str) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::read_parquet(filename, stream_ref(&stream), resource_ref(&resource))
+    }
+
+    fn sort_table(
+        input: &ffi::TableView,
+        column_order: &[i32],
+        null_precedence: &[i32],
+    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::sort_table(
+            input,
+            column_order,
+            null_precedence,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn stable_sort_table(
+        input: &ffi::TableView,
+        column_order: &[i32],
+        null_precedence: &[i32],
+    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::stable_sort_table(
+            input,
+            column_order,
+            null_precedence,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn sorted_order(
+        input: &ffi::TableView,
+        column_order: &[i32],
+        null_precedence: &[i32],
+    ) -> CxxResult<cxx::UniquePtr<ffi::Column>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::sorted_order(
+            input,
+            column_order,
+            null_precedence,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn is_sorted(
+        input: &ffi::TableView,
+        column_order: &[i32],
+        null_precedence: &[i32],
+    ) -> CxxResult<bool> {
+        let stream = ffi::get_default_stream();
+        ffi::is_sorted(input, column_order, null_precedence, stream_ref(&stream))
+    }
+
+    fn sort_by_key(
+        values: &ffi::TableView,
+        keys: &ffi::TableView,
+        column_order: &[i32],
+        null_precedence: &[i32],
+    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::sort_by_key(
+            values,
+            keys,
+            column_order,
+            null_precedence,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn stable_sort_by_key(
+        values: &ffi::TableView,
+        keys: &ffi::TableView,
+        column_order: &[i32],
+        null_precedence: &[i32],
+    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::stable_sort_by_key(
+            values,
+            keys,
+            column_order,
+            null_precedence,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn binary_operation_col_col(
+        lhs: &ffi::ColumnView,
+        rhs: &ffi::ColumnView,
+        op: i32,
+        output_type: &ffi::DataType,
+    ) -> CxxResult<cxx::UniquePtr<ffi::Column>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::binary_operation_col_col(
+            lhs,
+            rhs,
+            op,
+            output_type,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn reduce(
+        col: &ffi::ColumnView,
+        agg: &ffi::ReduceAggregation,
+        output_type: &ffi::DataType,
+    ) -> CxxResult<cxx::UniquePtr<ffi::Scalar>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::reduce(
+            col,
+            agg,
+            output_type,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn reduce_with_init(
+        col: &ffi::ColumnView,
+        agg: &ffi::ReduceAggregation,
+        output_type: &ffi::DataType,
+        init: &ffi::Scalar,
+    ) -> CxxResult<cxx::UniquePtr<ffi::Scalar>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::reduce_with_init(
+            col,
+            agg,
+            output_type,
+            init,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn get_element(column: &ffi::ColumnView, index: usize) -> cxx::UniquePtr<ffi::Scalar> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::get_element(column, index, stream_ref(&stream), resource_ref(&resource))
+    }
+
+    fn make_column_from_scalar(
+        scalar: &ffi::Scalar,
+        size: usize,
+    ) -> CxxResult<cxx::UniquePtr<ffi::Column>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::make_column_from_scalar(scalar, size, stream_ref(&stream), resource_ref(&resource))
+    }
+
+    fn apply_boolean_mask(
+        table: &ffi::TableView,
+        boolean_mask: &ffi::ColumnView,
+    ) -> CxxResult<cxx::UniquePtr<ffi::Table>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        ffi::apply_boolean_mask(
+            table,
+            boolean_mask,
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )
+    }
+
+    fn aggregate(
+        groupby: &ffi::GroupBy,
+        requests: &ffi::AggregationRequests,
+    ) -> CxxResult<cxx::UniquePtr<ffi::GroupByResult>> {
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
+        groupby.aggregate(requests, stream_ref(&stream), resource_ref(&resource))
+    }
+
+    fn slice_column(
+        column: &ffi::ColumnView,
+        offset: usize,
+        length: usize,
+    ) -> CxxResult<cxx::UniquePtr<ffi::ColumnView>> {
+        let stream = ffi::get_default_stream();
+        ffi::slice_column(column, offset, length, stream_ref(&stream))
+    }
+
     // Sorting tests
     #[test]
     fn test_sort_table_ascending() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let sorted_table = ffi::sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = sort_table(&table_view, &column_order, &null_precedence)?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1546,14 +1853,14 @@ mod tests {
 
     #[test]
     fn test_sort_table_descending() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Descending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::After as i32; num_cols];
 
-        let sorted_table = ffi::sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = sort_table(&table_view, &column_order, &null_precedence)?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1564,14 +1871,14 @@ mod tests {
 
     #[test]
     fn test_stable_sort_table() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let sorted_table = ffi::stable_sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = stable_sort_table(&table_view, &column_order, &null_precedence)?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1582,14 +1889,14 @@ mod tests {
 
     #[test]
     fn test_sorted_order() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let indices = ffi::sorted_order(&table_view, &column_order, &null_precedence)?;
+        let indices = sorted_order(&table_view, &column_order, &null_precedence)?;
 
         assert_eq!(indices.size(), table.num_rows());
         assert_snapshot!(pretty_column(&indices.view(), DataType::Int32)?);
@@ -1599,17 +1906,17 @@ mod tests {
 
     #[test]
     fn test_is_sorted() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let num_cols = table.num_columns();
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
-        let sorted_table = ffi::sort_table(&table_view, &column_order, &null_precedence)?;
+        let sorted_table = sort_table(&table_view, &column_order, &null_precedence)?;
         let sorted_view = sorted_table.view();
 
-        let is_sorted = ffi::is_sorted(&sorted_view, &column_order, &null_precedence)?;
+        let is_sorted = is_sorted(&sorted_view, &column_order, &null_precedence)?;
         assert!(is_sorted, "Table should be sorted after calling sort_table");
 
         Ok(())
@@ -1617,7 +1924,7 @@ mod tests {
 
     #[test]
     fn test_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0]);
@@ -1625,8 +1932,7 @@ mod tests {
         let column_order = vec![Order::Ascending as i32];
         let null_precedence = vec![NullOrder::Before as i32];
 
-        let sorted_table =
-            ffi::sort_by_key(&table_view, &keys_view, &column_order, &null_precedence)?;
+        let sorted_table = sort_by_key(&table_view, &keys_view, &column_order, &null_precedence)?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1637,7 +1943,7 @@ mod tests {
 
     #[test]
     fn test_stable_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0, 1]);
@@ -1646,7 +1952,7 @@ mod tests {
         let null_precedence = vec![NullOrder::Before as i32, NullOrder::After as i32];
 
         let sorted_table =
-            ffi::stable_sort_by_key(&table_view, &keys_view, &column_order, &null_precedence)?;
+            stable_sort_by_key(&table_view, &keys_view, &column_order, &null_precedence)?;
 
         assert_eq!(sorted_table.num_rows(), table.num_rows());
         assert_eq!(sorted_table.num_columns(), table.num_columns());
@@ -1658,7 +1964,7 @@ mod tests {
     // Binary operation tests
     #[test]
     fn test_binary_op_col_col_add() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let col1 = table_view.column(1);
@@ -1666,7 +1972,7 @@ mod tests {
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
         let result =
-            ffi::binary_operation_col_col(&col1, &col2, BinaryOperator::Add as i32, &output_type)?;
+            binary_operation_col_col(&col1, &col2, BinaryOperator::Add as i32, &output_type)?;
 
         assert_eq!(result.size(), col1.size());
         assert_eq!(result.size(), col2.size());
@@ -1677,7 +1983,7 @@ mod tests {
 
     #[test]
     fn test_binary_op_col_col_multiply() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let col1 = table_view.column(1);
@@ -1685,7 +1991,7 @@ mod tests {
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
         let result =
-            ffi::binary_operation_col_col(&col1, &col2, BinaryOperator::Mul as i32, &output_type)?;
+            binary_operation_col_col(&col1, &col2, BinaryOperator::Mul as i32, &output_type)?;
 
         assert_eq!(result.size(), col1.size());
         assert_snapshot!(pretty_column(&result.view(), DataType::Float64)?);
@@ -1756,7 +2062,7 @@ mod tests {
         let column = table.view().column(0);
         let output_type = ffi::new_data_type_with_scale(TypeId::Decimal128 as i32, -2);
 
-        let result = ffi::reduce(&column, &ffi::make_sum_aggregation(), &output_type)?;
+        let result = reduce(&column, &ffi::make_sum_aggregation(), &output_type)?;
         let result_type = result.data_type();
 
         assert!(result.is_valid());
@@ -1771,12 +2077,11 @@ mod tests {
         let table = table_from_i32_columns(&[("values", vec![1, 2, 3])])?;
         let values = table.view().column(0);
         let init_table = table_from_i32_columns(&[("init", vec![10])])?;
-        let init = ffi::get_element(&init_table.view().column(0), 0);
+        let init = get_element(&init_table.view().column(0), 0);
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
 
-        let result =
-            ffi::reduce_with_init(&values, &ffi::make_sum_aggregation(), &output_type, &init)?;
-        let result_column = ffi::make_column_from_scalar(&result, 1)?;
+        let result = reduce_with_init(&values, &ffi::make_sum_aggregation(), &output_type, &init)?;
+        let result_column = make_column_from_scalar(&result, 1)?;
 
         assert_snapshot!(pretty_column(&result_column.view(), DataType::Int32)?, @r"
         +------+
@@ -1795,19 +2100,19 @@ mod tests {
         let values = table.view().column(0);
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
 
-        let exclude = ffi::reduce(
+        let exclude = reduce(
             &values,
             &ffi::make_count_aggregation(NullPolicy::Exclude as i32),
             &output_type,
         )?;
-        let include = ffi::reduce(
+        let include = reduce(
             &values,
             &ffi::make_count_aggregation(NullPolicy::Include as i32),
             &output_type,
         )?;
 
-        let exclude_column = ffi::make_column_from_scalar(&exclude, 1)?;
-        let include_column = ffi::make_column_from_scalar(&include, 1)?;
+        let exclude_column = make_column_from_scalar(&exclude, 1)?;
+        let include_column = make_column_from_scalar(&include, 1)?;
 
         assert_snapshot!(pretty_column(&exclude_column.view(), DataType::Int32)?, @r"
         +------+
@@ -1916,21 +2221,21 @@ mod tests {
     // Filter tests
     #[test]
     fn test_apply_boolean_mask() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let min_temp = table_view.column(1);
         let max_temp = table_view.column(2);
 
         let output_type = ffi::new_data_type(TypeId::Bool8 as i32);
-        let boolean_mask = ffi::binary_operation_col_col(
+        let boolean_mask = binary_operation_col_col(
             &min_temp,
             &max_temp,
             BinaryOperator::Less as i32,
             &output_type,
         )?;
 
-        let filtered_table = ffi::apply_boolean_mask(&table_view, &boolean_mask.view())?;
+        let filtered_table = apply_boolean_mask(&table_view, &boolean_mask.view())?;
 
         assert!(filtered_table.num_rows() < table.num_rows());
         assert_eq!(filtered_table.num_columns(), table.num_columns());
@@ -1945,7 +2250,7 @@ mod tests {
     // GroupBy tests
     #[test]
     fn test_groupby_sum() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
 
         let column_order: &[i32] = &[];
@@ -1964,7 +2269,7 @@ mod tests {
 
         let mut agg_requests = ffi::aggregation_requests_create();
         agg_requests.pin_mut().add(request);
-        let mut groupby_result = groupby.aggregate(&agg_requests)?;
+        let mut groupby_result = aggregate(&groupby, &agg_requests)?;
 
         let mut aggregation_result = groupby_result.pin_mut().release_result(0);
         let keys = groupby_result.pin_mut().release_keys();
@@ -1980,7 +2285,7 @@ mod tests {
 
     #[test]
     fn test_groupby_multiple_aggregations() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000001.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000001.parquet")?;
         let table_view = table.view();
 
         let keys_view = table_view.select(&[0]);
@@ -2008,7 +2313,7 @@ mod tests {
 
         let mut requests = ffi::aggregation_requests_create();
         requests.pin_mut().add(agg_request);
-        let mut groupby_result = groupby.aggregate(&requests)?;
+        let mut groupby_result = aggregate(&groupby, &requests)?;
 
         assert_eq!(groupby_result.len(), 1);
         let mut agg_result = groupby_result.pin_mut().release_result(0);
@@ -2031,14 +2336,14 @@ mod tests {
     // Slice tests
     #[test]
     fn test_slice_column_basic() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
         let original_col = table_view.column(1);
 
         let original_size = original_col.size();
         assert!(original_size > 10, "Need at least 10 rows for testing");
 
-        let sliced_col = ffi::slice_column(&original_col, 5, 5)?;
+        let sliced_col = slice_column(&original_col, 5, 5)?;
 
         assert_eq!(sliced_col.size(), 5);
 
@@ -2063,11 +2368,11 @@ mod tests {
 
     #[test]
     fn test_slice_column_from_start() -> Result<(), Box<dyn std::error::Error>> {
-        let table = ffi::read_parquet("../testdata/weather/result-000000.parquet")?;
+        let table = read_parquet("../testdata/weather/result-000000.parquet")?;
         let table_view = table.view();
         let original_col = table_view.column(2);
 
-        let sliced_col = ffi::slice_column(&original_col, 0, 10)?;
+        let sliced_col = slice_column(&original_col, 0, 10)?;
 
         assert_eq!(sliced_col.size(), 10);
         assert_snapshot!(pretty_column(&sliced_col, DataType::Float64)?, @r"
@@ -2128,32 +2433,17 @@ mod tests {
     }
 
     #[test]
-    fn test_device_async_resource_ref_bindings() -> Result<(), Box<dyn std::error::Error>> {
-        let current = ffi::get_current_device_resource_ref();
-        let previous = ffi::set_current_device_resource_ref(
-            current
-                .as_ref()
-                .expect("DeviceAsyncResourceRef should not be null"),
-        );
-        let after = ffi::get_current_device_resource_ref();
+    fn test_current_device_resource_ref_reads_parquet() -> Result<(), Box<dyn std::error::Error>> {
+        let stream = ffi::get_default_stream();
+        let resource = get_current_device_resource_ref();
+        let table = ffi::read_parquet(
+            "../testdata/weather/result-000000.parquet",
+            stream_ref(&stream),
+            resource_ref(&resource),
+        )?;
 
-        assert!(ffi::device_async_resource_ref_equal(
-            current
-                .as_ref()
-                .expect("DeviceAsyncResourceRef should not be null"),
-            previous
-                .as_ref()
-                .expect("DeviceAsyncResourceRef should not be null"),
-        ));
-        assert!(ffi::device_async_resource_ref_equal(
-            current
-                .as_ref()
-                .expect("DeviceAsyncResourceRef should not be null"),
-            after
-                .as_ref()
-                .expect("DeviceAsyncResourceRef should not be null"),
-        ));
-
+        assert!(table.num_rows() > 0);
+        assert!(table.num_columns() > 0);
         Ok(())
     }
 
@@ -2266,9 +2556,15 @@ mod tests {
     fn pretty_table(table_view: &ffi::TableView) -> Result<impl Display + use<>, ArrowError> {
         let mut array = FFI_ArrowArray::empty();
         let mut schema = FFI_ArrowSchema::empty();
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
 
         let data = unsafe {
-            table_view.to_arrow_array(&mut array as *mut FFI_ArrowArray as *mut u8);
+            table_view.to_arrow_array(
+                &mut array as *mut FFI_ArrowArray as *mut u8,
+                stream_ref(&stream),
+                resource_ref(&resource),
+            );
             table_view.to_arrow_schema(&mut schema as *mut FFI_ArrowSchema as *mut u8);
 
             from_ffi(array, &schema).expect("ffi data should be valid")
@@ -2284,9 +2580,15 @@ mod tests {
         data_type: DataType,
     ) -> Result<impl Display + use<>, ArrowError> {
         let mut array = FFI_ArrowArray::empty();
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
 
         let data = unsafe {
-            column_view.to_arrow_array(&mut array as *mut FFI_ArrowArray as *mut u8);
+            column_view.to_arrow_array(
+                &mut array as *mut FFI_ArrowArray as *mut u8,
+                stream_ref(&stream),
+                resource_ref(&resource),
+            );
 
             from_ffi_and_data_type(array, data_type).expect("ffi data should be valid")
         };

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -1632,13 +1632,28 @@ mod tests {
             .expect("current device resource should not be null")
     }
 
+    fn expect_stream_and_resource<'a>(
+        stream: &'a cxx::UniquePtr<ffi::CudaStreamView>,
+        resource: &'a cxx::UniquePtr<ffi::DeviceAsyncResourceRef>,
+    ) -> (&'a ffi::CudaStreamView, &'a ffi::DeviceAsyncResourceRef) {
+        (expect_stream(stream), expect_resource(resource))
+    }
+
+    fn default_stream_and_resource() -> (
+        cxx::UniquePtr<ffi::CudaStreamView>,
+        cxx::UniquePtr<ffi::DeviceAsyncResourceRef>,
+    ) {
+        (
+            ffi::get_default_stream(),
+            ffi::get_current_device_resource_ref(),
+        )
+    }
+
     // Sorting tests
     #[test]
     fn test_sort_table_ascending() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1667,10 +1682,8 @@ mod tests {
 
     #[test]
     fn test_sort_table_descending() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1699,10 +1712,8 @@ mod tests {
 
     #[test]
     fn test_stable_sort_table() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1731,10 +1742,8 @@ mod tests {
 
     #[test]
     fn test_sorted_order() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1762,10 +1771,8 @@ mod tests {
 
     #[test]
     fn test_is_sorted() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1794,10 +1801,8 @@ mod tests {
 
     #[test]
     fn test_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1828,10 +1833,8 @@ mod tests {
 
     #[test]
     fn test_stable_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1863,10 +1866,8 @@ mod tests {
     // Binary operation tests
     #[test]
     fn test_binary_op_col_col_add() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1896,10 +1897,8 @@ mod tests {
 
     #[test]
     fn test_binary_op_col_col_multiply() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -1990,13 +1989,14 @@ mod tests {
         let output_type = ffi::new_data_type_with_scale(TypeId::Decimal128 as i32, -2);
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
         let result = ffi::reduce(
             &column,
             &ffi::make_sum_aggregation(),
             &output_type,
-            expect_stream(&stream),
-            expect_resource(&resource),
+            stream_view,
+            resource_ref,
         )?;
         let result_type = result.data_type();
 
@@ -2012,10 +2012,8 @@ mod tests {
         let table = table_from_i32_columns(&[("values", vec![1, 2, 3])])?;
         let values = table.view().column(0);
         let init_table = table_from_i32_columns(&[("init", vec![10])])?;
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let init = ffi::get_element(&init_table.view().column(0), 0, stream_view, resource_ref);
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
 
@@ -2045,10 +2043,8 @@ mod tests {
         let table = table_from_nullable_i32_column("values", vec![Some(1), None, Some(3), None])?;
         let values = table.view().column(0);
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
         let exclude = ffi::reduce(
             &values,
@@ -2112,12 +2108,13 @@ mod tests {
         let right_keys = right_view.select(&[0]);
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let mut indices = ffi::inner_join_indices(
             &left_keys,
             &right_keys,
             NullEquality::Equal as i32,
-            expect_stream(&stream),
-            expect_resource(&resource),
+            stream_view,
+            resource_ref,
         )?;
         let left_indices = indices.pin_mut().release_left();
         let right_indices = indices.pin_mut().release_right();
@@ -2154,8 +2151,8 @@ mod tests {
                 .expect("right index vector should not be null"),
             &predicate,
             JoinKind::Inner as i32,
-            expect_stream(&stream),
-            expect_resource(&resource),
+            stream_view,
+            resource_ref,
         )?;
         let filtered_left = filtered.pin_mut().release_left();
         let filtered_right = filtered.pin_mut().release_right();
@@ -2171,10 +2168,8 @@ mod tests {
     // Filter tests
     #[test]
     fn test_apply_boolean_mask() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -2211,10 +2206,8 @@ mod tests {
     // GroupBy tests
     #[test]
     fn test_groupby_sum() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -2254,10 +2247,8 @@ mod tests {
 
     #[test]
     fn test_groupby_multiple_aggregations() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000001.parquet",
             stream_view,
@@ -2313,10 +2304,8 @@ mod tests {
     // Slice tests
     #[test]
     fn test_slice_column_basic() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -2353,10 +2342,8 @@ mod tests {
 
     #[test]
     fn test_slice_column_from_start() -> Result<(), Box<dyn std::error::Error>> {
-        let stream = ffi::get_default_stream();
-        let resource = ffi::get_current_device_resource_ref();
-        let stream_view = expect_stream(&stream);
-        let resource_ref = expect_resource(&resource);
+        let (stream, resource) = default_stream_and_resource();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
             stream_view,
@@ -2429,10 +2416,11 @@ mod tests {
     fn test_current_device_resource_ref_reads_parquet() -> Result<(), Box<dyn std::error::Error>> {
         let stream = ffi::get_default_stream();
         let resource = get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
         let table = ffi::read_parquet(
             "../testdata/weather/result-000000.parquet",
-            expect_stream(&stream),
-            expect_resource(&resource),
+            stream_view,
+            resource_ref,
         )?;
 
         assert!(table.num_rows() > 0);
@@ -2480,13 +2468,9 @@ mod tests {
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &mr);
         Ok(unsafe {
-            ffi::table_from_arrow_host(
-                schema_ptr,
-                device_array_ptr,
-                expect_stream(&stream),
-                expect_resource(&mr),
-            )
+            ffi::table_from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
         }?)
     }
 
@@ -2507,13 +2491,9 @@ mod tests {
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &mr);
         Ok(unsafe {
-            ffi::table_from_arrow_host(
-                schema_ptr,
-                device_array_ptr,
-                expect_stream(&stream),
-                expect_resource(&mr),
-            )
+            ffi::table_from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
         }?)
     }
 
@@ -2536,13 +2516,9 @@ mod tests {
         let device_array_ptr = &device_array as *const ArrowDeviceArray as *const u8;
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &mr);
         Ok(unsafe {
-            ffi::table_from_arrow_host(
-                schema_ptr,
-                device_array_ptr,
-                expect_stream(&stream),
-                expect_resource(&mr),
-            )
+            ffi::table_from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
         }?)
     }
 
@@ -2551,12 +2527,13 @@ mod tests {
         let mut schema = FFI_ArrowSchema::empty();
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
         let data = unsafe {
             table_view.to_arrow_array(
                 &mut array as *mut FFI_ArrowArray as *mut u8,
-                expect_stream(&stream),
-                expect_resource(&resource),
+                stream_view,
+                resource_ref,
             );
             table_view.to_arrow_schema(&mut schema as *mut FFI_ArrowSchema as *mut u8);
 
@@ -2575,12 +2552,13 @@ mod tests {
         let mut array = FFI_ArrowArray::empty();
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
+        let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
         let data = unsafe {
             column_view.to_arrow_array(
                 &mut array as *mut FFI_ArrowArray as *mut u8,
-                expect_stream(&stream),
-                expect_resource(&resource),
+                stream_view,
+                resource_ref,
             );
 
             from_ffi_and_data_type(array, data_type).expect("ffi data should be valid")

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -10,7 +10,6 @@
 #include <cudf/interop.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/stream_compaction.hpp>
-#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/version_config.hpp>
 
@@ -18,7 +17,9 @@
 
 #include <functional>
 #include <limits>
+#include <memory>
 #include <sstream>
+#include <unordered_map>
 
 namespace libcudf_bridge {
     // Factory functions
@@ -43,35 +44,41 @@ namespace libcudf_bridge {
         return table;
     }
 
-    std::unique_ptr<Table> concat_table_views(rust::Slice<const std::unique_ptr<TableView>> views) {
+    std::unique_ptr<Table> concat_table_views(
+        rust::Slice<const std::unique_ptr<TableView>> views,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::table_view> table_views;
         table_views.reserve(views.size());
-
-        // Take ownership of tables by moving out of each unique pointer
         for (auto &col: views) {
             table_views.push_back(std::move(*col->inner));
         }
 
         auto table = std::make_unique<Table>();
-        table->inner = cudf::concatenate(table_views);
+        table->inner = cudf::concatenate(table_views, stream.inner, mr.inner);
         return table;
     }
 
-    std::unique_ptr<Column> concat_column_views(rust::Slice<const std::unique_ptr<ColumnView>> views) {
+    std::unique_ptr<Column> concat_column_views(
+        rust::Slice<const std::unique_ptr<ColumnView>> views,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::column_view> table_views;
         table_views.reserve(views.size());
-
-        // Take ownership of columns by moving out of each unique pointer
         for (auto &col: views) {
             table_views.push_back(std::move(*col->inner));
         }
 
         auto table = std::make_unique<Column>();
-        table->inner = cudf::concatenate(table_views);
+        table->inner = cudf::concatenate(table_views, stream.inner, mr.inner);
         return table;
     }
 
-    std::unique_ptr<Column> make_column_from_scalar(const Scalar &scalar, size_t size) {
+    std::unique_ptr<Column> make_column_from_scalar(
+        const Scalar &scalar,
+        size_t size,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         if (size > static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
             throw std::out_of_range("column size exceeds cudf::size_type");
         }
@@ -79,47 +86,68 @@ namespace libcudf_bridge {
         auto result = std::make_unique<Column>();
         result->inner = cudf::make_column_from_scalar(
             *scalar.inner,
-            static_cast<cudf::size_type>(size));
+            static_cast<cudf::size_type>(size),
+            stream.inner,
+            mr.inner);
         return result;
     }
 
-    std::unique_ptr<Column> sequence(size_t size, const Scalar &init, const Scalar &step) {
+    std::unique_ptr<Column> sequence(
+        size_t size,
+        const Scalar &init,
+        const Scalar &step,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         if (size > static_cast<size_t>(std::numeric_limits<cudf::size_type>::max())) {
             throw std::out_of_range("sequence size exceeds cudf::size_type");
         }
 
-        auto stream = cudf::get_default_stream();
         auto result = std::make_unique<Column>();
         result->inner = cudf::sequence(
             static_cast<cudf::size_type>(size),
             *init.inner,
             *step.inner,
-            stream);
+            stream.inner,
+            mr.inner);
         return result;
     }
 
-    // Direct cuDF operations exposed through bridge-owned return types.
-    std::unique_ptr<Table> apply_boolean_mask(const TableView &table, const ColumnView &boolean_mask) {
+    // Direct cuDF operations - 1:1 mappings
+    std::unique_ptr<Table> apply_boolean_mask(
+        const TableView &table,
+        const ColumnView &boolean_mask,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         auto result = std::make_unique<Table>();
-        result->inner = cudf::apply_boolean_mask(*table.inner, *boolean_mask.inner);
+        result->inner = cudf::apply_boolean_mask(*table.inner, *boolean_mask.inner, stream.inner, mr.inner);
         return result;
     }
 
     // Gather rows from a table based on a gather map
-    std::unique_ptr<Table> gather(const TableView &source_table, const ColumnView &gather_map) {
+    std::unique_ptr<Table> gather(
+        const TableView &source_table,
+        const ColumnView &gather_map,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         return gather_with_policy(source_table, gather_map,
-                                  static_cast<int32_t>(cudf::out_of_bounds_policy::DONT_CHECK));
+                                  static_cast<int32_t>(cudf::out_of_bounds_policy::DONT_CHECK),
+                                  stream,
+                                  mr);
     }
 
     std::unique_ptr<Table> gather_with_policy(
         const TableView &source_table,
         const ColumnView &gather_map,
-        int32_t out_of_bounds_policy) {
+        int32_t out_of_bounds_policy,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         auto result = std::make_unique<Table>();
         result->inner = cudf::gather(
             *source_table.inner,
             *gather_map.inner,
-            static_cast<cudf::out_of_bounds_policy>(out_of_bounds_policy)
+            static_cast<cudf::out_of_bounds_policy>(out_of_bounds_policy),
+            stream.inner,
+            mr.inner
         );
         return result;
     }
@@ -127,7 +155,9 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> scatter_scalars(
         rust::Slice<const Scalar *const> source,
         const ColumnView &indices,
-        const TableView &target) {
+        const TableView &target,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<std::reference_wrapper<cudf::scalar const>> scalars;
         scalars.reserve(source.size());
         for (auto *scalar: source) {
@@ -135,7 +165,7 @@ namespace libcudf_bridge {
         }
 
         auto result = std::make_unique<Table>();
-        result->inner = cudf::scatter(scalars, *indices.inner, *target.inner);
+        result->inner = cudf::scatter(scalars, *indices.inner, *target.inner, stream.inner, mr.inner);
         return result;
     }
 
@@ -144,7 +174,9 @@ namespace libcudf_bridge {
         rust::Slice<const int32_t> keys,
         int32_t keep,
         int32_t nulls_equal,
-        int32_t nans_equal) {
+        int32_t nans_equal,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::size_type> key_indices;
         key_indices.reserve(keys.size());
         for (auto key: keys) {
@@ -157,12 +189,18 @@ namespace libcudf_bridge {
             key_indices,
             static_cast<cudf::duplicate_keep_option>(keep),
             static_cast<cudf::null_equality>(nulls_equal),
-            static_cast<cudf::nan_equality>(nans_equal));
+            static_cast<cudf::nan_equality>(nans_equal),
+            stream.inner,
+            mr.inner);
         return result;
     }
 
     // Create a sliced view of a column
-    std::unique_ptr<ColumnView> slice_column(const ColumnView &column, size_t offset, size_t length) {
+    std::unique_ptr<ColumnView> slice_column(
+        const ColumnView &column,
+        size_t offset,
+        size_t length,
+        const CudaStreamView &stream) {
         if (!column.inner) {
             throw std::runtime_error("Cannot slice null column view");
         }
@@ -176,7 +214,7 @@ namespace libcudf_bridge {
         auto end = static_cast<cudf::size_type>(offset + length);
         std::vector indices = {start, end};
 
-        auto sliced_views = cudf::slice(*column.inner, indices);
+        auto sliced_views = cudf::slice(*column.inner, indices, stream.inner);
 
         // We expect exactly one view back since we provided one [start, end) pair
         if (sliced_views.empty()) {

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -16,7 +16,11 @@ struct ArrowArray;
 
 namespace libcudf_bridge {
     // Direct cuDF operations exposed through bridge-owned return types.
-    std::unique_ptr<Table> apply_boolean_mask(const TableView &table, const ColumnView &boolean_mask);
+    std::unique_ptr<Table> apply_boolean_mask(
+        const TableView &table,
+        const ColumnView &boolean_mask,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     // Arrow interop - direct cuDF calls
     std::unique_ptr<Table> table_from_arrow_host(
@@ -31,36 +35,65 @@ namespace libcudf_bridge {
         const CudaStreamView &stream,
         const DeviceAsyncResourceRef &mr);
 
-    std::unique_ptr<Table> concat_table_views(rust::Slice<const std::unique_ptr<TableView>> views);
+    std::unique_ptr<Table> concat_table_views(
+        rust::Slice<const std::unique_ptr<TableView>> views,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
-    std::unique_ptr<Column> concat_column_views(rust::Slice<const std::unique_ptr<ColumnView>> views);
+    std::unique_ptr<Column> concat_column_views(
+        rust::Slice<const std::unique_ptr<ColumnView>> views,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
-    std::unique_ptr<Column> make_column_from_scalar(const Scalar &scalar, size_t size);
+    std::unique_ptr<Column> make_column_from_scalar(
+        const Scalar &scalar,
+        size_t size,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
-    std::unique_ptr<Column> sequence(size_t size, const Scalar &init, const Scalar &step);
+    std::unique_ptr<Column> sequence(
+        size_t size,
+        const Scalar &init,
+        const Scalar &step,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     // Gather rows from a table based on a gather map (column of indices)
-    std::unique_ptr<Table> gather(const TableView &source_table, const ColumnView &gather_map);
+    std::unique_ptr<Table> gather(
+        const TableView &source_table,
+        const ColumnView &gather_map,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Table> gather_with_policy(
         const TableView &source_table,
         const ColumnView &gather_map,
-        int32_t out_of_bounds_policy);
+        int32_t out_of_bounds_policy,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Table> scatter_scalars(
         rust::Slice<const Scalar *const> source,
         const ColumnView &indices,
-        const TableView &target);
+        const TableView &target,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Table> distinct(
         const TableView &input,
         rust::Slice<const int32_t> keys,
         int32_t keep,
         int32_t nulls_equal,
-        int32_t nans_equal);
+        int32_t nans_equal,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     // Create a sliced view of a column
-    std::unique_ptr<ColumnView> slice_column(const ColumnView &column, size_t offset, size_t length);
+    std::unique_ptr<ColumnView> slice_column(
+        const ColumnView &column,
+        size_t offset,
+        size_t length,
+        const CudaStreamView &stream);
 
     // Utility functions
     rust::String get_cudf_version();

--- a/libcudf-sys/src/pinned_host.cpp
+++ b/libcudf-sys/src/pinned_host.cpp
@@ -1,7 +1,5 @@
 #include "pinned_host.h"
 
-#include <cudf/utilities/default_stream.hpp>
-
 #include <utility>
 
 namespace libcudf_bridge {
@@ -20,7 +18,4 @@ namespace libcudf_bridge {
         return std::make_unique<HostDeviceAsyncResourceRef>(cudf::get_pinned_memory_resource());
     }
 
-    void cuda_default_stream_synchronize() {
-        cudf::get_default_stream().synchronize();
-    }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/pinned_host.h
+++ b/libcudf-sys/src/pinned_host.h
@@ -37,6 +37,4 @@ namespace libcudf_bridge {
     /// Return cuDF's process-global pinned memory resource handle.
     std::unique_ptr<HostDeviceAsyncResourceRef> get_pinned_memory_resource();
 
-    /// Block until all work on cuDF's default stream has completed.
-    void cuda_default_stream_synchronize();
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/scalar.cpp
+++ b/libcudf-sys/src/scalar.cpp
@@ -18,12 +18,16 @@ namespace libcudf_bridge {
     Scalar::~Scalar() = default;
 
     // Get the scalar's data as an FFI Arrow Array
-    void Scalar::to_arrow_array(uint8_t *out_array_ptr) const {
+    void Scalar::to_arrow_array(
+        uint8_t *out_array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) const {
         if (!inner) {
             throw std::runtime_error("Cannot convert null column view to arrow array");
         }
-        std::unique_ptr<cudf::column> single_element_col = cudf::make_column_from_scalar(*inner, 1);
-        auto device_array_unique = cudf::to_arrow_host(single_element_col->view());
+        std::unique_ptr<cudf::column> single_element_col =
+            cudf::make_column_from_scalar(*inner, 1, stream.inner, mr.inner);
+        auto device_array_unique = cudf::to_arrow_host(single_element_col->view(), stream.inner, mr.inner);
         auto *out_array = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
         *out_array = *device_array_unique.get();
         device_array_unique.release();

--- a/libcudf-sys/src/scalar.h
+++ b/libcudf-sys/src/scalar.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 
 #include "rust/cxx.h"
+#include "stream.h"
+#include "memory_resource.h"
 
 // Forward declarations
 namespace cudf {
@@ -22,7 +24,10 @@ namespace libcudf_bridge {
         ~Scalar();
 
         // Get the scalar's data as an FFI Arrow Array
-        void to_arrow_array(uint8_t *out_array_ptr) const;
+        void to_arrow_array(
+            uint8_t *out_array_ptr,
+            const CudaStreamView &stream,
+            const DeviceAsyncResourceRef &mr) const;
 
         // Check if the scalar is valid (not null)
         [[nodiscard]] bool is_valid() const;

--- a/libcudf-sys/src/sorting.cpp
+++ b/libcudf-sys/src/sorting.cpp
@@ -12,7 +12,9 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> sort_table(
         const TableView &input,
         const rust::Slice<const int32_t> column_order,
-        const rust::Slice<const int32_t> null_precedence) {
+        const rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -23,7 +25,7 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        auto result_table = cudf::sort(*input.inner, orders, null_orders);
+        auto result_table = cudf::sort(*input.inner, orders, null_orders, stream.inner, mr.inner);
 
         auto wrapped = std::make_unique<Table>();
         wrapped->inner = std::move(result_table);
@@ -34,7 +36,9 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> stable_sort_table(
         const TableView &input,
         const rust::Slice<const int32_t> column_order,
-        const rust::Slice<const int32_t> null_precedence) {
+        const rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -45,7 +49,7 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        auto result_table = cudf::stable_sort(*input.inner, orders, null_orders);
+        auto result_table = cudf::stable_sort(*input.inner, orders, null_orders, stream.inner, mr.inner);
 
         auto wrapped = std::make_unique<Table>();
         wrapped->inner = std::move(result_table);
@@ -56,7 +60,9 @@ namespace libcudf_bridge {
     std::unique_ptr<Column> sorted_order(
         const TableView &input,
         const rust::Slice<const int32_t> column_order,
-        const rust::Slice<const int32_t> null_precedence) {
+        const rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -67,7 +73,7 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        auto result_col = cudf::sorted_order(*input.inner, orders, null_orders);
+        auto result_col = cudf::sorted_order(*input.inner, orders, null_orders, stream.inner, mr.inner);
 
         return std::make_unique<Column>(column_from_unique_ptr(std::move(result_col)));
     }
@@ -76,7 +82,9 @@ namespace libcudf_bridge {
     std::unique_ptr<Column> stable_sorted_order(
         const TableView &input,
         const rust::Slice<const int32_t> column_order,
-        const rust::Slice<const int32_t> null_precedence) {
+        const rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -87,7 +95,7 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        auto result_col = cudf::stable_sorted_order(*input.inner, orders, null_orders);
+        auto result_col = cudf::stable_sorted_order(*input.inner, orders, null_orders, stream.inner, mr.inner);
 
         return std::make_unique<Column>(column_from_unique_ptr(std::move(result_col)));
     }
@@ -96,7 +104,8 @@ namespace libcudf_bridge {
     bool is_sorted(
         const TableView &input,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence) {
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -107,7 +116,7 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        return cudf::is_sorted(*input.inner, orders, null_orders);
+        return cudf::is_sorted(*input.inner, orders, null_orders, stream.inner);
     }
 
     // Sort values table by keys table
@@ -115,7 +124,9 @@ namespace libcudf_bridge {
         const TableView &values,
         const TableView &keys,
         const rust::Slice<const int32_t> column_order,
-        const rust::Slice<const int32_t> null_precedence) {
+        const rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -126,7 +137,7 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        auto result_table = cudf::sort_by_key(*values.inner, *keys.inner, orders, null_orders);
+        auto result_table = cudf::sort_by_key(*values.inner, *keys.inner, orders, null_orders, stream.inner, mr.inner);
 
         auto wrapped = std::make_unique<Table>();
         wrapped->inner = std::move(result_table);
@@ -138,7 +149,9 @@ namespace libcudf_bridge {
         const TableView &values,
         const TableView &keys,
         const rust::Slice<const int32_t> column_order,
-        const rust::Slice<const int32_t> null_precedence) {
+        const rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) {
         std::vector<cudf::order> orders;
         for (auto ord: column_order) {
             orders.push_back(static_cast<cudf::order>(ord));
@@ -149,7 +162,13 @@ namespace libcudf_bridge {
             null_orders.push_back(static_cast<cudf::null_order>(null_ord));
         }
 
-        auto result_table = cudf::stable_sort_by_key(*values.inner, *keys.inner, orders, null_orders);
+        auto result_table = cudf::stable_sort_by_key(
+            *values.inner,
+            *keys.inner,
+            orders,
+            null_orders,
+            stream.inner,
+            mr.inner);
 
         auto wrapped = std::make_unique<Table>();
         wrapped->inner = std::move(result_table);

--- a/libcudf-sys/src/sorting.h
+++ b/libcudf-sys/src/sorting.h
@@ -5,6 +5,8 @@
 #include "rust/cxx.h"
 #include "table.h"
 #include "column.h"
+#include "stream.h"
+#include "memory_resource.h"
 
 namespace libcudf_bridge {
 
@@ -12,37 +14,50 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> sort_table(
         const TableView &input,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Table> stable_sort_table(
         const TableView &input,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Column> sorted_order(
         const TableView &input,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Column> stable_sorted_order(
         const TableView &input,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     bool is_sorted(
         const TableView &input,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream);
 
     std::unique_ptr<Table> sort_by_key(
         const TableView &values,
         const TableView &keys,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 
     std::unique_ptr<Table> stable_sort_by_key(
         const TableView &values,
         const TableView &keys,
         rust::Slice<const int32_t> column_order,
-        rust::Slice<const int32_t> null_precedence);
+        rust::Slice<const int32_t> null_precedence,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/table.cpp
+++ b/libcudf-sys/src/table.cpp
@@ -116,11 +116,14 @@ namespace libcudf_bridge {
         schema_unique.release();
     }
 
-    void TableView::to_arrow_array(uint8_t *out_array_ptr) const {
+    void TableView::to_arrow_array(
+        uint8_t *out_array_ptr,
+        const CudaStreamView &stream,
+        const DeviceAsyncResourceRef &mr) const {
         if (!inner) {
             throw std::runtime_error("Cannot convert null table view to arrow array");
         }
-        auto device_array_unique = cudf::to_arrow_host(*this->inner);
+        auto device_array_unique = cudf::to_arrow_host(*this->inner, stream.inner, mr.inner);
         auto *out_array = reinterpret_cast<ArrowArray *>(out_array_ptr);
         // Extract just the ArrowArray from the ArrowDeviceArray
         *out_array = device_array_unique->array;

--- a/libcudf-sys/src/table.h
+++ b/libcudf-sys/src/table.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include "rust/cxx.h"
 #include "column.h"
+#include "stream.h"
+#include "memory_resource.h"
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 
@@ -35,7 +37,10 @@ namespace libcudf_bridge {
         void to_arrow_schema(uint8_t *out_schema_ptr) const;
 
         // Get the columns' data as an FFI Arrow Array
-        void to_arrow_array(uint8_t *out_array_ptr) const;
+        void to_arrow_array(
+            uint8_t *out_array_ptr,
+            const CudaStreamView &stream,
+            const DeviceAsyncResourceRef &mr) const;
 
         // Clone this table view
         [[nodiscard]] std::unique_ptr<TableView> clone() const;

--- a/src/binary_op.rs
+++ b/src/binary_op.rs
@@ -1,5 +1,6 @@
 use crate::column::CuDFColumn;
 use crate::data_type::arrow_type_to_cudf_data_type;
+use crate::stream::{resource_ref, stream_ref};
 use crate::{CuDFColumnViewOrScalar, CuDFError};
 use arrow_schema::{ArrowError, DataType};
 use libcudf_sys::ffi;
@@ -99,8 +100,8 @@ pub fn cudf_binary_op(
     };
     let stream = ffi::get_default_stream();
     let mr = ffi::get_current_device_resource_ref();
-    let stream_ref = crate::stream::stream_ref(&stream)?;
-    let mr_ref = crate::stream::resource_ref(&mr)?;
+    let stream_view = stream_ref(&stream)?;
+    let mr_ref = resource_ref(&mr)?;
 
     let result = match (left, right) {
         (CuDFColumnViewOrScalar::ColumnView(lhs), CuDFColumnViewOrScalar::ColumnView(rhs)) => {
@@ -109,7 +110,7 @@ pub fn cudf_binary_op(
                 rhs.inner(),
                 op as i32,
                 &dt,
-                stream_ref,
+                stream_view,
                 mr_ref,
             )
         }
@@ -119,7 +120,7 @@ pub fn cudf_binary_op(
                 rhs.inner(),
                 op as i32,
                 &dt,
-                stream_ref,
+                stream_view,
                 mr_ref,
             )
         }
@@ -129,7 +130,7 @@ pub fn cudf_binary_op(
                 rhs.inner(),
                 op as i32,
                 &dt,
-                stream_ref,
+                stream_view,
                 mr_ref,
             )
         }

--- a/src/binary_op.rs
+++ b/src/binary_op.rs
@@ -1,6 +1,7 @@
 use crate::column::CuDFColumn;
 use crate::data_type::arrow_type_to_cudf_data_type;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{CuDFColumnViewOrScalar, CuDFError};
 use arrow_schema::{ArrowError, DataType};
 use libcudf_sys::ffi;

--- a/src/binary_op.rs
+++ b/src/binary_op.rs
@@ -2,6 +2,7 @@ use crate::column::CuDFColumn;
 use crate::data_type::arrow_type_to_cudf_data_type;
 use crate::{CuDFColumnViewOrScalar, CuDFError};
 use arrow_schema::{ArrowError, DataType};
+use libcudf_sys::ffi;
 
 /// Binary operations supported by cuDF
 ///
@@ -96,16 +97,41 @@ pub fn cudf_binary_op(
             "Output type {output_type} not supported in CuDF"
         )))?;
     };
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
+    let stream_ref = crate::stream::stream_ref(&stream)?;
+    let mr_ref = crate::stream::resource_ref(&mr)?;
 
     let result = match (left, right) {
         (CuDFColumnViewOrScalar::ColumnView(lhs), CuDFColumnViewOrScalar::ColumnView(rhs)) => {
-            libcudf_sys::ffi::binary_operation_col_col(lhs.inner(), rhs.inner(), op as i32, &dt)
+            ffi::binary_operation_col_col(
+                lhs.inner(),
+                rhs.inner(),
+                op as i32,
+                &dt,
+                stream_ref,
+                mr_ref,
+            )
         }
         (CuDFColumnViewOrScalar::ColumnView(lhs), CuDFColumnViewOrScalar::Scalar(rhs)) => {
-            libcudf_sys::ffi::binary_operation_col_scalar(lhs.inner(), rhs.inner(), op as i32, &dt)
+            ffi::binary_operation_col_scalar(
+                lhs.inner(),
+                rhs.inner(),
+                op as i32,
+                &dt,
+                stream_ref,
+                mr_ref,
+            )
         }
         (CuDFColumnViewOrScalar::Scalar(lhs), CuDFColumnViewOrScalar::ColumnView(rhs)) => {
-            libcudf_sys::ffi::binary_operation_scalar_col(lhs.inner(), rhs.inner(), op as i32, &dt)
+            ffi::binary_operation_scalar_col(
+                lhs.inner(),
+                rhs.inner(),
+                op as i32,
+                &dt,
+                stream_ref,
+                mr_ref,
+            )
         }
         (CuDFColumnViewOrScalar::Scalar(_), CuDFColumnViewOrScalar::Scalar(_)) => {
             return Err(ArrowError::InvalidArgumentError("".to_string()))?

--- a/src/column.rs
+++ b/src/column.rs
@@ -1,5 +1,6 @@
 use crate::data_type::arrow_type_to_cudf;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{CuDFColumnView, CuDFError};
 use arrow::array::Array;
 use arrow::ffi::FFI_ArrowArray;

--- a/src/column.rs
+++ b/src/column.rs
@@ -1,4 +1,5 @@
 use crate::data_type::arrow_type_to_cudf;
+use crate::stream::{resource_ref, stream_ref};
 use crate::{CuDFColumnView, CuDFError};
 use arrow::array::Array;
 use arrow::ffi::FFI_ArrowArray;
@@ -65,8 +66,8 @@ impl CuDFColumn {
             ffi::column_from_arrow(
                 schema_ptr,
                 array_ptr,
-                crate::stream::stream_ref(&stream)?,
-                crate::stream::resource_ref(&mr)?,
+                stream_ref(&stream)?,
+                resource_ref(&mr)?,
             )
         }?;
         Ok(Self { inner })
@@ -99,8 +100,8 @@ impl CuDFColumn {
         let mr = ffi::get_current_device_resource_ref();
         Ok(Self::new(libcudf_sys::ffi::concat_column_views(
             &views,
-            crate::stream::stream_ref(&stream)?,
-            crate::stream::resource_ref(&mr)?,
+            stream_ref(&stream)?,
+            resource_ref(&mr)?,
         )?))
     }
 }

--- a/src/column.rs
+++ b/src/column.rs
@@ -65,8 +65,8 @@ impl CuDFColumn {
             ffi::column_from_arrow(
                 schema_ptr,
                 array_ptr,
-                stream.as_ref().expect("default stream should not be null"),
-                mr.as_ref().expect("device resource should not be null"),
+                crate::stream::stream_ref(&stream)?,
+                crate::stream::resource_ref(&mr)?,
             )
         }?;
         Ok(Self { inner })
@@ -95,7 +95,13 @@ impl CuDFColumn {
                 x.into_inner()
             })
             .collect::<Vec<_>>();
-        Ok(Self::new(libcudf_sys::ffi::concat_column_views(&views)?))
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        Ok(Self::new(libcudf_sys::ffi::concat_column_views(
+            &views,
+            crate::stream::stream_ref(&stream)?,
+            crate::stream::resource_ref(&mr)?,
+        )?))
     }
 }
 

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -1,5 +1,6 @@
 use crate::cudf_reference::CuDFRef;
 use crate::data_type::cudf_type_to_arrow;
+use crate::stream::{resource_ref, stream_ref};
 use crate::{slice_column, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef};
 use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
@@ -102,11 +103,8 @@ impl CuDFColumnView {
                 &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
             let stream = ffi::get_default_stream();
             let mr = ffi::get_current_device_resource_ref();
-            self.inner.to_arrow_array(
-                device_array_ptr,
-                crate::stream::stream_ref(&stream)?,
-                crate::stream::resource_ref(&mr)?,
-            );
+            self.inner
+                .to_arrow_array(device_array_ptr, stream_ref(&stream)?, resource_ref(&mr)?);
         }
 
         // Convert from FFI structures to Arrow ArrayData
@@ -115,6 +113,18 @@ impl CuDFColumnView {
 
         // Create an ArrayRef from the ArrayData
         Ok(arrow::array::make_array(array_data))
+    }
+
+    /// Return the device buffer memory used by this column view.
+    pub fn get_buffer_memory_size(&self) -> Result<usize, CuDFError> {
+        let stream = ffi::get_default_stream();
+        Ok(self.inner().get_buffer_memory_size(stream_ref(&stream)?))
+    }
+
+    /// Return the total device memory used by this column view, including child buffers.
+    pub fn get_array_memory_size(&self) -> Result<usize, CuDFError> {
+        let stream = ffi::get_default_stream();
+        Ok(self.inner().get_array_memory_size(stream_ref(&stream)?))
     }
 }
 
@@ -205,17 +215,13 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        let stream = ffi::get_default_stream();
-        let stream_ref = crate::stream::stream_ref(&stream)
-            .expect("default CUDA stream view should not be null");
-        self.inner().get_buffer_memory_size(stream_ref)
+        CuDFColumnView::get_buffer_memory_size(self)
+            .expect("failed to get cuDF column buffer memory size")
     }
 
     fn get_array_memory_size(&self) -> usize {
-        let stream = ffi::get_default_stream();
-        let stream_ref = crate::stream::stream_ref(&stream)
-            .expect("default CUDA stream view should not be null");
-        self.inner().get_array_memory_size(stream_ref)
+        CuDFColumnView::get_array_memory_size(self)
+            .expect("failed to get cuDF column array memory size")
     }
 
     fn logical_nulls(&self) -> Option<NullBuffer> {
@@ -284,7 +290,7 @@ mod tests {
         let array = StringArray::from(vec!["hello", "world", ""]);
         let column = CuDFColumn::from_arrow_host(&array)?.into_view();
 
-        let size = column.get_array_memory_size();
+        let size = column.get_array_memory_size()?;
         let min_offsets_and_chars =
             (array.len() + 1) * std::mem::size_of::<i32>() + array.value_data().len();
         assert!(size >= min_offsets_and_chars);
@@ -369,7 +375,7 @@ mod tests {
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
-        let size = column.get_buffer_memory_size();
+        let size = column.get_buffer_memory_size()?;
         assert_eq!(size, 20, "Int32 column should be 20 bytes");
 
         Ok(())
@@ -383,7 +389,7 @@ mod tests {
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
-        let size = column.get_buffer_memory_size();
+        let size = column.get_buffer_memory_size()?;
         assert_eq!(size, 4_000_000, "1M Int32 elements should be 4MB");
 
         Ok(())
@@ -396,8 +402,8 @@ mod tests {
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
-        let buffer_size = column.get_buffer_memory_size();
-        let array_size = column.get_array_memory_size();
+        let buffer_size = column.get_buffer_memory_size()?;
+        let array_size = column.get_array_memory_size()?;
 
         // With no nulls, array_size should equal buffer_size
         assert_eq!(
@@ -415,8 +421,8 @@ mod tests {
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
-        let buffer_size = column.get_buffer_memory_size();
-        let array_size = column.get_array_memory_size();
+        let buffer_size = column.get_buffer_memory_size()?;
+        let array_size = column.get_array_memory_size()?;
 
         // With nulls -> array_size = buffer_size + null_mask_size
         assert!(

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -1,6 +1,7 @@
 use crate::cudf_reference::CuDFRef;
 use crate::data_type::cudf_type_to_arrow;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{slice_column, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef};
 use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -6,6 +6,7 @@ use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
 use arrow::ffi::FFI_ArrowSchema;
 use arrow_schema::DataType;
 use cxx::UniquePtr;
+use libcudf_sys::ffi;
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, OnceLock};
@@ -21,7 +22,7 @@ use std::sync::{Arc, OnceLock};
 pub struct CuDFColumnView {
     // Keep a ref to CuDF structs so that they live as long as this view exists
     pub(crate) _ref: Option<Arc<dyn CuDFRef>>,
-    inner: UniquePtr<libcudf_sys::ffi::ColumnView>,
+    inner: UniquePtr<ffi::ColumnView>,
     dt: DataType,
     null_buf: OnceLock<Option<NullBuffer>>,
 }
@@ -31,7 +32,7 @@ impl CuDFColumnView {
     ///
     /// This is used internally to create column views that keep the source table or column alive
     pub(crate) fn new_with_ref(
-        inner: UniquePtr<libcudf_sys::ffi::ColumnView>,
+        inner: UniquePtr<ffi::ColumnView>,
         _ref: Option<Arc<dyn CuDFRef>>,
     ) -> Self {
         let cudf_dtype = inner.data_type();
@@ -45,12 +46,12 @@ impl CuDFColumnView {
         }
     }
 
-    pub(crate) fn inner(&self) -> &UniquePtr<libcudf_sys::ffi::ColumnView> {
+    pub(crate) fn inner(&self) -> &UniquePtr<ffi::ColumnView> {
         &self.inner
     }
 
     /// Consume this wrapper and return the underlying cuDF column view
-    pub(crate) fn into_inner(self) -> UniquePtr<libcudf_sys::ffi::ColumnView> {
+    pub(crate) fn into_inner(self) -> UniquePtr<ffi::ColumnView> {
         self.inner
     }
 
@@ -99,7 +100,13 @@ impl CuDFColumnView {
         unsafe {
             let device_array_ptr =
                 &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
-            self.inner.to_arrow_array(device_array_ptr);
+            let stream = ffi::get_default_stream();
+            let mr = ffi::get_current_device_resource_ref();
+            self.inner.to_arrow_array(
+                device_array_ptr,
+                crate::stream::stream_ref(&stream)?,
+                crate::stream::resource_ref(&mr)?,
+            );
         }
 
         // Convert from FFI structures to Arrow ArrayData
@@ -198,11 +205,17 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        self.inner().get_buffer_memory_size()
+        let stream = ffi::get_default_stream();
+        let stream_ref = crate::stream::stream_ref(&stream)
+            .expect("default CUDA stream view should not be null");
+        self.inner().get_buffer_memory_size(stream_ref)
     }
 
     fn get_array_memory_size(&self) -> usize {
-        self.inner().get_array_memory_size()
+        let stream = ffi::get_default_stream();
+        let stream_ref = crate::stream::stream_ref(&stream)
+            .expect("default CUDA stream view should not be null");
+        self.inner().get_array_memory_size(stream_ref)
     }
 
     fn logical_nulls(&self) -> Option<NullBuffer> {

--- a/src/device_resource.rs
+++ b/src/device_resource.rs
@@ -1,0 +1,16 @@
+use cxx::UniquePtr;
+use libcudf_sys::ffi;
+
+use crate::{CuDFError, Result};
+
+/// Return a non-null device resource reference from a cuDF FFI handle.
+///
+/// cuDF should always return a valid device resource ref; this surfaces a Rust
+/// error if the FFI handle is unexpectedly null.
+pub(crate) fn resource_ref(
+    resource: &UniquePtr<ffi::DeviceAsyncResourceRef>,
+) -> Result<&ffi::DeviceAsyncResourceRef> {
+    resource
+        .as_ref()
+        .ok_or(CuDFError::NullHandle("current device resource ref"))
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,10 @@ pub enum CuDFError {
     /// Arrow error during conversion or other operations
     #[error(transparent)]
     ArrowError(#[from] arrow::error::ArrowError),
+
+    /// cuDF returned a null handle where a valid handle was required
+    #[error("cuDF returned a null {0} handle")]
+    NullHandle(&'static str),
 }
 
 /// Result type alias for libcudf-rs operations

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -59,7 +59,13 @@ impl CuDFGroupBy {
             requests_inner.pin_mut().add(request.inner);
         }
 
-        let mut gby_result = self.inner.aggregate(&requests_inner)?;
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let mut gby_result = self.inner.aggregate(
+            &requests_inner,
+            crate::stream::stream_ref(&stream)?,
+            crate::stream::resource_ref(&mr)?,
+        )?;
         let keys = gby_result.pin_mut().release_keys();
         let keys = CuDFTable::from_ptr(keys);
 

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -1,6 +1,7 @@
 use crate::cudf_reference::CuDFRef;
+use crate::device_resource::resource_ref;
 use crate::errors::Result;
-use crate::stream::{resource_ref, stream_ref};
+use crate::stream::stream_ref;
 use crate::table_view::CuDFTableView;
 use crate::{CuDFColumn, CuDFColumnView, CuDFTable};
 use cxx::UniquePtr;

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -1,5 +1,6 @@
 use crate::cudf_reference::CuDFRef;
 use crate::errors::Result;
+use crate::stream::{resource_ref, stream_ref};
 use crate::table_view::CuDFTableView;
 use crate::{CuDFColumn, CuDFColumnView, CuDFTable};
 use cxx::UniquePtr;
@@ -61,11 +62,9 @@ impl CuDFGroupBy {
 
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        let mut gby_result = self.inner.aggregate(
-            &requests_inner,
-            crate::stream::stream_ref(&stream)?,
-            crate::stream::resource_ref(&mr)?,
-        )?;
+        let mut gby_result =
+            self.inner
+                .aggregate(&requests_inner, stream_ref(&stream)?, resource_ref(&mr)?)?;
         let keys = gby_result.pin_mut().release_keys();
         let keys = CuDFTable::from_ptr(keys);
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -66,26 +66,18 @@ impl JoinIndexVector {
 
 impl CuDFRef for JoinIndexVector {}
 
-fn default_join_context() -> (
-    UniquePtr<ffi::CudaStreamView>,
-    UniquePtr<ffi::DeviceAsyncResourceRef>,
-) {
-    (
-        ffi::get_default_stream(),
-        ffi::get_current_device_resource_ref(),
-    )
-}
-
-fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> &ffi::CudaStreamView {
+fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> Result<&ffi::CudaStreamView, CuDFError> {
     stream
         .as_ref()
-        .expect("default CUDA stream view should not be null")
+        .ok_or(CuDFError::NullHandle("CUDA stream view"))
 }
 
-fn resource_ref(resource: &UniquePtr<ffi::DeviceAsyncResourceRef>) -> &ffi::DeviceAsyncResourceRef {
+fn resource_ref(
+    resource: &UniquePtr<ffi::DeviceAsyncResourceRef>,
+) -> Result<&ffi::DeviceAsyncResourceRef, CuDFError> {
     resource
         .as_ref()
-        .expect("current device resource ref should not be null")
+        .ok_or(CuDFError::NullHandle("current device resource ref"))
 }
 
 fn null_gather_index() -> i32 {
@@ -96,12 +88,13 @@ fn sys_hash_join_inner_join_indices(
     join: &ffi::HashJoin,
     probe_keys: &ffi::TableView,
 ) -> Result<UniquePtr<ffi::HashJoinIndices>, CuDFError> {
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     Ok(ffi::hash_join_inner_join_indices(
         join,
         probe_keys,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?)
 }
 
@@ -109,12 +102,13 @@ fn sys_hash_join_left_join_indices(
     join: &ffi::HashJoin,
     probe_keys: &ffi::TableView,
 ) -> Result<UniquePtr<ffi::HashJoinIndices>, CuDFError> {
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     Ok(ffi::hash_join_left_join_indices(
         join,
         probe_keys,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?)
 }
 
@@ -131,15 +125,21 @@ fn gather_join_output(
     left_policy: OutOfBoundsPolicy,
     right_policy: OutOfBoundsPolicy,
 ) -> Result<CuDFTable, CuDFError> {
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let left = CuDFTable::from_inner(ffi::gather_with_policy(
         left_payload,
         left_indices,
         left_policy as i32,
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?);
     let right = CuDFTable::from_inner(ffi::gather_with_policy(
         right_payload,
         right_indices,
         right_policy as i32,
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?);
     let mut columns = left.into_columns();
     columns.extend(right.into_columns());
@@ -209,7 +209,8 @@ fn gather_filtered_hash_join_indices(
     // the public `[build_cols | probe_cols]` output order.
     let probe_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_probe()));
     let build_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_build()));
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let mut filtered_indices = ffi::filter_join_indices(
         args.build_conditional,
         args.probe_conditional,
@@ -217,8 +218,8 @@ fn gather_filtered_hash_join_indices(
         probe_indices.as_sys(),
         args.predicate.inner(),
         args.join_kind as i32,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?;
     let filtered_build_indices = Arc::new(JoinIndexVector::new(
         filtered_indices.pin_mut().release_left(),
@@ -254,17 +255,23 @@ fn distinct_valid_indices(indices: CuDFColumnView) -> Result<Option<Arc<CuDFColu
         return Ok(None);
     }
 
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let zero = int32_scalar(0)?;
     let valid_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
         indices.inner(),
         zero.inner(),
         BinaryOperator::GreaterEqual as i32,
         &bool_data_type(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?));
     let indices_table = CuDFTableView::from_column_views(vec![indices])?;
     let valid_indices_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
         indices_table.inner(),
         Arc::clone(&valid_mask).view().inner(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?);
     if valid_indices_table.num_rows() == 0 {
         return Ok(None);
@@ -277,6 +284,8 @@ fn distinct_valid_indices(indices: CuDFColumnView) -> Result<Option<Arc<CuDFColu
         DuplicateKeepOption::KeepAny as i32,
         NullEquality::Equal as i32,
         NanEquality::AllEqual as i32,
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?);
     if distinct_indices.num_rows() == 0 {
         return Ok(None);
@@ -295,10 +304,14 @@ fn matched_row_mask(
     row_count: usize,
     matched_indices: Arc<JoinIndexVector>,
 ) -> Result<Arc<CuDFColumn>, CuDFError> {
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let false_scalar = bool_scalar(false)?;
     let mask = Arc::new(CuDFColumn::new(ffi::make_column_from_scalar(
         false_scalar.inner(),
         row_count,
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?));
     let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&matched_indices).view())?
     else {
@@ -313,6 +326,8 @@ fn matched_row_mask(
         &source,
         distinct_indices_view.inner(),
         target.inner(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?);
     Ok(Arc::new(
         updated
@@ -327,6 +342,8 @@ fn unmatched_indices_from_matches(
     row_count: usize,
     matched_indices: Arc<JoinIndexVector>,
 ) -> Result<Arc<CuDFColumn>, CuDFError> {
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let all_indices = join_index_sequence(row_count, 0, 1)?;
     let matched_mask = matched_row_mask(row_count, matched_indices)?;
     let false_scalar = bool_scalar(false)?;
@@ -335,12 +352,16 @@ fn unmatched_indices_from_matches(
         false_scalar.inner(),
         BinaryOperator::Equal as i32,
         &bool_data_type(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?));
     let all_indices_table =
         CuDFTableView::from_column_views(vec![Arc::clone(&all_indices).view()])?;
     let unmatched_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
         all_indices_table.inner(),
         Arc::clone(&unmatched_mask).view().inner(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?);
     Ok(Arc::new(
         unmatched_table
@@ -352,6 +373,8 @@ fn unmatched_indices_from_matches(
 }
 
 fn join_index_sequence(size: usize, init: i32, step: i32) -> Result<Arc<CuDFColumn>, CuDFError> {
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let init_array = Int32Array::from(vec![init]);
     let step_array = Int32Array::from(vec![step]);
     let init_scalar = CuDFScalar::from_arrow_host(Scalar::new(&init_array))?;
@@ -360,6 +383,8 @@ fn join_index_sequence(size: usize, init: i32, step: i32) -> Result<Arc<CuDFColu
         size,
         init_scalar.inner(),
         step_scalar.inner(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?)))
 }
 
@@ -417,7 +442,7 @@ impl CuDFHashJoin {
         let inner = ffi::hash_join_create(
             &build_keys,
             null_equality.into_sys() as i32,
-            stream_ref(&stream),
+            stream_ref(&stream)?,
         )?;
         Ok(Self {
             inner,
@@ -713,6 +738,8 @@ impl CuDFHashJoin {
             return Ok(());
         };
 
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
         let matched_build_mask = match &self.matched_build_mask {
             Some(mask) => Arc::clone(mask),
             None => {
@@ -720,6 +747,8 @@ impl CuDFHashJoin {
                 let mask = Arc::new(CuDFColumn::new(ffi::make_column_from_scalar(
                     false_scalar.inner(),
                     self.build_rows,
+                    stream_ref(&stream)?,
+                    resource_ref(&resource)?,
                 )?));
                 self.matched_build_mask = Some(Arc::clone(&mask));
                 mask
@@ -734,6 +763,8 @@ impl CuDFHashJoin {
             &source,
             scatter_indices_view.inner(),
             target.inner(),
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
         )?);
         self.matched_build_mask = Some(Arc::new(
             updated
@@ -751,18 +782,24 @@ impl CuDFHashJoin {
             return Ok(all_build_indices);
         };
 
+        let stream = ffi::get_default_stream();
+        let resource = ffi::get_current_device_resource_ref();
         let false_scalar = bool_scalar(false)?;
         let unmatched_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
             Arc::clone(matched_build_mask).view().inner(),
             false_scalar.inner(),
             BinaryOperator::Equal as i32,
             &bool_data_type(),
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
         )?));
         let all_build_table =
             CuDFTableView::from_column_views(vec![Arc::clone(&all_build_indices).view()])?;
         let unmatched_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
             all_build_table.inner(),
             Arc::clone(&unmatched_mask).view().inner(),
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
         )?);
         Ok(Arc::new(
             unmatched_table
@@ -791,13 +828,14 @@ pub fn inner_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let indices = ffi::inner_join_indices(
         &left_keys,
         &right_keys,
         NullEquality::Equal as i32,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?;
     gather_join_indices(
         indices,
@@ -825,13 +863,14 @@ pub fn left_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let indices = ffi::left_join_indices(
         &left_keys,
         &right_keys,
         NullEquality::Equal as i32,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?;
     gather_join_indices(
         indices,
@@ -859,13 +898,14 @@ pub fn full_join(
     let right_keys = select_cols(right, right_on);
     let left_payload = left_out_cols.map(|c| select_cols(left, c));
     let right_payload = right_out_cols.map(|c| select_cols(right, c));
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let indices = ffi::full_join_indices(
         &left_keys,
         &right_keys,
         NullEquality::Equal as i32,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?;
     gather_join_indices(
         indices,
@@ -887,23 +927,26 @@ pub fn left_semi_join(
 ) -> Result<CuDFTable, CuDFError> {
     let left_keys = select_cols(left, left_on);
     let right_keys = select_cols(right, right_on);
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let join = ffi::filtered_join_create(
         &right_keys,
         NullEquality::Equal as i32,
         SetAsBuildTable::Right as i32,
-        stream_ref(&stream),
+        stream_ref(&stream)?,
     )?;
     let indices = Arc::new(JoinIndexVector::new(ffi::filtered_join_semi_join(
         &join,
         &left_keys,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?));
     let indices_view = indices.view();
     Ok(CuDFTable::from_inner(ffi::gather(
         left.inner(),
         indices_view.inner(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?))
 }
 
@@ -918,23 +961,26 @@ pub fn left_anti_join(
 ) -> Result<CuDFTable, CuDFError> {
     let left_keys = select_cols(left, left_on);
     let right_keys = select_cols(right, right_on);
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     let join = ffi::filtered_join_create(
         &right_keys,
         NullEquality::Equal as i32,
         SetAsBuildTable::Right as i32,
-        stream_ref(&stream),
+        stream_ref(&stream)?,
     )?;
     let indices = Arc::new(JoinIndexVector::new(ffi::filtered_join_anti_join(
         &join,
         &left_keys,
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?));
     let indices_view = indices.view();
     Ok(CuDFTable::from_inner(ffi::gather(
         left.inner(),
         indices_view.inner(),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?))
 }
 
@@ -942,12 +988,13 @@ pub fn left_anti_join(
 ///
 /// Returns all combinations of rows from both inputs.
 pub fn cross_join(left: &CuDFTableView, right: &CuDFTableView) -> Result<CuDFTable, CuDFError> {
-    let (stream, resource) = default_join_context();
+    let stream = ffi::get_default_stream();
+    let resource = ffi::get_current_device_resource_ref();
     Ok(CuDFTable::from_inner(ffi::cross_join(
         left.inner(),
         right.inner(),
-        stream_ref(&stream),
-        resource_ref(&resource),
+        stream_ref(&stream)?,
+        resource_ref(&resource)?,
     )?))
 }
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,4 +1,6 @@
 use crate::data_type::arrow_type_to_cudf_data_type;
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{
     CuDFAstExpression, CuDFColumn, CuDFColumnView, CuDFError, CuDFRef, CuDFScalar, CuDFTable,
     CuDFTableView,
@@ -65,20 +67,6 @@ impl JoinIndexVector {
 }
 
 impl CuDFRef for JoinIndexVector {}
-
-fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> Result<&ffi::CudaStreamView, CuDFError> {
-    stream
-        .as_ref()
-        .ok_or(CuDFError::NullHandle("CUDA stream view"))
-}
-
-fn resource_ref(
-    resource: &UniquePtr<ffi::DeviceAsyncResourceRef>,
-) -> Result<&ffi::DeviceAsyncResourceRef, CuDFError> {
-    resource
-        .as_ref()
-        .ok_or(CuDFError::NullHandle("current device resource ref"))
-}
 
 fn null_gather_index() -> i32 {
     ffi::join_no_match()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod config;
 mod cudf_array;
 mod cudf_reference;
 mod data_type;
+mod device_resource;
 mod errors;
 mod group_by;
 mod join;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,5 +1,6 @@
 use crate::data_type::arrow_type_to_cudf_data_type;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{CuDFColumn, CuDFColumnView, CuDFError, CuDFRef, CuDFTable, CuDFTableView};
 use arrow_schema::{ArrowError, DataType};
 use libcudf_sys::ffi;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -38,7 +38,14 @@ use std::sync::Arc;
 /// # Ok::<(), libcudf_rs::CuDFError>(())
 /// ```
 pub fn gather(table: &CuDFTableView, gather_map: &CuDFColumnView) -> Result<CuDFTable, CuDFError> {
-    let inner = ffi::gather(table.inner(), gather_map.inner())?;
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
+    let inner = ffi::gather(
+        table.inner(),
+        gather_map.inner(),
+        crate::stream::stream_ref(&stream)?,
+        crate::stream::resource_ref(&mr)?,
+    )?;
     Ok(CuDFTable::from_inner(inner))
 }
 
@@ -89,7 +96,14 @@ pub fn apply_boolean_mask(
     table: &CuDFTableView,
     boolean_mask: &CuDFColumnView,
 ) -> Result<CuDFTable, CuDFError> {
-    let inner = ffi::apply_boolean_mask(table.inner(), boolean_mask.inner())?;
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
+    let inner = ffi::apply_boolean_mask(
+        table.inner(),
+        boolean_mask.inner(),
+        crate::stream::stream_ref(&stream)?,
+        crate::stream::resource_ref(&mr)?,
+    )?;
     Ok(CuDFTable::from_inner(inner))
 }
 
@@ -130,7 +144,13 @@ pub fn slice_column(
     offset: usize,
     length: usize,
 ) -> Result<CuDFColumnView, CuDFError> {
-    let inner = ffi::slice_column(column.inner(), offset, length)?;
+    let stream = ffi::get_default_stream();
+    let inner = ffi::slice_column(
+        column.inner(),
+        offset,
+        length,
+        crate::stream::stream_ref(&stream)?,
+    )?;
     Ok(CuDFColumnView::new_with_ref(
         inner,
         Some(Arc::new(column.clone()) as Arc<dyn CuDFRef>),
@@ -160,7 +180,14 @@ pub fn cast(column: &CuDFColumnView, target_type: &DataType) -> Result<CuDFColum
             target_type
         )))
     })?;
-    let result = ffi::cast_column(column.inner(), &cudf_dt)?;
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
+    let result = ffi::cast_column(
+        column.inner(),
+        &cudf_dt,
+        crate::stream::stream_ref(&stream)?,
+        crate::stream::resource_ref(&mr)?,
+    )?;
     Ok(CuDFColumn::new(result))
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,4 +1,5 @@
 use crate::data_type::arrow_type_to_cudf_data_type;
+use crate::stream::{resource_ref, stream_ref};
 use crate::{CuDFColumn, CuDFColumnView, CuDFError, CuDFRef, CuDFTable, CuDFTableView};
 use arrow_schema::{ArrowError, DataType};
 use libcudf_sys::ffi;
@@ -43,8 +44,8 @@ pub fn gather(table: &CuDFTableView, gather_map: &CuDFColumnView) -> Result<CuDF
     let inner = ffi::gather(
         table.inner(),
         gather_map.inner(),
-        crate::stream::stream_ref(&stream)?,
-        crate::stream::resource_ref(&mr)?,
+        stream_ref(&stream)?,
+        resource_ref(&mr)?,
     )?;
     Ok(CuDFTable::from_inner(inner))
 }
@@ -101,8 +102,8 @@ pub fn apply_boolean_mask(
     let inner = ffi::apply_boolean_mask(
         table.inner(),
         boolean_mask.inner(),
-        crate::stream::stream_ref(&stream)?,
-        crate::stream::resource_ref(&mr)?,
+        stream_ref(&stream)?,
+        resource_ref(&mr)?,
     )?;
     Ok(CuDFTable::from_inner(inner))
 }
@@ -145,12 +146,7 @@ pub fn slice_column(
     length: usize,
 ) -> Result<CuDFColumnView, CuDFError> {
     let stream = ffi::get_default_stream();
-    let inner = ffi::slice_column(
-        column.inner(),
-        offset,
-        length,
-        crate::stream::stream_ref(&stream)?,
-    )?;
+    let inner = ffi::slice_column(column.inner(), offset, length, stream_ref(&stream)?)?;
     Ok(CuDFColumnView::new_with_ref(
         inner,
         Some(Arc::new(column.clone()) as Arc<dyn CuDFRef>),
@@ -185,8 +181,8 @@ pub fn cast(column: &CuDFColumnView, target_type: &DataType) -> Result<CuDFColum
     let result = ffi::cast_column(
         column.inner(),
         &cudf_dt,
-        crate::stream::stream_ref(&stream)?,
-        crate::stream::resource_ref(&mr)?,
+        stream_ref(&stream)?,
+        resource_ref(&mr)?,
     )?;
     Ok(CuDFColumn::new(result))
 }

--- a/src/pinned.rs
+++ b/src/pinned.rs
@@ -11,6 +11,7 @@
 //! is fully asynchronous.
 use crate::config::ensure_pools_configured;
 use crate::errors::Result;
+use crate::stream::stream_ref;
 use arrow::alloc::Allocation;
 use arrow::array::{make_array, ArrayData, ArrayDataBuilder, RecordBatch};
 use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
@@ -73,7 +74,7 @@ impl Drop for PinnedHostBuffer {
 /// DMA has finished and the pinned buffer must outlive the transfer.
 pub fn synchronize_default_stream() -> Result<()> {
     let stream = ffi::get_default_stream();
-    crate::stream::stream_ref(&stream)?.synchronize()?;
+    stream_ref(&stream)?.synchronize()?;
     Ok(())
 }
 

--- a/src/pinned.rs
+++ b/src/pinned.rs
@@ -15,9 +15,7 @@ use arrow::alloc::Allocation;
 use arrow::array::{make_array, ArrayData, ArrayDataBuilder, RecordBatch};
 use arrow::buffer::{BooleanBuffer, Buffer, NullBuffer};
 use cxx::UniquePtr;
-use libcudf_sys::ffi::{
-    cuda_default_stream_synchronize, get_pinned_memory_resource, HostDeviceAsyncResourceRef,
-};
+use libcudf_sys::ffi::{self, get_pinned_memory_resource, HostDeviceAsyncResourceRef};
 use std::ptr::NonNull;
 use std::sync::{Arc, OnceLock};
 
@@ -74,7 +72,8 @@ impl Drop for PinnedHostBuffer {
 /// source is about to be dropped, since `cudaMemcpyAsync` returns before the
 /// DMA has finished and the pinned buffer must outlive the transfer.
 pub fn synchronize_default_stream() -> Result<()> {
-    cuda_default_stream_synchronize()?;
+    let stream = ffi::get_default_stream();
+    crate::stream::stream_ref(&stream)?.synchronize()?;
     Ok(())
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,5 +1,6 @@
 use crate::data_type::cudf_type_to_arrow;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{CuDFColumn, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef, Scalar};
 use arrow::buffer::NullBuffer;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -4,6 +4,7 @@ use arrow::array::{Array, ArrayData, ArrayRef, Scalar};
 use arrow::buffer::NullBuffer;
 use arrow_schema::DataType;
 use cxx::UniquePtr;
+use libcudf_sys::ffi;
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
@@ -14,14 +15,14 @@ use std::sync::{Arc, RwLock};
 /// This allows scalar values to be used in contexts that expect arrays, enabling
 /// seamless integration with operations that work on both scalars and columns.
 pub struct CuDFScalar {
-    inner: UniquePtr<libcudf_sys::ffi::Scalar>,
+    inner: UniquePtr<ffi::Scalar>,
     dt: DataType,
     cached_scalar: RwLock<Option<Arc<ArrayData>>>,
 }
 
 impl CuDFScalar {
     /// Create a CuDFScalar from an existing cuDF scalar
-    pub(crate) fn new(inner: UniquePtr<libcudf_sys::ffi::Scalar>) -> Self {
+    pub(crate) fn new(inner: UniquePtr<ffi::Scalar>) -> Self {
         let cudf_dtype = inner.data_type();
         let dt = cudf_type_to_arrow(&cudf_dtype);
         let dt = dt.unwrap_or(DataType::Null);
@@ -34,7 +35,7 @@ impl CuDFScalar {
     }
 
     /// Get a reference to the underlying cuDF scalar
-    pub(crate) fn inner(&self) -> &UniquePtr<libcudf_sys::ffi::Scalar> {
+    pub(crate) fn inner(&self) -> &UniquePtr<ffi::Scalar> {
         &self.inner
     }
 
@@ -84,7 +85,13 @@ impl CuDFScalar {
         unsafe {
             let device_array_ptr =
                 &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
-            self.inner.to_arrow_array(device_array_ptr);
+            let stream = ffi::get_default_stream();
+            let mr = ffi::get_current_device_resource_ref();
+            self.inner.to_arrow_array(
+                device_array_ptr,
+                crate::stream::stream_ref(&stream)?,
+                crate::stream::resource_ref(&mr)?,
+            );
         }
 
         // Convert from FFI structures to Arrow ArrayData
@@ -126,7 +133,14 @@ impl CuDFScalar {
         let column = CuDFColumn::from_arrow_host(&array)?.into_view();
 
         // Extract the scalar from the column at index 0
-        let cudf_scalar = libcudf_sys::ffi::get_element(column.inner(), 0);
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let cudf_scalar = ffi::get_element(
+            column.inner(),
+            0,
+            crate::stream::stream_ref(&stream)?,
+            crate::stream::resource_ref(&mr)?,
+        );
 
         Ok(Self::new(cudf_scalar))
     }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,4 +1,5 @@
 use crate::data_type::cudf_type_to_arrow;
+use crate::stream::{resource_ref, stream_ref};
 use crate::{CuDFColumn, CuDFError};
 use arrow::array::{Array, ArrayData, ArrayRef, Scalar};
 use arrow::buffer::NullBuffer;
@@ -87,11 +88,8 @@ impl CuDFScalar {
                 &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
             let stream = ffi::get_default_stream();
             let mr = ffi::get_current_device_resource_ref();
-            self.inner.to_arrow_array(
-                device_array_ptr,
-                crate::stream::stream_ref(&stream)?,
-                crate::stream::resource_ref(&mr)?,
-            );
+            self.inner
+                .to_arrow_array(device_array_ptr, stream_ref(&stream)?, resource_ref(&mr)?);
         }
 
         // Convert from FFI structures to Arrow ArrayData
@@ -135,12 +133,8 @@ impl CuDFScalar {
         // Extract the scalar from the column at index 0
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        let cudf_scalar = ffi::get_element(
-            column.inner(),
-            0,
-            crate::stream::stream_ref(&stream)?,
-            crate::stream::resource_ref(&mr)?,
-        );
+        let cudf_scalar =
+            ffi::get_element(column.inner(), 0, stream_ref(&stream)?, resource_ref(&mr)?);
 
         Ok(Self::new(cudf_scalar))
     }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -105,12 +105,16 @@ pub fn sort(
     let column_order_i32: Vec<i32> = sort_orders.iter().map(|&o| o.order() as i32).collect();
     let null_precedence_i32: Vec<i32> =
         sort_orders.iter().map(|&o| o.null_order() as i32).collect();
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
 
     let inner = ffi::stable_sort_by_key(
         table.inner(),
         keys_view.inner(),
         &column_order_i32,
         &null_precedence_i32,
+        crate::stream::stream_ref(&stream)?,
+        crate::stream::resource_ref(&mr)?,
     )?;
     Ok(CuDFTable::from_inner(inner))
 }
@@ -151,8 +155,16 @@ pub fn sort_by_all(
     let column_order_i32: Vec<i32> = sort_orders.iter().map(|&o| o.order() as i32).collect();
     let null_precedence_i32: Vec<i32> =
         sort_orders.iter().map(|&o| o.null_order() as i32).collect();
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
 
-    let inner = ffi::stable_sort_table(table.inner(), &column_order_i32, &null_precedence_i32)?;
+    let inner = ffi::stable_sort_table(
+        table.inner(),
+        &column_order_i32,
+        &null_precedence_i32,
+        crate::stream::stream_ref(&stream)?,
+        crate::stream::resource_ref(&mr)?,
+    )?;
     Ok(CuDFTable::from_inner(inner))
 }
 
@@ -189,8 +201,16 @@ pub fn stable_sorted_order(
     let column_order_i32: Vec<i32> = sort_orders.iter().map(|&o| o.order() as i32).collect();
     let null_precedence_i32: Vec<i32> =
         sort_orders.iter().map(|&o| o.null_order() as i32).collect();
+    let stream = ffi::get_default_stream();
+    let mr = ffi::get_current_device_resource_ref();
 
-    let inner = ffi::stable_sorted_order(table.inner(), &column_order_i32, &null_precedence_i32)?;
+    let inner = ffi::stable_sorted_order(
+        table.inner(),
+        &column_order_i32,
+        &null_precedence_i32,
+        crate::stream::stream_ref(&stream)?,
+        crate::stream::resource_ref(&mr)?,
+    )?;
     Ok(CuDFColumn::new(inner))
 }
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,4 +1,5 @@
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{CuDFColumn, CuDFError, CuDFTable, CuDFTableView};
 use libcudf_sys::{ffi, NullOrder, Order};
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,3 +1,4 @@
+use crate::stream::{resource_ref, stream_ref};
 use crate::{CuDFColumn, CuDFError, CuDFTable, CuDFTableView};
 use libcudf_sys::{ffi, NullOrder, Order};
 
@@ -113,8 +114,8 @@ pub fn sort(
         keys_view.inner(),
         &column_order_i32,
         &null_precedence_i32,
-        crate::stream::stream_ref(&stream)?,
-        crate::stream::resource_ref(&mr)?,
+        stream_ref(&stream)?,
+        resource_ref(&mr)?,
     )?;
     Ok(CuDFTable::from_inner(inner))
 }
@@ -162,8 +163,8 @@ pub fn sort_by_all(
         table.inner(),
         &column_order_i32,
         &null_precedence_i32,
-        crate::stream::stream_ref(&stream)?,
-        crate::stream::resource_ref(&mr)?,
+        stream_ref(&stream)?,
+        resource_ref(&mr)?,
     )?;
     Ok(CuDFTable::from_inner(inner))
 }
@@ -208,8 +209,8 @@ pub fn stable_sorted_order(
         table.inner(),
         &column_order_i32,
         &null_precedence_i32,
-        crate::stream::stream_ref(&stream)?,
-        crate::stream::resource_ref(&mr)?,
+        stream_ref(&stream)?,
+        resource_ref(&mr)?,
     )?;
     Ok(CuDFColumn::new(inner))
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -21,6 +21,9 @@ impl From<CuDFStreamFlags> for u32 {
 
 /// Owning Rust wrapper for a CUDA stream used by cuDF operations.
 ///
+/// For the default stream, use [`ffi::get_default_stream`] to get the default stream
+/// view instead.
+///
 /// This type owns an opaque C++ `rmm::cuda_stream`. Dropping `CuDFStream`
 /// destroys that underlying stream.
 ///
@@ -30,7 +33,6 @@ impl From<CuDFStreamFlags> for u32 {
 pub struct CuDFStream {
     // Kept alive so the underlying C++ `rmm::cuda_stream` is destroyed on
     // drop. Accessed via `inner()` from within the crate.
-    #[allow(dead_code)]
     inner: UniquePtr<libcudf_sys::ffi::CudaStream>,
 }
 
@@ -65,6 +67,12 @@ impl CuDFStream {
         Ok(())
     }
 
+    /// Returns an owned [ffi::CudaStreamView] for this stream.
+    #[allow(dead_code)]
+    pub(crate) fn view(&self) -> UniquePtr<ffi::CudaStreamView> {
+        ffi::cuda_stream_view(self.inner())
+    }
+
     /// Get a reference to the underlying FFI stream handle.
     #[allow(dead_code)]
     pub(crate) fn inner(&self) -> &libcudf_sys::ffi::CudaStream {
@@ -72,18 +80,14 @@ impl CuDFStream {
     }
 }
 
+/// Return a non-null CUDA stream view reference from a cuDF FFI handle.
+///
+/// cuDF should always return a valid stream view; this surfaces a Rust error if
+/// the FFI handle is unexpectedly null.
 pub(crate) fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> Result<&ffi::CudaStreamView> {
     stream
         .as_ref()
         .ok_or(CuDFError::NullHandle("CUDA stream view"))
-}
-
-pub(crate) fn resource_ref(
-    resource: &UniquePtr<ffi::DeviceAsyncResourceRef>,
-) -> Result<&ffi::DeviceAsyncResourceRef> {
-    resource
-        .as_ref()
-        .ok_or(CuDFError::NullHandle("current device resource ref"))
 }
 
 impl Default for CuDFStream {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,7 @@
 use cxx::UniquePtr;
 
-use crate::Result;
+use crate::{CuDFError, Result};
+use libcudf_sys::ffi;
 
 /// Stream creation flags for CUDA stream-backed cuDF execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +70,20 @@ impl CuDFStream {
     pub(crate) fn inner(&self) -> &libcudf_sys::ffi::CudaStream {
         self.inner.as_ref().expect("CudaStream should not be null")
     }
+}
+
+pub(crate) fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> Result<&ffi::CudaStreamView> {
+    stream
+        .as_ref()
+        .ok_or(CuDFError::NullHandle("CUDA stream view"))
+}
+
+pub(crate) fn resource_ref(
+    resource: &UniquePtr<ffi::DeviceAsyncResourceRef>,
+) -> Result<&ffi::DeviceAsyncResourceRef> {
+    resource
+        .as_ref()
+        .ok_or(CuDFError::NullHandle("current device resource ref"))
 }
 
 impl Default for CuDFStream {

--- a/src/table.rs
+++ b/src/table.rs
@@ -80,7 +80,13 @@ impl CuDFTable {
             ArrowError::InvalidArgumentError("Path contains invalid UTF-8".to_string())
         })?;
 
-        let inner = ffi::read_parquet(path_str)?;
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let inner = ffi::read_parquet(
+            path_str,
+            crate::stream::stream_ref(&stream)?,
+            crate::stream::resource_ref(&mr)?,
+        )?;
         Ok(Self { inner })
     }
 
@@ -111,7 +117,8 @@ impl CuDFTable {
         })?;
 
         let view = self.inner.view();
-        ffi::write_parquet(&view, path_str)?;
+        let stream = ffi::get_default_stream();
+        ffi::write_parquet(&view, path_str, crate::stream::stream_ref(&stream)?)?;
         Ok(())
     }
 
@@ -166,8 +173,8 @@ impl CuDFTable {
             ffi::table_from_arrow_host(
                 schema_ptr,
                 device_array_ptr,
-                stream.as_ref().expect("default stream should not be null"),
-                mr.as_ref().expect("device resource should not be null"),
+                crate::stream::stream_ref(&stream)?,
+                crate::stream::resource_ref(&mr)?,
             )
         }?;
 
@@ -278,7 +285,13 @@ impl CuDFTable {
                 v.into_inner()
             })
             .collect();
-        let inner = ffi::concat_table_views(&inner_views)?;
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let inner = ffi::concat_table_views(
+            &inner_views,
+            crate::stream::stream_ref(&stream)?,
+            crate::stream::resource_ref(&mr)?,
+        )?;
         Ok(Self { inner })
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,4 +1,5 @@
 use crate::cudf_array::is_cudf_array;
+use crate::stream::{resource_ref, stream_ref};
 use crate::table_view::CuDFTableView;
 use crate::{CuDFColumn, CuDFError};
 use arrow::array::{Array, ArrayData, StructArray};
@@ -82,11 +83,7 @@ impl CuDFTable {
 
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        let inner = ffi::read_parquet(
-            path_str,
-            crate::stream::stream_ref(&stream)?,
-            crate::stream::resource_ref(&mr)?,
-        )?;
+        let inner = ffi::read_parquet(path_str, stream_ref(&stream)?, resource_ref(&mr)?)?;
         Ok(Self { inner })
     }
 
@@ -118,7 +115,7 @@ impl CuDFTable {
 
         let view = self.inner.view();
         let stream = ffi::get_default_stream();
-        ffi::write_parquet(&view, path_str, crate::stream::stream_ref(&stream)?)?;
+        ffi::write_parquet(&view, path_str, stream_ref(&stream)?)?;
         Ok(())
     }
 
@@ -173,8 +170,8 @@ impl CuDFTable {
             ffi::table_from_arrow_host(
                 schema_ptr,
                 device_array_ptr,
-                crate::stream::stream_ref(&stream)?,
-                crate::stream::resource_ref(&mr)?,
+                stream_ref(&stream)?,
+                resource_ref(&mr)?,
             )
         }?;
 
@@ -287,11 +284,8 @@ impl CuDFTable {
             .collect();
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        let inner = ffi::concat_table_views(
-            &inner_views,
-            crate::stream::stream_ref(&stream)?,
-            crate::stream::resource_ref(&mr)?,
-        )?;
+        let inner =
+            ffi::concat_table_views(&inner_views, stream_ref(&stream)?, resource_ref(&mr)?)?;
         Ok(Self { inner })
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,6 @@
 use crate::cudf_array::is_cudf_array;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::table_view::CuDFTableView;
 use crate::{CuDFColumn, CuDFError};
 use arrow::array::{Array, ArrayData, StructArray};

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -164,8 +164,13 @@ impl CuDFTableView {
         unsafe {
             self.inner
                 .to_arrow_schema(&mut ffi_schema as *mut FFI_ArrowSchema as *mut u8);
-            self.inner
-                .to_arrow_array(&mut ffi_array as *mut FFI_ArrowArray as *mut u8);
+            let stream = ffi::get_default_stream();
+            let mr = ffi::get_current_device_resource_ref();
+            self.inner.to_arrow_array(
+                &mut ffi_array as *mut FFI_ArrowArray as *mut u8,
+                crate::stream::stream_ref(&stream)?,
+                crate::stream::resource_ref(&mr)?,
+            );
         }
 
         let schema = Arc::new(Schema::try_from(&ffi_schema)?);

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -1,5 +1,6 @@
 use crate::cudf_reference::CuDFRef;
-use crate::stream::{resource_ref, stream_ref};
+use crate::device_resource::resource_ref;
+use crate::stream::stream_ref;
 use crate::{CuDFColumnView, CuDFError};
 use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
 use arrow::ffi::{from_ffi, FFI_ArrowArray};

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -1,4 +1,5 @@
 use crate::cudf_reference::CuDFRef;
+use crate::stream::{resource_ref, stream_ref};
 use crate::{CuDFColumnView, CuDFError};
 use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
 use arrow::ffi::{from_ffi, FFI_ArrowArray};
@@ -168,8 +169,8 @@ impl CuDFTableView {
             let mr = ffi::get_current_device_resource_ref();
             self.inner.to_arrow_array(
                 &mut ffi_array as *mut FFI_ArrowArray as *mut u8,
-                crate::stream::stream_ref(&stream)?,
-                crate::stream::resource_ref(&mr)?,
+                stream_ref(&stream)?,
+                resource_ref(&mr)?,
             );
         }
 


### PR DESCRIPTION

Libcudf-sys is an ffi layer wrapping lubcudf cpp functions such as
```
std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> aggregate(
    host_span<aggregation_request const> requests,
    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
```
as rust functions like
```
fn aggregate(
    self: &GroupBy,
    requests: &AggregationRequests,
    ) -> Result<UniquePtr<GroupByResult>>;
```

However, we are missing the `stream` and `mr` arguments, so we are forced to use the default
`stream` and `mr`.

This change adds the missing arguments to `libcudf-sys` wrapper functions:
```
fn aggregate(
    self: &GroupBy,
    requests: &AggregationRequests,
    stream: &CudaStreamView,
    mr: &DeviceAsyncResourceRef,
) -> Result<UniquePtr<GroupByResult>>;
```

You can obtain the default `stream` and `mr` by doing so
```
let stream = ffi::get_default_stream();
let mr = ffi::get_current_device_resource_ref();
```
And pass them in as arguments like so
```
let mut gby_result = self.inner.aggregate(
    &requests_inner,
    stream::stream_ref(&stream)?, // small wrapper which errors if the stream is null, which it should never be
    stream::resource_ref(&mr)?,
)?;
```