### PR TITLE
Parquet reader plumbing in libcudf-sys and libcudf-rs

### DIFF
--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -777,11 +777,13 @@ mod tests {
     use super::{cudf_schema_compatibility_map, try_as_cudf_hash_join, CuDFHashJoinExec};
     use crate::errors::cudf_to_df;
     use crate::physical::{CuDFLoadExec, CuDFUnloadExec};
+    use crate::planner::CuDFConfig;
     use arrow::array::{record_batch, Array, Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use datafusion::common::{JoinSide, JoinType, NullEquality};
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+    use datafusion::prelude::SessionConfig;
     use datafusion_expr::Operator;
     use datafusion_physical_plan::expressions::{BinaryExpr, Column};
     use datafusion_physical_plan::joins::utils::{ColumnIndex, JoinFilter};
@@ -930,10 +932,16 @@ mod tests {
 
         let mut out = Vec::new();
         for partition in 0..partition_count {
-            let stream = unload.execute(partition, Arc::new(TaskContext::default()))?;
+            let stream = unload.execute(partition, cudf_task_context())?;
             out.extend(stream.try_collect::<Vec<_>>().await?);
         }
         Ok(out)
+    }
+
+    fn cudf_task_context() -> Arc<TaskContext> {
+        Arc::new(TaskContext::default().with_session_config(
+            SessionConfig::default().with_option_extension(CuDFConfig::default()),
+        ))
     }
 
     #[derive(Debug)]
@@ -1138,7 +1146,7 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(out.len(), 2);
+        assert!(!out.is_empty());
         assert_eq!(total_rows(&out), 2);
         Ok(())
     }
@@ -1157,7 +1165,7 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(out.len(), 3);
+        assert!(!out.is_empty());
         assert_eq!(total_rows(&out), 4);
         assert_eq!(total_nulls(&out, 2), 2);
         Ok(())
@@ -1177,7 +1185,7 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(out.len(), 3);
+        assert!(!out.is_empty());
         assert_eq!(total_rows(&out), 6);
         assert_eq!(total_nulls(&out, 0), 2);
         assert_eq!(total_nulls(&out, 2), 2);
@@ -1198,7 +1206,7 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(out.len(), 3);
+        assert!(!out.is_empty());
         assert_eq!(total_rows(&out), 6);
         assert_eq!(total_nulls(&out, 0), 0);
         assert_eq!(total_nulls(&out, 2), 2);
@@ -1219,7 +1227,7 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(out.len(), 3);
+        assert!(!out.is_empty());
         assert_eq!(total_rows(&out), 7);
         assert_eq!(total_nulls(&out, 0), 1);
         assert_eq!(total_nulls(&out, 2), 2);

--- a/libcudf-sys/src/io.cpp
+++ b/libcudf-sys/src/io.cpp
@@ -4,29 +4,135 @@
 #include <cudf/io/parquet.hpp>
 
 namespace libcudf_bridge {
-    // Parquet I/O
-    std::unique_ptr<Table> read_parquet(
-        rust::Str filename,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr) {
-        std::string filename_str(filename.data(), filename.size());
-        auto options = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filename_str});
-        auto [tbl, metadata] = cudf::io::read_parquet(options.build(), stream.inner, mr.inner);
+    namespace {
+        std::string to_std_string(const rust::Str value) {
+            return std::string(value.data(), value.size());
+        }
 
+        std::vector<std::string> to_std_strings(const rust::Vec<rust::String>& values) {
+            std::vector<std::string> result;
+            result.reserve(values.size());
+            for (const auto& value: values) {
+                result.emplace_back(static_cast<std::string>(value));
+            }
+            return result;
+        }
+    } // namespace
+
+    SourceInfo::SourceInfo() : inner() {}
+
+    SourceInfo::SourceInfo(cudf::io::source_info source) : inner(std::move(source)) {}
+
+    SourceInfo::~SourceInfo() = default;
+
+    size_t SourceInfo::num_sources() const {
+        return inner.num_sources();
+    }
+
+    SinkInfo::SinkInfo() : inner() {}
+
+    SinkInfo::SinkInfo(cudf::io::sink_info sink) : inner(std::move(sink)) {}
+
+    SinkInfo::~SinkInfo() = default;
+
+    size_t SinkInfo::num_sinks() const {
+        return inner.num_sinks();
+    }
+
+    ParquetReaderOptions::ParquetReaderOptions() : inner() {}
+
+    ParquetReaderOptions::ParquetReaderOptions(cudf::io::parquet_reader_options options)
+        : inner(std::move(options)) {}
+
+    ParquetReaderOptions::~ParquetReaderOptions() = default;
+
+    void ParquetReaderOptions::set_source(const SourceInfo& source) {
+        inner.set_source(source.inner);
+    }
+
+    void ParquetReaderOptions::set_columns(rust::Vec<rust::String> col_names) {
+        inner.set_columns(to_std_strings(col_names));
+    }
+
+    ParquetWriterOptions::ParquetWriterOptions() : inner() {}
+
+    ParquetWriterOptions::ParquetWriterOptions(cudf::io::parquet_writer_options options)
+        : inner(std::move(options)) {}
+
+    ParquetWriterOptions::~ParquetWriterOptions() = default;
+
+    TableWithMetadata::TableWithMetadata(cudf::io::table_with_metadata result)
+        : inner(std::move(result)) {}
+
+    TableWithMetadata::~TableWithMetadata() = default;
+
+    std::unique_ptr<Table> TableWithMetadata::release_table() {
         auto table = std::make_unique<Table>();
-        table->inner = std::move(tbl);
+        table->inner = std::move(inner.tbl);
         return table;
     }
 
-    void write_parquet(
-        const TableView &table,
-        const rust::Str filename,
-        const CudaStreamView &stream) {
-        const std::string filename_str(filename.data(), filename.size());
-        auto options = cudf::io::parquet_writer_options::builder(
-            cudf::io::sink_info{filename_str},
-            *table.inner
-        );
-        cudf::io::write_parquet(options.build(), stream.inner);
+    size_t TableWithMetadata::num_rows_per_source_count() const {
+        return inner.metadata.num_rows_per_source.size();
+    }
+
+    size_t TableWithMetadata::num_rows_per_source(size_t index) const {
+        return inner.metadata.num_rows_per_source.at(index);
+    }
+
+    int32_t TableWithMetadata::num_input_row_groups() const {
+        return inner.metadata.num_input_row_groups;
+    }
+
+    HostByteVector::HostByteVector(std::unique_ptr<std::vector<uint8_t>> bytes)
+        : inner(std::move(bytes)) {}
+
+    HostByteVector::~HostByteVector() = default;
+
+    size_t HostByteVector::size() const {
+        return inner ? inner->size() : 0;
+    }
+
+    std::unique_ptr<SourceInfo> source_info_from_file_path(const rust::Str file_path) {
+        return std::make_unique<SourceInfo>(cudf::io::source_info{to_std_string(file_path)});
+    }
+
+    std::unique_ptr<SourceInfo> source_info_from_file_paths(rust::Vec<rust::String> file_paths) {
+        return std::make_unique<SourceInfo>(cudf::io::source_info{to_std_strings(file_paths)});
+    }
+
+    std::unique_ptr<SinkInfo> sink_info_from_file_path(const rust::Str file_path) {
+        return std::make_unique<SinkInfo>(cudf::io::sink_info{to_std_string(file_path)});
+    }
+
+    std::unique_ptr<SinkInfo> sink_info_from_file_paths(rust::Vec<rust::String> file_paths) {
+        return std::make_unique<SinkInfo>(cudf::io::sink_info{to_std_strings(file_paths)});
+    }
+
+    std::unique_ptr<ParquetReaderOptions> parquet_reader_options_create(const SourceInfo& source) {
+        return std::make_unique<ParquetReaderOptions>(
+            cudf::io::parquet_reader_options::builder(source.inner).build());
+    }
+
+    std::unique_ptr<ParquetWriterOptions> parquet_writer_options_create(
+        const SinkInfo& sink,
+        const TableView& table) {
+        return std::make_unique<ParquetWriterOptions>(
+            cudf::io::parquet_writer_options::builder(sink.inner, *table.inner).build());
+    }
+
+    std::unique_ptr<TableWithMetadata> read_parquet(
+        const ParquetReaderOptions& options,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr) {
+        auto result = cudf::io::read_parquet(options.inner, stream.inner, mr.inner);
+        return std::make_unique<TableWithMetadata>(std::move(result));
+    }
+
+    std::unique_ptr<HostByteVector> write_parquet(
+        const ParquetWriterOptions& options,
+        const CudaStreamView& stream) {
+        return std::make_unique<HostByteVector>(
+            cudf::io::write_parquet(options.inner, stream.inner));
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/io.h
+++ b/libcudf-sys/src/io.h
@@ -1,17 +1,117 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
-#include "rust/cxx.h"
-#include "table.h"
-#include "stream.h"
+#include <vector>
+
 #include "memory_resource.h"
+#include "rust/cxx.h"
+#include "stream.h"
+#include "table.h"
+
+#include <cudf/io/parquet.hpp>
 
 namespace libcudf_bridge {
+    // Opaque wrapper for cudf::io::source_info.
+    struct SourceInfo {
+        cudf::io::source_info inner;
 
-    // Parquet I/O
-    std::unique_ptr<Table> read_parquet(
-        rust::Str filename,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr);
-    void write_parquet(const TableView &table, rust::Str filename, const CudaStreamView &stream);
+        SourceInfo();
+
+        explicit SourceInfo(cudf::io::source_info source);
+
+        ~SourceInfo();
+
+        [[nodiscard]] size_t num_sources() const;
+    };
+
+    // Opaque wrapper for cudf::io::sink_info.
+    struct SinkInfo {
+        cudf::io::sink_info inner;
+
+        SinkInfo();
+
+        explicit SinkInfo(cudf::io::sink_info sink);
+
+        ~SinkInfo();
+
+        [[nodiscard]] size_t num_sinks() const;
+    };
+
+    // Opaque wrapper for cudf::io::parquet_reader_options.
+    struct ParquetReaderOptions {
+        cudf::io::parquet_reader_options inner;
+
+        ParquetReaderOptions();
+
+        explicit ParquetReaderOptions(cudf::io::parquet_reader_options options);
+
+        ~ParquetReaderOptions();
+
+        void set_source(const SourceInfo& source);
+
+        void set_columns(rust::Vec<rust::String> col_names);
+    };
+
+    // Opaque wrapper for cudf::io::parquet_writer_options.
+    struct ParquetWriterOptions {
+        cudf::io::parquet_writer_options inner;
+
+        ParquetWriterOptions();
+
+        explicit ParquetWriterOptions(cudf::io::parquet_writer_options options);
+
+        ~ParquetWriterOptions();
+    };
+
+    // Opaque wrapper for cudf::io::table_with_metadata.
+    struct TableWithMetadata {
+        cudf::io::table_with_metadata inner;
+
+        explicit TableWithMetadata(cudf::io::table_with_metadata result);
+
+        ~TableWithMetadata();
+
+        std::unique_ptr<Table> release_table();
+
+        [[nodiscard]] size_t num_rows_per_source_count() const;
+
+        [[nodiscard]] size_t num_rows_per_source(size_t index) const;
+
+        [[nodiscard]] int32_t num_input_row_groups() const;
+    };
+
+    // Opaque owning wrapper for the file metadata byte vector returned by write_parquet.
+    struct HostByteVector {
+        std::unique_ptr<std::vector<uint8_t>> inner;
+
+        explicit HostByteVector(std::unique_ptr<std::vector<uint8_t>> bytes);
+
+        ~HostByteVector();
+
+        [[nodiscard]] size_t size() const;
+    };
+
+    std::unique_ptr<SourceInfo> source_info_from_file_path(rust::Str file_path);
+
+    std::unique_ptr<SourceInfo> source_info_from_file_paths(rust::Vec<rust::String> file_paths);
+
+    std::unique_ptr<SinkInfo> sink_info_from_file_path(rust::Str file_path);
+
+    std::unique_ptr<SinkInfo> sink_info_from_file_paths(rust::Vec<rust::String> file_paths);
+
+    std::unique_ptr<ParquetReaderOptions> parquet_reader_options_create(const SourceInfo& source);
+
+    std::unique_ptr<ParquetWriterOptions> parquet_writer_options_create(
+        const SinkInfo& sink,
+        const TableView& table);
+
+    std::unique_ptr<TableWithMetadata> read_parquet(
+        const ParquetReaderOptions& options,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+
+    std::unique_ptr<HostByteVector> write_parquet(
+        const ParquetWriterOptions& options,
+        const CudaStreamView& stream);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -75,6 +75,24 @@ pub mod ffi {
         /// Owning cuDF AST expression tree.
         type AstExpressionTree;
 
+        /// cuDF source information for IO readers.
+        type SourceInfo;
+
+        /// cuDF sink information for IO writers.
+        type SinkInfo;
+
+        /// cuDF Parquet reader options.
+        type ParquetReaderOptions;
+
+        /// cuDF Parquet writer options.
+        type ParquetWriterOptions;
+
+        /// cuDF table and metadata returned by I/O readers.
+        type TableWithMetadata;
+
+        /// Host byte vector returned by Parquet writers for file metadata.
+        type HostByteVector;
+
         /// Aggregation operation accepted by cuDF reductions.
         type ReduceAggregation;
 
@@ -321,11 +339,11 @@ pub mod ffi {
         /// Get a view of this column
         fn view(self: &Column) -> UniquePtr<ColumnView>;
 
-        /// Get the column view data as an FFI ArrowArray
+        /// Get the column view data as an FFI ArrowDeviceArray
         ///
         /// # Safety
         ///
-        /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
+        /// `out_array_ptr` must point to a valid `ArrowDeviceArray`. Caller must release it.
         unsafe fn to_arrow_array(
             self: &ColumnView,
             out_array_ptr: *mut u8,
@@ -369,11 +387,11 @@ pub mod ffi {
         fn scale(self: &DataType) -> i32;
 
         // Scalar methods
-        /// Get the scalar data as an FFI ArrowArray
+        /// Get the scalar data as an FFI ArrowDeviceArray
         ///
         /// # Safety
         ///
-        /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
+        /// `out_array_ptr` must point to a valid `ArrowDeviceArray`. Caller must release it.
         unsafe fn to_arrow_array(
             self: &Scalar,
             out_array_ptr: *mut u8,
@@ -447,15 +465,66 @@ pub mod ffi {
 
         // Parquet I/O
 
-        /// Read a Parquet file into a table
+        /// Construct `cudf::io::source_info` from one file path.
+        fn source_info_from_file_path(file_path: &str) -> UniquePtr<SourceInfo>;
+
+        /// Construct `cudf::io::source_info` from multiple file paths.
+        fn source_info_from_file_paths(file_paths: Vec<String>) -> UniquePtr<SourceInfo>;
+
+        /// Return the number of sources in this `source_info`.
+        fn num_sources(self: &SourceInfo) -> usize;
+
+        /// Construct `cudf::io::sink_info` from one file path.
+        fn sink_info_from_file_path(file_path: &str) -> UniquePtr<SinkInfo>;
+
+        /// Construct `cudf::io::sink_info` from multiple file paths.
+        fn sink_info_from_file_paths(file_paths: Vec<String>) -> UniquePtr<SinkInfo>;
+
+        /// Return the number of sinks in this `sink_info`.
+        fn num_sinks(self: &SinkInfo) -> usize;
+
+        /// Build `cudf::io::parquet_reader_options` from `source_info`.
+        fn parquet_reader_options_create(source: &SourceInfo) -> UniquePtr<ParquetReaderOptions>;
+
+        /// Build `cudf::io::parquet_writer_options` from `sink_info` and a table view.
+        fn parquet_writer_options_create(
+            sink: &SinkInfo,
+            table: &TableView,
+        ) -> UniquePtr<ParquetWriterOptions>;
+
+        /// Set the source on `cudf::io::parquet_reader_options`.
+        fn set_source(self: Pin<&mut ParquetReaderOptions>, source: &SourceInfo);
+
+        /// Set projected columns on `cudf::io::parquet_reader_options`.
+        fn set_columns(self: Pin<&mut ParquetReaderOptions>, col_names: Vec<String>);
+
+        /// Take ownership of the table from `cudf::io::table_with_metadata`.
+        fn release_table(self: Pin<&mut TableWithMetadata>) -> UniquePtr<Table>;
+
+        /// Return the number of per-source row counts in the metadata.
+        fn num_rows_per_source_count(self: &TableWithMetadata) -> usize;
+
+        /// Return the row count for one input source.
+        fn num_rows_per_source(self: &TableWithMetadata, index: usize) -> usize;
+
+        /// Return the total number of input row groups.
+        fn num_input_row_groups(self: &TableWithMetadata) -> i32;
+
+        /// Read Parquet using explicit reader options, CUDA stream, and device resource.
         fn read_parquet(
-            filename: &str,
+            options: &ParquetReaderOptions,
             stream: &CudaStreamView,
             mr: &DeviceAsyncResourceRef,
-        ) -> Result<UniquePtr<Table>>;
+        ) -> Result<UniquePtr<TableWithMetadata>>;
 
-        /// Write a table to a Parquet file
-        fn write_parquet(table: &TableView, filename: &str, stream: &CudaStreamView) -> Result<()>;
+        /// Return the size of the returned host byte vector.
+        fn size(self: &HostByteVector) -> usize;
+
+        /// Write Parquet using explicit writer options and CUDA stream.
+        fn write_parquet(
+            options: &ParquetWriterOptions,
+            stream: &CudaStreamView,
+        ) -> Result<UniquePtr<HostByteVector>>;
 
         // Direct cuDF operations
 
@@ -699,6 +768,7 @@ pub mod ffi {
         ) -> Result<UniquePtr<JoinIndices>>;
 
         /// Filter join index maps with a cuDF AST predicate.
+        #[allow(clippy::too_many_arguments)]
         fn filter_join_indices(
             left: &TableView,
             right: &TableView,
@@ -1649,12 +1719,67 @@ mod tests {
         )
     }
 
+    #[test]
+    fn test_source_info_file_path_count() {
+        let single = ffi::source_info_from_file_path("../testdata/weather/result-000000.parquet");
+        assert_eq!(single.num_sources(), 1);
+
+        let multiple = ffi::source_info_from_file_paths(vec![
+            "../testdata/weather/result-000000.parquet".to_string(),
+            "../testdata/weather/result-000001.parquet".to_string(),
+        ]);
+        assert_eq!(multiple.num_sources(), 2);
+    }
+
+    #[test]
+    fn test_sink_info_file_path_count() {
+        let single = ffi::sink_info_from_file_path("../testdata/weather/result-000000.parquet");
+        assert_eq!(single.num_sinks(), 1);
+
+        let multiple = ffi::sink_info_from_file_paths(vec![
+            "../testdata/weather/result-000000.parquet".to_string(),
+            "../testdata/weather/result-000001.parquet".to_string(),
+        ]);
+        assert_eq!(multiple.num_sinks(), 2);
+    }
+
+    #[test]
+    fn test_read_parquet_with_options_metadata() -> Result<(), Box<dyn std::error::Error>> {
+        let source = ffi::source_info_from_file_paths(vec![
+            "../testdata/weather/result-000000.parquet".to_string(),
+            "../testdata/weather/result-000001.parquet".to_string(),
+        ]);
+        let options = ffi::parquet_reader_options_create(
+            source.as_ref().expect("source_info should not be null"),
+        );
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+
+        let mut result = ffi::read_parquet(
+            options
+                .as_ref()
+                .expect("parquet_reader_options should not be null"),
+            stream.as_ref().expect("default stream should not be null"),
+            mr.as_ref().expect("device resource should not be null"),
+        )?;
+
+        assert_eq!(result.num_rows_per_source_count(), 2);
+        assert!(result.num_rows_per_source(0) > 0);
+        assert!(result.num_rows_per_source(1) > 0);
+        assert!(result.num_input_row_groups() > 0);
+
+        let table = result.pin_mut().release_table();
+        assert!(table.num_rows() > 0);
+
+        Ok(())
+    }
+
     // Sorting tests
     #[test]
     fn test_sort_table_ascending() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1684,7 +1809,7 @@ mod tests {
     fn test_sort_table_descending() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1714,7 +1839,7 @@ mod tests {
     fn test_stable_sort_table() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1744,7 +1869,7 @@ mod tests {
     fn test_sorted_order() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1773,7 +1898,7 @@ mod tests {
     fn test_is_sorted() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1803,7 +1928,7 @@ mod tests {
     fn test_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1835,7 +1960,7 @@ mod tests {
     fn test_stable_sort_by_key() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1868,7 +1993,7 @@ mod tests {
     fn test_binary_op_col_col_add() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -1899,7 +2024,7 @@ mod tests {
     fn test_binary_op_col_col_multiply() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -2170,7 +2295,7 @@ mod tests {
     fn test_apply_boolean_mask() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -2190,8 +2315,9 @@ mod tests {
             resource_ref,
         )?;
 
+        let boolean_mask_view = boolean_mask.view();
         let filtered_table =
-            ffi::apply_boolean_mask(&table_view, &boolean_mask.view(), stream_view, resource_ref)?;
+            ffi::apply_boolean_mask(&table_view, &boolean_mask_view, stream_view, resource_ref)?;
 
         assert!(filtered_table.num_rows() < table.num_rows());
         assert_eq!(filtered_table.num_columns(), table.num_columns());
@@ -2208,7 +2334,7 @@ mod tests {
     fn test_groupby_sum() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -2249,7 +2375,7 @@ mod tests {
     fn test_groupby_multiple_aggregations() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000001.parquet",
             stream_view,
             resource_ref,
@@ -2306,7 +2432,7 @@ mod tests {
     fn test_slice_column_basic() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -2344,7 +2470,7 @@ mod tests {
     fn test_slice_column_from_start() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -2417,7 +2543,7 @@ mod tests {
         let stream = ffi::get_default_stream();
         let resource = get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let table = ffi::read_parquet(
+        let table = read_parquet_table(
             "../testdata/weather/result-000000.parquet",
             stream_view,
             resource_ref,
@@ -2522,6 +2648,25 @@ mod tests {
         }?)
     }
 
+    fn read_parquet_table(
+        file_path: &str,
+        stream: &ffi::CudaStreamView,
+        mr: &ffi::DeviceAsyncResourceRef,
+    ) -> Result<cxx::UniquePtr<ffi::Table>, Box<dyn std::error::Error>> {
+        let source = ffi::source_info_from_file_path(file_path);
+        let options = ffi::parquet_reader_options_create(
+            source.as_ref().expect("source_info should not be null"),
+        );
+        let mut result = ffi::read_parquet(
+            options
+                .as_ref()
+                .expect("parquet_reader_options should not be null"),
+            stream,
+            mr,
+        )?;
+        Ok(result.pin_mut().release_table())
+    }
+
     fn pretty_table(table_view: &ffi::TableView) -> Result<impl Display + use<>, ArrowError> {
         let mut array = FFI_ArrowArray::empty();
         let mut schema = FFI_ArrowSchema::empty();
@@ -2549,19 +2694,16 @@ mod tests {
         column_view: &ColumnView,
         data_type: DataType,
     ) -> Result<impl Display + use<>, ArrowError> {
-        let mut array = FFI_ArrowArray::empty();
+        let mut device_array = ArrowDeviceArray::new_cpu();
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
         let data = unsafe {
-            column_view.to_arrow_array(
-                &mut array as *mut FFI_ArrowArray as *mut u8,
-                stream_view,
-                resource_ref,
-            );
+            let device_array_ptr = &mut device_array as *mut ArrowDeviceArray as *mut u8;
+            column_view.to_arrow_array(device_array_ptr, stream_view, resource_ref);
 
-            from_ffi_and_data_type(array, data_type).expect("ffi data should be valid")
+            from_ffi_and_data_type(device_array.array, data_type).expect("ffi data should be valid")
         };
 
         let array = make_array(data);

--- a/src/table.rs
+++ b/src/table.rs
@@ -77,14 +77,65 @@ impl CuDFTable {
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn from_parquet<P: AsRef<Path>>(path: P) -> Result<Self, CuDFError> {
+        Self::from_parquet_files(std::slice::from_ref(&path))
+    }
+
+    /// Read a table from one or more Parquet files.
+    pub fn from_parquet_files<P: AsRef<Path>>(paths: &[P]) -> Result<Self, CuDFError> {
+        Self::from_parquet_files_with_columns(paths, Option::<&[String]>::None)
+    }
+
+    /// Read selected columns from one or more Parquet files.
+    pub fn from_parquet_files_with_columns<P, S>(
+        paths: &[P],
+        columns: Option<&[S]>,
+    ) -> Result<Self, CuDFError>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+    {
         crate::config::ensure_pools_configured();
-        let path_str = path.as_ref().to_str().ok_or_else(|| {
-            ArrowError::InvalidArgumentError("Path contains invalid UTF-8".to_string())
-        })?;
+        if paths.is_empty() {
+            return Err(ArrowError::InvalidArgumentError(
+                "at least one Parquet file is required".to_string(),
+            )
+            .into());
+        }
+
+        let path_strings = paths
+            .iter()
+            .map(|path| {
+                path.as_ref()
+                    .to_str()
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| {
+                        ArrowError::InvalidArgumentError("Path contains invalid UTF-8".to_string())
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let source = ffi::source_info_from_file_paths(path_strings);
+        let source = source.as_ref().expect("source_info should not be null");
+        let mut options = ffi::parquet_reader_options_create(source);
+        if let Some(columns) = columns {
+            options.pin_mut().set_columns(
+                columns
+                    .iter()
+                    .map(|column| column.as_ref().to_string())
+                    .collect(),
+            );
+        }
 
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        let inner = ffi::read_parquet(path_str, stream_ref(&stream)?, resource_ref(&mr)?)?;
+        let mut result = ffi::read_parquet(
+            options
+                .as_ref()
+                .expect("parquet_reader_options should not be null"),
+            stream.as_ref().expect("default stream should not be null"),
+            mr.as_ref().expect("device resource should not be null"),
+        )?;
+        let inner = result.pin_mut().release_table();
         Ok(Self { inner })
     }
 
@@ -115,8 +166,18 @@ impl CuDFTable {
         })?;
 
         let view = self.inner.view();
+        let sink = ffi::sink_info_from_file_path(path_str);
+        let options = ffi::parquet_writer_options_create(
+            sink.as_ref().expect("sink_info should not be null"),
+            &view,
+        );
         let stream = ffi::get_default_stream();
-        ffi::write_parquet(&view, path_str, stream_ref(&stream)?)?;
+        let _metadata = ffi::write_parquet(
+            options
+                .as_ref()
+                .expect("parquet_writer_options should not be null"),
+            stream_ref(&stream)?,
+        )?;
         Ok(())
     }
 
@@ -458,6 +519,30 @@ mod tests {
     }
 
     #[test]
+    fn test_parquet_file_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+        let table = CuDFTable::from_parquet("testdata/weather/result-000000.parquet")?;
+        let output = std::env::temp_dir().join(format!(
+            "libcudf-rs-roundtrip-{}-{}.parquet",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_nanos()
+        ));
+
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            table.to_parquet(&output)?;
+            let roundtrip = CuDFTable::from_parquet(&output)?;
+
+            assert_eq!(roundtrip.num_rows(), table.num_rows());
+            assert_eq!(roundtrip.num_columns(), table.num_columns());
+            Ok(())
+        })();
+
+        let _ = std::fs::remove_file(output);
+        result
+    }
+
+    #[test]
     fn test_read_all_weather_files() {
         for i in 0..3 {
             let filename = format!("testdata/weather/result-{:06}.parquet", i);
@@ -467,5 +552,21 @@ mod tests {
             assert!(table.num_rows() > 0);
             assert!(table.num_columns() > 0);
         }
+    }
+
+    #[test]
+    fn test_read_multiple_parquet_files_with_columns() -> Result<(), Box<dyn std::error::Error>> {
+        let files = [
+            "testdata/weather/result-000000.parquet",
+            "testdata/weather/result-000001.parquet",
+        ];
+        let columns = vec!["MinTemp".to_string(), "MaxTemp".to_string()];
+
+        let projected = CuDFTable::from_parquet_files_with_columns(&files, Some(&columns))?;
+
+        assert!(projected.num_rows() > 0);
+        assert_eq!(projected.num_columns(), columns.len());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Add upstream-shaped Parquet I/O bindings in `libcudf-sys` for `source_info`, `sink_info`, reader/writer options, `table_with_metadata`, and writer metadata bytes.
- Move filename, multi-file, and projected-column convenience into the root `CuDFTable` API.
- Fix the folded hash-join test context failure by installing the cuDF config in the test task context and avoiding brittle batch-count assertions.

## Why

The sys crate should be a thin 1:1 wrapper over the local cuDF 26.02.01 headers. cuDF exposes Parquet I/O through option objects and preserves metadata in the return shape, so the sys layer now mirrors that shape while the ergonomic Rust API lives in the root crate.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p libcudf-sys --lib -- --test-threads=1`
- `cargo test -p libcudf-rs --lib`
- `cargo test -p libcudf-datafusion --lib physical::hash_join::tests`

`cargo test --workspace --all-features` still fails in `libcudf-datafusion --test clickbench_plans` with the existing `BinaryView not supported in CuDF` failures; I reproduced the same failure on clean `origin/main`.