### PR TITLE
[codex] Handle DataFusion string view compatibility

### DIFF
--- a/libcudf-datafusion-benchmarks/src/datasets/common.rs
+++ b/libcudf-datafusion-benchmarks/src/datasets/common.rs
@@ -70,6 +70,20 @@ pub fn get_query(path: &str, id: &str) -> Result<String, DataFusionError> {
     Ok(query_sql)
 }
 
+/// Applies DataFusion settings declared as SQL comments in benchmark queries.
+///
+/// For example, a query can include
+/// `-- set datafusion.execution.parquet.binary_as_string = true`.
+pub async fn apply_query_settings(
+    ctx: &SessionContext,
+    query_sql: &str,
+) -> Result<(), DataFusionError> {
+    for statement in query_setting_statements(query_sql) {
+        ctx.sql(&statement).await?;
+    }
+    Ok(())
+}
+
 pub async fn register_tables(
     ctx: &SessionContext,
     data_path: &Path,
@@ -87,4 +101,34 @@ pub async fn register_tables(
         }
     }
     Ok(())
+}
+
+fn query_setting_statements(query_sql: &str) -> impl Iterator<Item = String> + '_ {
+    query_sql.lines().filter_map(|line| {
+        let directive = line.trim().strip_prefix("--")?.trim_start();
+        let setting = directive.strip_prefix("set ")?;
+        let setting = setting.trim().trim_end_matches(';').trim();
+        (!setting.is_empty()).then(|| format!("SET {setting}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::query_setting_statements;
+
+    #[test]
+    fn test_query_setting_statements() -> Result<(), Box<dyn std::error::Error>> {
+        let statements = query_setting_statements(
+            "-- ignored\n\
+             -- set datafusion.execution.parquet.binary_as_string = true;\n\
+             SELECT * FROM hits",
+        )
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            statements,
+            vec!["SET datafusion.execution.parquet.binary_as_string = true"]
+        );
+        Ok(())
+    }
 }

--- a/libcudf-datafusion-benchmarks/src/datasets/mod.rs
+++ b/libcudf-datafusion-benchmarks/src/datasets/mod.rs
@@ -3,4 +3,4 @@ mod common;
 pub mod tpcds;
 pub mod tpch;
 
-pub use common::register_tables;
+pub use common::{apply_query_settings, register_tables};

--- a/libcudf-datafusion-benchmarks/src/run.rs
+++ b/libcudf-datafusion-benchmarks/src/run.rs
@@ -27,7 +27,9 @@ use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::*;
 use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
 use libcudf_datafusion::{CuDFConfig, SessionStateBuilderExt};
-use libcudf_datafusion_benchmarks::datasets::{clickbench, register_tables, tpcds, tpch};
+use libcudf_datafusion_benchmarks::datasets::{
+    apply_query_settings, clickbench, register_tables, tpcds, tpch,
+};
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -184,16 +186,20 @@ impl RunOpt {
             ctx.register_udaf((*sum()).clone());
         }
 
+        let dataset_prefix = self.dataset.split("_").next().unwrap();
+        let queries = queries_for_dataset(dataset_prefix)?
+            .into_iter()
+            .filter(|(id, _)| self.query.is_empty() || self.query.contains(id))
+            .collect::<Vec<_>>();
+        for (_, sql) in &queries {
+            apply_query_settings(&ctx, sql).await?;
+        }
         register_tables(&ctx, &self.get_path()?).await?;
 
         println!("Running benchmarks with the following options: {self:?}");
         let mut benchmark_run = BenchmarkRun::new(self.dataset.clone(), self.gpu);
 
-        let dataset_prefix = self.dataset.split("_").next().unwrap();
-        for (id, sql) in queries_for_dataset(dataset_prefix)? {
-            if !self.query.is_empty() && !self.query.contains(&id.to_string()) {
-                continue;
-            }
+        for (id, sql) in queries {
             let query_id = format!("{} {id}", self.dataset);
             let query_run = self.benchmark_query(&query_id, &sql, &ctx).await;
             if let Err(e) = &query_run {

--- a/libcudf-datafusion/src/expr/ast.rs
+++ b/libcudf-datafusion/src/expr/ast.rs
@@ -107,8 +107,8 @@ fn can_lower_expr(expr: &dyn PhysicalExpr, column_indices: &[ColumnIndex]) -> bo
             .get(column.index())
             .is_some_and(|column_index| column_index.side != JoinSide::None);
     }
-    if any.downcast_ref::<Literal>().is_some() {
-        return true;
+    if let Some(literal) = any.downcast_ref::<Literal>() {
+        return normalize_scalar_for_cudf(literal.value().clone()).is_ok();
     }
     if let Some(cast) = any.downcast_ref::<CastExpr>() {
         return matches!(
@@ -181,7 +181,7 @@ fn lower_literal_expr(
     literal: &Literal,
     ast: &mut CuDFAstExpression,
 ) -> Result<CuDFAstNode, DataFusionError> {
-    let value = normalize_scalar_for_cudf(literal.value().clone());
+    let value = normalize_scalar_for_cudf(literal.value().clone())?;
     let scalar = CuDFScalar::from_arrow_host(value.to_scalar()?).map_err(cudf_to_df)?;
     ast.literal(scalar).map_err(cudf_to_df)
 }
@@ -227,7 +227,7 @@ mod tests {
     use super::{is_join_filter_supported_by_cudf_ast, join_filter_to_cudf_ast};
     use arrow::array::{Array, Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
-    use datafusion::common::{JoinSide, ScalarValue};
+    use datafusion::common::{DataFusionError, JoinSide, ScalarValue};
     use datafusion::physical_expr::expressions::{
         in_list, BinaryExpr, Column, IsNullExpr, Literal,
     };
@@ -282,6 +282,34 @@ mod tests {
 
         let batch = run_filtered_inner_join(filter)?;
         assert_eq!(batch.num_rows(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_filter_ast_checks_string_view_literals() -> Result<(), Box<dyn Error>> {
+        let filter = string_literal_filter(
+            DataType::Utf8View,
+            ScalarValue::Utf8View(Some("needle".to_string())),
+        );
+        assert!(is_join_filter_supported_by_cudf_ast(&filter)?);
+        join_filter_to_cudf_ast(&filter)?;
+
+        let filter = string_literal_filter(
+            DataType::BinaryView,
+            ScalarValue::BinaryView(Some(b"needle".to_vec())),
+        );
+        assert!(is_join_filter_supported_by_cudf_ast(&filter)?);
+        join_filter_to_cudf_ast(&filter)?;
+
+        let filter = string_literal_filter(
+            DataType::BinaryView,
+            ScalarValue::BinaryView(Some(vec![0xff])),
+        );
+        assert!(!is_join_filter_supported_by_cudf_ast(&filter)?);
+        let Err(err) = join_filter_to_cudf_ast(&filter) else {
+            panic!("invalid BinaryView literal should not lower");
+        };
+        assert!(matches!(err, DataFusionError::NotImplemented(_)));
         Ok(())
     }
 
@@ -371,6 +399,21 @@ mod tests {
             Field::new("left_val", DataType::Int32, true),
             Field::new("right_val", DataType::Int32, false),
         ]))
+    }
+
+    fn string_literal_filter(data_type: DataType, literal: ScalarValue) -> JoinFilter {
+        JoinFilter::new(
+            Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("left_text", 0)),
+                Operator::Eq,
+                Arc::new(Literal::new(literal)),
+            )) as Arc<dyn PhysicalExpr>,
+            vec![ColumnIndex {
+                index: 0,
+                side: JoinSide::Left,
+            }],
+            Arc::new(Schema::new(vec![Field::new("left_text", data_type, true)])),
+        )
     }
 
     fn filter_indices() -> Vec<ColumnIndex> {

--- a/libcudf-datafusion/src/expr/literal.rs
+++ b/libcudf-datafusion/src/expr/literal.rs
@@ -34,7 +34,7 @@ impl Hash for CuDFLiteral {
 
 impl CuDFLiteral {
     pub fn from_host(inner: Literal) -> datafusion::common::Result<Self> {
-        let value = normalize_scalar_for_cudf(inner.value().clone());
+        let value = normalize_scalar_for_cudf(inner.value().clone())?;
         let host_scalar = value.to_scalar()?;
         let scalar = CuDFScalar::from_arrow_host(host_scalar).map_err(cudf_to_df)?;
         Ok(Self {
@@ -86,9 +86,32 @@ impl PhysicalExpr for CuDFLiteral {
 
 #[cfg(test)]
 mod tests {
+    use super::CuDFLiteral;
     use crate::assert_snapshot;
     use crate::test_utils::TestFramework;
+    use arrow::array::Array;
+    use arrow_schema::DataType;
     use datafusion::common::assert_contains;
+    use datafusion::common::{DataFusionError, ScalarValue};
+    use datafusion_physical_plan::expressions::Literal;
+
+    #[test]
+    fn test_string_view_literals_lower_to_cudf_string() -> Result<(), Box<dyn std::error::Error>> {
+        let literal = CuDFLiteral::from_host(Literal::new(ScalarValue::Utf8View(Some(
+            "needle".to_string(),
+        ))))?;
+        assert_eq!(literal.scalar.data_type(), &DataType::Utf8);
+
+        let literal = CuDFLiteral::from_host(Literal::new(ScalarValue::BinaryView(Some(
+            b"needle".to_vec(),
+        ))))?;
+        assert_eq!(literal.scalar.data_type(), &DataType::Utf8);
+
+        let err = CuDFLiteral::from_host(Literal::new(ScalarValue::BinaryView(Some(vec![0xff]))))
+            .expect_err("invalid BinaryView literal should not lower to cuDF");
+        assert!(matches!(err, DataFusionError::NotImplemented(_)));
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_string_equality_filter() -> Result<(), Box<dyn std::error::Error>> {

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -348,10 +348,21 @@ impl CuDFLoadMetrics {
 }
 
 /// Converts Arrow scalar types that cuDF does not support into cuDF-compatible equivalents.
-pub(crate) fn normalize_scalar_for_cudf(value: ScalarValue) -> ScalarValue {
+pub(crate) fn normalize_scalar_for_cudf(
+    value: ScalarValue,
+) -> Result<ScalarValue, DataFusionError> {
     match value {
-        ScalarValue::Utf8View(s) => ScalarValue::Utf8(s),
-        other => other,
+        ScalarValue::Utf8View(s) => Ok(ScalarValue::Utf8(s)),
+        ScalarValue::BinaryView(Some(bytes)) => {
+            let value = String::from_utf8(bytes).map_err(|err| {
+                DataFusionError::NotImplemented(format!(
+                    "BinaryView literal is not valid UTF-8 and cannot be lowered to cuDF: {err}"
+                ))
+            })?;
+            Ok(ScalarValue::Utf8(Some(value)))
+        }
+        ScalarValue::BinaryView(None) => Ok(ScalarValue::Utf8(None)),
+        other => Ok(other),
     }
 }
 

--- a/libcudf-datafusion/tests/clickbench_correctness.rs
+++ b/libcudf-datafusion/tests/clickbench_correctness.rs
@@ -6,7 +6,9 @@ mod tests {
     use futures::TryStreamExt;
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
     use libcudf_datafusion::SessionStateBuilderExt;
-    use libcudf_datafusion_benchmarks::datasets::{clickbench, register_tables};
+    use libcudf_datafusion_benchmarks::datasets::{
+        apply_query_settings, clickbench, register_tables,
+    };
     use std::error::Error;
     use std::fmt::Display;
     use std::ops::Range;
@@ -285,6 +287,7 @@ mod tests {
     ) -> Result<impl Display, Box<dyn Error>> {
         let data_dir = ensure_clickbench_data(FILE_RANGE).await;
 
+        apply_query_settings(&ctx, &sql).await?;
         register_tables(&ctx, &data_dir).await?;
 
         let df = ctx.sql(&sql).await?;

--- a/libcudf-datafusion/tests/clickbench_plans.rs
+++ b/libcudf-datafusion/tests/clickbench_plans.rs
@@ -5,7 +5,9 @@ mod tests {
     use datafusion_physical_plan::displayable;
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
     use libcudf_datafusion::{assert_snapshot, SessionStateBuilderExt};
-    use libcudf_datafusion_benchmarks::datasets::{clickbench, register_tables};
+    use libcudf_datafusion_benchmarks::datasets::{
+        apply_query_settings, clickbench, register_tables,
+    };
     use std::error::Error;
     use std::ops::Range;
     use std::path::Path;
@@ -313,9 +315,9 @@ mod tests {
           CuDFProjectionExec: expr=[count(Int64(1))@0 as count(*)]
             CuDFLoadExec
               AggregateExec: mode=Single, gby=[], aggr=[count(Int64(1))]
-                FilterExec: CAST(URL@0 AS Utf8View) LIKE %google%, projection=[]
+                FilterExec: URL@0 LIKE %google%, projection=[]
                   CoalescePartitionsExec
-                    DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[URL], file_type=parquet, predicate=CAST(URL@13 AS Utf8View) LIKE %google%
+                    DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[URL], file_type=parquet, predicate=URL@13 LIKE %google%
         ");
         Ok(())
     }
@@ -323,15 +325,15 @@ mod tests {
     #[tokio::test]
     async fn test_clickbench_21() -> Result<(), Box<dyn Error>> {
         let plan = test_clickbench_query("q21").await?;
-        assert_snapshot!(plan, @r"
+        assert_snapshot!(plan, @"
         CuDFUnloadExec
           CuDFSortExec: TopK(fetch=10), expr=[c@2 DESC], preserve_partitioning=[false]
             CuDFProjectionExec: expr=[SearchPhrase@0 as SearchPhrase, min(hits.URL)@1 as min(hits.URL), count(Int64(1))@2 as c]
               CuDFAggregateExec: mode=Single, group_by=[SearchPhrase@SearchPhrase@1], aggr_expr=[min(hits.URL), count(Int64(1))]
                 CuDFLoadExec
-                  FilterExec: CAST(URL@0 AS Utf8View) LIKE %google% AND SearchPhrase@1 != 
+                  FilterExec: URL@0 LIKE %google% AND SearchPhrase@1 !=\x20
                     CoalescePartitionsExec
-                      DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[URL, SearchPhrase], file_type=parquet, predicate=CAST(URL@13 AS Utf8View) LIKE %google% AND SearchPhrase@39 != , pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1), required_guarantees=[SearchPhrase not in ()]
+                      DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[URL, SearchPhrase], file_type=parquet, predicate=URL@13 LIKE %google% AND SearchPhrase@39 != , pruning_predicate=SearchPhrase_null_count@4 != row_count@5 AND (SearchPhrase_min@2 !=  OR  != SearchPhrase_max@3), required_guarantees=[SearchPhrase not in ()]
         ");
         Ok(())
     }
@@ -339,15 +341,15 @@ mod tests {
     #[tokio::test]
     async fn test_clickbench_22() -> Result<(), Box<dyn Error>> {
         let plan = test_clickbench_query("q22").await?;
-        assert_snapshot!(plan, @r"
+        assert_snapshot!(plan, @"
         CuDFUnloadExec
           CuDFSortExec: TopK(fetch=10), expr=[c@3 DESC], preserve_partitioning=[false]
             CuDFProjectionExec: expr=[SearchPhrase@0 as SearchPhrase, min(hits.URL)@1 as min(hits.URL), min(hits.Title)@2 as min(hits.Title), count(Int64(1))@3 as c, count(DISTINCT hits.UserID)@4 as count(DISTINCT hits.UserID)]
               CuDFLoadExec
                 AggregateExec: mode=Single, gby=[SearchPhrase@3 as SearchPhrase], aggr=[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]
-                  FilterExec: CAST(Title@0 AS Utf8View) LIKE %Google% AND CAST(URL@2 AS Utf8View) NOT LIKE %.google.% AND SearchPhrase@3 != 
+                  FilterExec: Title@0 LIKE %Google% AND URL@2 NOT LIKE %.google.% AND SearchPhrase@3 !=\x20
                     CoalescePartitionsExec
-                      DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[Title, UserID, URL, SearchPhrase], file_type=parquet, predicate=CAST(Title@2 AS Utf8View) LIKE %Google% AND CAST(URL@13 AS Utf8View) NOT LIKE %.google.% AND SearchPhrase@39 != , pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1), required_guarantees=[SearchPhrase not in ()]
+                      DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[Title, UserID, URL, SearchPhrase], file_type=parquet, predicate=Title@2 LIKE %Google% AND URL@13 NOT LIKE %.google.% AND SearchPhrase@39 != , pruning_predicate=SearchPhrase_null_count@6 != row_count@7 AND (SearchPhrase_min@4 !=  OR  != SearchPhrase_max@5), required_guarantees=[SearchPhrase not in ()]
         ");
         Ok(())
     }
@@ -359,9 +361,9 @@ mod tests {
         CuDFUnloadExec
           CuDFSortExec: TopK(fetch=10), expr=[EventTime@4 ASC NULLS LAST], preserve_partitioning=[false]
             CuDFLoadExec
-              FilterExec: CAST(URL@13 AS Utf8View) LIKE %google%
+              FilterExec: URL@13 LIKE %google%
                 CoalescePartitionsExec
-                  DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[WatchID, JavaEnable, Title, GoodEvent, EventTime, EventDate, CounterID, ClientIP, RegionID, UserID, CounterClass, OS, UserAgent, URL, Referer, IsRefresh, RefererCategoryID, RefererRegionID, URLCategoryID, URLRegionID, ResolutionWidth, ResolutionHeight, ResolutionDepth, FlashMajor, FlashMinor, FlashMinor2, NetMajor, NetMinor, UserAgentMajor, UserAgentMinor, CookieEnable, JavascriptEnable, IsMobile, MobilePhone, MobilePhoneModel, Params, IPNetworkID, TraficSourceID, SearchEngineID, SearchPhrase, AdvEngineID, IsArtifical, WindowClientWidth, WindowClientHeight, ClientTimeZone, ClientEventTime, SilverlightVersion1, SilverlightVersion2, SilverlightVersion3, SilverlightVersion4, PageCharset, CodeVersion, IsLink, IsDownload, IsNotBounce, FUniqID, OriginalURL, HID, IsOldCounter, IsEvent, IsParameter, DontCountHits, WithHash, HitColor, LocalEventTime, Age, Sex, Income, Interests, Robotness, RemoteIP, WindowName, OpenerName, HistoryLength, BrowserLanguage, BrowserCountry, SocialNetwork, SocialAction, HTTPError, SendTiming, DNSTiming, ConnectTiming, ResponseStartTiming, ResponseEndTiming, FetchTiming, SocialSourceNetworkID, SocialSourcePage, ParamPrice, ParamOrderID, ParamCurrency, ParamCurrencyID, OpenstatServiceName, OpenstatCampaignID, OpenstatAdID, OpenstatSourceID, UTMSource, UTMMedium, UTMCampaign, UTMContent, UTMTerm, FromTag, HasGCLID, RefererHash, URLHash, CLID], file_type=parquet, predicate=CAST(URL@13 AS Utf8View) LIKE %google% AND DynamicFilter [ empty ]
+                  DataSourceExec: file_groups={6 groups: [[/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/0.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/1.parquet:<int>..<int>, /data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>], [/data/clickbench/plan_range0-3/hits/2.parquet:<int>..<int>]]}, projection=[WatchID, JavaEnable, Title, GoodEvent, EventTime, EventDate, CounterID, ClientIP, RegionID, UserID, CounterClass, OS, UserAgent, URL, Referer, IsRefresh, RefererCategoryID, RefererRegionID, URLCategoryID, URLRegionID, ResolutionWidth, ResolutionHeight, ResolutionDepth, FlashMajor, FlashMinor, FlashMinor2, NetMajor, NetMinor, UserAgentMajor, UserAgentMinor, CookieEnable, JavascriptEnable, IsMobile, MobilePhone, MobilePhoneModel, Params, IPNetworkID, TraficSourceID, SearchEngineID, SearchPhrase, AdvEngineID, IsArtifical, WindowClientWidth, WindowClientHeight, ClientTimeZone, ClientEventTime, SilverlightVersion1, SilverlightVersion2, SilverlightVersion3, SilverlightVersion4, PageCharset, CodeVersion, IsLink, IsDownload, IsNotBounce, FUniqID, OriginalURL, HID, IsOldCounter, IsEvent, IsParameter, DontCountHits, WithHash, HitColor, LocalEventTime, Age, Sex, Income, Interests, Robotness, RemoteIP, WindowName, OpenerName, HistoryLength, BrowserLanguage, BrowserCountry, SocialNetwork, SocialAction, HTTPError, SendTiming, DNSTiming, ConnectTiming, ResponseStartTiming, ResponseEndTiming, FetchTiming, SocialSourceNetworkID, SocialSourcePage, ParamPrice, ParamOrderID, ParamCurrency, ParamCurrencyID, OpenstatServiceName, OpenstatCampaignID, OpenstatAdID, OpenstatSourceID, UTMSource, UTMMedium, UTMCampaign, UTMContent, UTMTerm, FromTag, HasGCLID, RefererHash, URLHash, CLID], file_type=parquet, predicate=URL@13 LIKE %google% AND DynamicFilter [ empty ]
         ");
         Ok(())
     }
@@ -436,7 +438,7 @@ mod tests {
             CuDFProjectionExec: expr=[regexp_replace(hits.Referer,Utf8("^https?://(?:www\.)?([^/]+)/.*$"),Utf8("\1"))@0 as k, avg(length(hits.Referer))@1 as l, count(Int64(1))@2 as c, min(hits.Referer)@3 as min(hits.Referer)]
               CuDFFilterExec: count(Int64(1))@2 > 100000
                 CuDFLoadExec
-                  AggregateExec: mode=Single, gby=[regexp_replace(CAST(Referer@0 AS LargeUtf8), ^https?://(?:www\.)?([^/]+)/.*$, \1) as regexp_replace(hits.Referer,Utf8("^https?://(?:www\.)?([^/]+)/.*$"),Utf8("\1"))], aggr=[avg(length(hits.Referer)), count(Int64(1)), min(hits.Referer)]
+                  AggregateExec: mode=Single, gby=[regexp_replace(Referer@0, ^https?://(?:www\.)?([^/]+)/.*$, \1) as regexp_replace(hits.Referer,Utf8("^https?://(?:www\.)?([^/]+)/.*$"),Utf8("\1"))], aggr=[avg(length(hits.Referer)), count(Int64(1)), min(hits.Referer)]
                     CuDFUnloadExec
                       CuDFFilterExec: Referer@0 != 
                         CuDFLoadExec
@@ -678,6 +680,7 @@ mod tests {
         let data_dir = ensure_clickbench_data(FILE_RANGE).await;
         let sql = clickbench::get_query(query_id)?;
 
+        apply_query_settings(&ctx, &sql).await?;
         register_tables(&ctx, &data_dir).await?;
 
         let df = ctx.sql(&sql).await?;


### PR DESCRIPTION
## Summary

- Normalize DataFusion `Utf8View` and UTF-8-compatible `BinaryView` literals before lowering them into cuDF expressions.
- Reject invalid `BinaryView` literals with `NotImplemented` so planning can stay on the CPU path instead of failing inside cuDF lowering.
- Honor benchmark query `-- set ...` pragmas before Parquet table registration, which lets ClickBench apply `binary_as_string` where the SQL files already request it.
- Update only the ClickBench plan snapshots affected by the corrected ClickBench string schema.

## Root Cause

DataFusion 53 can surface string-like literals as `Utf8View` or `BinaryView`, while cuDF expects string scalars in the existing lowering path. ClickBench also stores string columns as Parquet binary and already carries a query-level `binary_as_string` setting, but the tests and benchmark runner were not applying those settings before Parquet schema inference.

## Validation

- `cargo test -p libcudf-datafusion --lib expr::`
- `cargo test -p libcudf-datafusion-benchmarks datasets::common::tests::test_query_setting_statements`
- `cargo test -p libcudf-datafusion --test clickbench_plans --all-features`
- `cargo test -p libcudf-datafusion --test clickbench_correctness --all-features`
- `git diff --check`
