### PR TITLE
Add experimental cuDF direct Parquet scans

### DIFF
--- a/libcudf-datafusion-benchmarks/README.md
+++ b/libcudf-datafusion-benchmarks/README.md
@@ -130,6 +130,39 @@ runs. cuDF aggregate chunks derive their default target from that cap:
 `--cudf-aggregate-chunk-target-bytes` only when testing an explicit aggregate
 chunk budget.
 
+Enable the experimental cuDF-backed Parquet scan for GPU runs with:
+
+```bash
+target/release/dfbench run \
+  --dataset tpch_sf1 \
+  --query q22 \
+  --iterations 3 \
+  --gpu \
+  --enable-cudf-parquet-scan
+```
+
+For paired harness reports, the flag applies only to the GPU leg:
+
+```bash
+target/release/dfbench harness \
+  --dataset tpch_sf1 \
+  --query q22 \
+  --iterations 3 \
+  --enable-cudf-parquet-scan
+```
+
+Use `--cudf-parquet-scan-files-per-batch` to override how many files are
+included in each cuDF Parquet read:
+
+```bash
+target/release/dfbench harness \
+  --dataset tpch_sf1 \
+  --query q22 \
+  --iterations 3 \
+  --enable-cudf-parquet-scan \
+  --cudf-parquet-scan-files-per-batch 4
+```
+
 Capture physical plans for selected queries:
 
 ```bash
@@ -249,6 +282,8 @@ are excluded from speedup totals.
 
 - Run release builds for timing data.
 - Keep correctness checks in tests, not in the benchmark harness.
+- Direct Parquet scan correctness and plan tests are gated by
+  `LIBCUDF_DATAFUSION_DIRECT_PARQUET_SCAN_TESTS=1`.
 - `benchmark-results/` is ignored by git.
 - The harness keeps CPU and GPU runs in separate subprocesses so command logs
   and process-level setup are reproducible.

--- a/libcudf-datafusion-benchmarks/src/harness.rs
+++ b/libcudf-datafusion-benchmarks/src/harness.rs
@@ -49,6 +49,14 @@ pub struct HarnessOpt {
     #[structopt(long)]
     cuda_batch_size: Option<usize>,
 
+    /// Run the GPU leg with the experimental cuDF-backed Parquet scan.
+    #[structopt(long = "enable-cudf-parquet-scan")]
+    enable_cudf_parquet_scan: bool,
+
+    /// Maximum number of files included in each cuDF Parquet read.
+    #[structopt(long = "cudf-parquet-scan-files-per-batch")]
+    cudf_parquet_scan_files_per_batch: Option<usize>,
+
     /// Run each query once before timed iterations.
     #[structopt(long)]
     warmup: bool,
@@ -87,6 +95,8 @@ struct HarnessMetadata {
     gpu_execution_batch_size: Option<usize>,
     aggregate_chunk_target_bytes: Option<usize>,
     load_coalesce_target_rows: Option<usize>,
+    enable_cudf_parquet_scan: bool,
+    cudf_parquet_scan_files_per_batch: Option<usize>,
     warmup: bool,
     plan_queries: Vec<String>,
     profile_queries: Vec<String>,
@@ -181,6 +191,8 @@ impl HarnessOpt {
             gpu_execution_batch_size,
             aggregate_chunk_target_bytes: self.aggregate_chunk_target_bytes,
             load_coalesce_target_rows: self.cuda_batch_size,
+            enable_cudf_parquet_scan: self.enable_cudf_parquet_scan,
+            cudf_parquet_scan_files_per_batch: self.cudf_parquet_scan_files_per_batch,
             warmup: self.warmup,
             plan_queries: self.plan_query.clone(),
             profile_queries: self.profile_query.clone(),
@@ -249,8 +261,15 @@ impl HarnessOpt {
                 args.push(bytes.to_string());
             }
             if let Some(rows) = self.cuda_batch_size {
-                args.push("--cudf-load-coalesce-target-rows".to_string());
+                args.push("--cuda-batch-size".to_string());
                 args.push(rows.to_string());
+            }
+            if self.enable_cudf_parquet_scan {
+                args.push("--enable-cudf-parquet-scan".to_string());
+            }
+            if let Some(files_per_batch) = self.cudf_parquet_scan_files_per_batch {
+                args.push("--cudf-parquet-scan-files-per-batch".to_string());
+                args.push(files_per_batch.to_string());
             }
         }
         if debug {
@@ -440,6 +459,14 @@ fn write_report(run_dir: &Path, metadata: &HarnessMetadata) -> Result<()> {
     report.push_str(&format!(
         "- cuDF load coalesce target rows: `{:?}`\n",
         metadata.load_coalesce_target_rows
+    ));
+    report.push_str(&format!(
+        "- cuDF parquet scan enabled: `{}`\n",
+        metadata.enable_cudf_parquet_scan
+    ));
+    report.push_str(&format!(
+        "- cuDF parquet scan files per batch: `{:?}`\n",
+        metadata.cudf_parquet_scan_files_per_batch
     ));
     report.push_str(&format!("- warmup: `{}`\n\n", metadata.warmup));
 
@@ -853,6 +880,49 @@ mod tests {
         assert!(contains_arg_pair(&gpu_args, "--batch-size", "65536"));
     }
 
+    #[test]
+    fn run_args_pass_parquet_scan_options_to_gpu_only() {
+        let mut opt = harness_opt(Some(8192), Some(131072));
+        opt.enable_cudf_parquet_scan = true;
+        opt.cudf_parquet_scan_files_per_batch = Some(2);
+        opt.cuda_batch_size = Some(524288);
+
+        let cpu_args = opt.dfbench_run_args(
+            false,
+            opt.cpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/cpu")),
+            true,
+        );
+        let gpu_args = opt.dfbench_run_args(
+            true,
+            opt.gpu_execution_batch_size(),
+            false,
+            None,
+            3,
+            Some(Path::new("/tmp/gpu")),
+            true,
+        );
+
+        assert!(!cpu_args
+            .iter()
+            .any(|arg| arg == "--enable-cudf-parquet-scan"));
+        assert!(!cpu_args
+            .iter()
+            .any(|arg| arg == "--cudf-parquet-scan-files-per-batch"));
+        assert!(gpu_args
+            .iter()
+            .any(|arg| arg == "--enable-cudf-parquet-scan"));
+        assert!(contains_arg_pair(
+            &gpu_args,
+            "--cudf-parquet-scan-files-per-batch",
+            "2"
+        ));
+        assert!(contains_arg_pair(&gpu_args, "--cuda-batch-size", "524288"));
+    }
+
     fn harness_opt(
         batch_size: Option<usize>,
         gpu_execution_batch_size: Option<usize>,
@@ -866,6 +936,8 @@ mod tests {
             gpu_execution_batch_size,
             aggregate_chunk_target_bytes: None,
             cuda_batch_size: None,
+            enable_cudf_parquet_scan: false,
+            cudf_parquet_scan_files_per_batch: None,
             warmup: false,
             output: PathBuf::from("/tmp/bench-results"),
             run_id: None,

--- a/libcudf-datafusion-benchmarks/src/run.rs
+++ b/libcudf-datafusion-benchmarks/src/run.rs
@@ -72,6 +72,14 @@ pub struct RunOpt {
     #[structopt(long)]
     cuda_batch_size: Option<usize>,
 
+    /// Enable the experimental cuDF-backed Parquet scan.
+    #[structopt(long = "enable-cudf-parquet-scan")]
+    enable_cudf_parquet_scan: bool,
+
+    /// Maximum number of files included in each cuDF Parquet read.
+    #[structopt(long = "cudf-parquet-scan-files-per-batch")]
+    cudf_parquet_scan_files_per_batch: Option<usize>,
+
     /// Activate debug mode to see more details
     #[structopt(short, long)]
     debug: bool,
@@ -128,13 +136,17 @@ impl RunOpt {
         }
         config = config.with_target_partitions(self.partitions());
         if self.gpu {
-            let mut cudf_config = CuDFConfig::default();
-            cudf_config.enable = true;
+            let mut cudf_config = CuDFConfig::default()
+                .with_enable(true)
+                .with_parquet_scan(self.enable_cudf_parquet_scan);
             if let Some(bytes) = self.aggregate_chunk_target_bytes {
-                cudf_config.aggregate_chunk_target_bytes = bytes;
+                cudf_config = cudf_config.with_aggregate_chunk_target_bytes(bytes);
             }
             if let Some(rows) = self.cuda_batch_size {
-                cudf_config.batch_size = rows;
+                cudf_config = cudf_config.with_batch_size(rows);
+            }
+            if let Some(files_per_batch) = self.cudf_parquet_scan_files_per_batch {
+                cudf_config = cudf_config.with_parquet_scan_files_per_batch(files_per_batch);
             }
             config = config.with_option_extension(cudf_config);
         }

--- a/libcudf-datafusion/src/expr/ast.rs
+++ b/libcudf-datafusion/src/expr/ast.rs
@@ -1,6 +1,6 @@
 use crate::errors::cudf_to_df;
 use crate::physical::normalize_scalar_for_cudf;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Schema};
 use datafusion::common::{not_impl_err, JoinSide};
 use datafusion::error::DataFusionError;
 use datafusion::physical_expr::expressions::{
@@ -12,6 +12,14 @@ use datafusion_physical_plan::joins::utils::{ColumnIndex, JoinFilter};
 use libcudf_rs::{
     CuDFAstExpression, CuDFAstNode, CuDFAstOperator, CuDFAstTableReference, CuDFScalar,
 };
+
+/// cuDF AST filter plus the file-schema columns it reads.
+pub(crate) struct CuDFParquetScanFilter {
+    /// Predicate expression passed to the cuDF Parquet reader.
+    pub(crate) expression: CuDFAstExpression,
+    /// File column names referenced by the predicate.
+    pub(crate) column_names: Vec<String>,
+}
 
 /// Lower a DataFusion join filter into a cuDF AST predicate.
 ///
@@ -46,6 +54,28 @@ pub(crate) fn is_join_filter_supported_by_cudf_ast(
         filter.expression().as_ref(),
         filter.column_indices(),
     ))
+}
+
+/// Lower a DataFusion Parquet scan predicate into a cuDF AST predicate.
+///
+/// The predicate uses cuDF column-name references so filter columns do not need
+/// to be present in the scan projection.
+pub(crate) fn parquet_filter_to_cudf_filter(
+    filter: &dyn PhysicalExpr,
+    file_schema: &Schema,
+) -> Result<CuDFParquetScanFilter, DataFusionError> {
+    if filter.data_type(file_schema)? != DataType::Boolean {
+        return not_impl_err!("Parquet filter expression must evaluate to Boolean for cuDF AST");
+    }
+
+    let mut ast = CuDFAstExpression::new();
+    let mut column_names = Vec::new();
+    lower_parquet_expr(filter, file_schema, &mut ast, &mut column_names)?;
+
+    Ok(CuDFParquetScanFilter {
+        expression: ast,
+        column_names,
+    })
 }
 
 fn lower_expr(
@@ -127,6 +157,185 @@ fn can_lower_expr(expr: &dyn PhysicalExpr, column_indices: &[ColumnIndex]) -> bo
     }
 
     false
+}
+
+fn lower_parquet_expr(
+    expr: &dyn PhysicalExpr,
+    file_schema: &Schema,
+    ast: &mut CuDFAstExpression,
+    column_names: &mut Vec<String>,
+) -> Result<CuDFAstNode, DataFusionError> {
+    let any = expr.as_any();
+    if let Some(binary) = any.downcast_ref::<BinaryExpr>() {
+        return lower_parquet_binary_expr(binary, file_schema, ast, column_names);
+    }
+    if let Some(column) = any.downcast_ref::<Column>() {
+        return lower_parquet_column_expr(column, file_schema, ast, column_names);
+    }
+    if let Some(literal) = any.downcast_ref::<Literal>() {
+        return lower_literal_expr(literal, ast);
+    }
+    if let Some(is_null) = any.downcast_ref::<IsNullExpr>() {
+        let input =
+            lower_parquet_column_arg(is_null.arg().as_ref(), file_schema, ast, column_names)?;
+        return ast
+            .unary_operation(CuDFAstOperator::IsNull, input)
+            .map_err(cudf_to_df);
+    }
+    if let Some(is_not_null) = any.downcast_ref::<IsNotNullExpr>() {
+        let input =
+            lower_parquet_column_arg(is_not_null.arg().as_ref(), file_schema, ast, column_names)?;
+        let is_null = ast
+            .unary_operation(CuDFAstOperator::IsNull, input)
+            .map_err(cudf_to_df)?;
+        return ast
+            .unary_operation(CuDFAstOperator::Not, is_null)
+            .map_err(cudf_to_df);
+    }
+
+    unsupported_parquet_filter()
+}
+
+fn lower_parquet_binary_expr(
+    expr: &BinaryExpr,
+    file_schema: &Schema,
+    ast: &mut CuDFAstExpression,
+    column_names: &mut Vec<String>,
+) -> Result<CuDFAstNode, DataFusionError> {
+    match expr.op() {
+        Operator::And | Operator::Or => {
+            let left = lower_parquet_expr(expr.left().as_ref(), file_schema, ast, column_names)?;
+            let right = lower_parquet_expr(expr.right().as_ref(), file_schema, ast, column_names)?;
+            let op = map_binary_op(expr.op()).expect("logical parquet op should map to cuDF AST");
+            ast.binary_operation(op, left, right).map_err(cudf_to_df)
+        }
+        Operator::Eq
+        | Operator::NotEq
+        | Operator::Lt
+        | Operator::LtEq
+        | Operator::Gt
+        | Operator::GtEq => {
+            validate_parquet_comparison(expr.left().as_ref(), expr.right().as_ref(), file_schema)?;
+            let left = lower_parquet_expr(expr.left().as_ref(), file_schema, ast, column_names)?;
+            let right = lower_parquet_expr(expr.right().as_ref(), file_schema, ast, column_names)?;
+            let op =
+                map_binary_op(expr.op()).expect("comparison parquet op should map to cuDF AST");
+            ast.binary_operation(op, left, right).map_err(cudf_to_df)
+        }
+        _ => unsupported_parquet_filter(),
+    }
+}
+
+fn lower_parquet_column_arg(
+    expr: &dyn PhysicalExpr,
+    file_schema: &Schema,
+    ast: &mut CuDFAstExpression,
+    column_names: &mut Vec<String>,
+) -> Result<CuDFAstNode, DataFusionError> {
+    let Some(column) = expr.as_any().downcast_ref::<Column>() else {
+        return unsupported_parquet_filter();
+    };
+    lower_parquet_column_expr(column, file_schema, ast, column_names)
+}
+
+fn lower_parquet_column_expr(
+    column: &Column,
+    file_schema: &Schema,
+    ast: &mut CuDFAstExpression,
+    column_names: &mut Vec<String>,
+) -> Result<CuDFAstNode, DataFusionError> {
+    let Some((name, data_type)) = parquet_column_name_and_type(column, file_schema) else {
+        return unsupported_parquet_filter();
+    };
+    if !is_supported_parquet_filter_type(&data_type) {
+        return unsupported_parquet_filter();
+    }
+    if !column_names.contains(&name) {
+        column_names.push(name.clone());
+    }
+    ast.column_name_reference(name).map_err(cudf_to_df)
+}
+
+fn validate_parquet_comparison(
+    left: &dyn PhysicalExpr,
+    right: &dyn PhysicalExpr,
+    file_schema: &Schema,
+) -> Result<(), DataFusionError> {
+    let left_is_column = parquet_column_name_and_type_expr(left, file_schema).is_some();
+    let right_is_column = parquet_column_name_and_type_expr(right, file_schema).is_some();
+    let left_literal_type = parquet_literal_type(left, file_schema);
+    let right_literal_type = parquet_literal_type(right, file_schema);
+
+    let supported = match (
+        left_is_column,
+        right_is_column,
+        left_literal_type,
+        right_literal_type,
+    ) {
+        (true, false, _, Some(data_type)) | (false, true, Some(data_type), _) => {
+            is_supported_parquet_filter_type(&data_type)
+        }
+        _ => false,
+    };
+    if supported {
+        Ok(())
+    } else {
+        unsupported_parquet_filter()
+    }
+}
+
+fn parquet_literal_type(expr: &dyn PhysicalExpr, file_schema: &Schema) -> Option<DataType> {
+    let literal = expr.as_any().downcast_ref::<Literal>()?;
+    normalize_scalar_for_cudf(literal.value().clone()).ok()?;
+    literal.data_type(file_schema).ok()
+}
+
+fn parquet_column_name_and_type_expr(
+    expr: &dyn PhysicalExpr,
+    file_schema: &Schema,
+) -> Option<(String, DataType)> {
+    let column = expr.as_any().downcast_ref::<Column>()?;
+    parquet_column_name_and_type(column, file_schema)
+}
+
+fn parquet_column_name_and_type(
+    column: &Column,
+    file_schema: &Schema,
+) -> Option<(String, DataType)> {
+    let field = file_schema.fields().get(column.index())?;
+    if column.name() != field.name() {
+        return None;
+    }
+    Some((field.name().clone(), column.data_type(file_schema).ok()?))
+}
+
+fn is_supported_parquet_filter_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Timestamp(_, _)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+            | DataType::BinaryView
+    )
+}
+
+fn unsupported_parquet_filter<T>() -> Result<T, DataFusionError> {
+    not_impl_err!("Parquet filter expression is not supported by cuDF Parquet scan")
 }
 
 fn lower_binary_expr(

--- a/libcudf-datafusion/src/expr/ast.rs
+++ b/libcudf-datafusion/src/expr/ast.rs
@@ -35,11 +35,10 @@ pub(crate) fn join_filter_to_cudf_ast(
     }
 
     let mut ast = CuDFAstExpression::new();
-    lower_expr(
-        filter.expression().as_ref(),
-        filter.column_indices(),
-        &mut ast,
-    )?;
+    let mut resolver = JoinColumnResolver {
+        column_indices: filter.column_indices(),
+    };
+    lower_expr(filter.expression().as_ref(), &mut resolver, &mut ast)?;
     Ok(ast)
 }
 
@@ -52,7 +51,9 @@ pub(crate) fn is_join_filter_supported_by_cudf_ast(
 
     Ok(can_lower_expr(
         filter.expression().as_ref(),
-        filter.column_indices(),
+        &JoinColumnResolver {
+            column_indices: filter.column_indices(),
+        },
     ))
 }
 
@@ -69,191 +70,400 @@ pub(crate) fn parquet_filter_to_cudf_filter(
     }
 
     let mut ast = CuDFAstExpression::new();
-    let mut column_names = Vec::new();
-    lower_parquet_expr(filter, file_schema, &mut ast, &mut column_names)?;
+    let mut resolver = ParquetColumnResolver::new(file_schema);
+    lower_expr(filter, &mut resolver, &mut ast)?;
 
     Ok(CuDFParquetScanFilter {
         expression: ast,
-        column_names,
+        column_names: resolver.into_column_names(),
     })
+}
+
+trait AstColumnResolver {
+    fn context(&self) -> &'static str;
+
+    fn lower_column(
+        &mut self,
+        column: &Column,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError>;
+
+    fn can_lower_column(&self, column: &Column) -> bool;
+
+    fn lower_binary(
+        &mut self,
+        expr: &BinaryExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError>
+    where
+        Self: Sized,
+    {
+        lower_binary_expr(expr, self, ast)
+    }
+
+    fn can_lower_binary(&self, expr: &BinaryExpr) -> bool
+    where
+        Self: Sized,
+    {
+        can_lower_binary_expr(expr, self)
+    }
+
+    fn lower_cast(
+        &mut self,
+        cast: &CastExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError>
+    where
+        Self: Sized,
+    {
+        lower_cast_expr(cast, self, ast)
+    }
+
+    fn can_lower_cast(&self, cast: &CastExpr) -> bool
+    where
+        Self: Sized,
+    {
+        matches!(
+            cast.cast_type(),
+            DataType::Int64 | DataType::UInt64 | DataType::Float64
+        ) && can_lower_expr(cast.expr().as_ref(), self)
+    }
+
+    fn lower_not(
+        &mut self,
+        not: &NotExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError>
+    where
+        Self: Sized,
+    {
+        let input = lower_expr(not.arg().as_ref(), self, ast)?;
+        ast.unary_operation(CuDFAstOperator::Not, input)
+            .map_err(cudf_to_df)
+    }
+
+    fn can_lower_not(&self, not: &NotExpr) -> bool
+    where
+        Self: Sized,
+    {
+        can_lower_expr(not.arg().as_ref(), self)
+    }
+
+    fn lower_is_null(
+        &mut self,
+        is_null: &IsNullExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError>
+    where
+        Self: Sized,
+    {
+        let input = lower_expr(is_null.arg().as_ref(), self, ast)?;
+        ast.unary_operation(CuDFAstOperator::IsNull, input)
+            .map_err(cudf_to_df)
+    }
+
+    fn can_lower_is_null(&self, is_null: &IsNullExpr) -> bool
+    where
+        Self: Sized,
+    {
+        can_lower_expr(is_null.arg().as_ref(), self)
+    }
+
+    fn lower_is_not_null(
+        &mut self,
+        is_not_null: &IsNotNullExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError>
+    where
+        Self: Sized,
+    {
+        let input = lower_expr(is_not_null.arg().as_ref(), self, ast)?;
+        let is_null = ast
+            .unary_operation(CuDFAstOperator::IsNull, input)
+            .map_err(cudf_to_df)?;
+        ast.unary_operation(CuDFAstOperator::Not, is_null)
+            .map_err(cudf_to_df)
+    }
+
+    fn can_lower_is_not_null(&self, is_not_null: &IsNotNullExpr) -> bool
+    where
+        Self: Sized,
+    {
+        can_lower_expr(is_not_null.arg().as_ref(), self)
+    }
+}
+
+struct JoinColumnResolver<'a> {
+    column_indices: &'a [ColumnIndex],
+}
+
+impl AstColumnResolver for JoinColumnResolver<'_> {
+    fn context(&self) -> &'static str {
+        "Join filter"
+    }
+
+    fn lower_column(
+        &mut self,
+        column: &Column,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        let Some(ColumnIndex { index, side }) = self.column_indices.get(column.index()) else {
+            return not_impl_err!(
+                "Join filter column {} is outside the filter column index list",
+                column.index()
+            );
+        };
+        let table = match side {
+            JoinSide::Left => CuDFAstTableReference::Left,
+            JoinSide::Right => CuDFAstTableReference::Right,
+            JoinSide::None => {
+                return not_impl_err!("Join filter marker columns are not supported by cuDF AST");
+            }
+        };
+        ast.column_reference(*index, table).map_err(cudf_to_df)
+    }
+
+    fn can_lower_column(&self, column: &Column) -> bool {
+        self.column_indices
+            .get(column.index())
+            .is_some_and(|column_index| column_index.side != JoinSide::None)
+    }
+}
+
+struct ParquetColumnResolver<'a> {
+    file_schema: &'a Schema,
+    column_names: Vec<String>,
+}
+
+impl<'a> ParquetColumnResolver<'a> {
+    fn new(file_schema: &'a Schema) -> Self {
+        Self {
+            file_schema,
+            column_names: Vec::new(),
+        }
+    }
+
+    fn into_column_names(self) -> Vec<String> {
+        self.column_names
+    }
+
+    fn lower_column_arg(
+        &mut self,
+        expr: &dyn PhysicalExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        let Some(column) = expr.as_any().downcast_ref::<Column>() else {
+            return unsupported_parquet_filter();
+        };
+        self.lower_column(column, ast)
+    }
+}
+
+impl AstColumnResolver for ParquetColumnResolver<'_> {
+    fn context(&self) -> &'static str {
+        "Parquet filter"
+    }
+
+    fn lower_column(
+        &mut self,
+        column: &Column,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        let Some((name, data_type)) = parquet_column_name_and_type(column, self.file_schema) else {
+            return unsupported_parquet_filter();
+        };
+        if !is_supported_parquet_filter_type(&data_type) {
+            return unsupported_parquet_filter();
+        }
+        if !self.column_names.contains(&name) {
+            self.column_names.push(name.clone());
+        }
+        ast.column_name_reference(name).map_err(cudf_to_df)
+    }
+
+    fn can_lower_column(&self, column: &Column) -> bool {
+        parquet_column_name_and_type(column, self.file_schema)
+            .is_some_and(|(_, data_type)| is_supported_parquet_filter_type(&data_type))
+    }
+
+    fn lower_binary(
+        &mut self,
+        expr: &BinaryExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        match expr.op() {
+            Operator::And | Operator::Or => {
+                let left = lower_expr(expr.left().as_ref(), self, ast)?;
+                let right = lower_expr(expr.right().as_ref(), self, ast)?;
+                let op = map_binary_op(expr.op()).expect("logical parquet op should map");
+                ast.binary_operation(op, left, right).map_err(cudf_to_df)
+            }
+            Operator::Eq
+            | Operator::NotEq
+            | Operator::Lt
+            | Operator::LtEq
+            | Operator::Gt
+            | Operator::GtEq => {
+                validate_parquet_comparison(
+                    expr.left().as_ref(),
+                    expr.right().as_ref(),
+                    self.file_schema,
+                )?;
+                let left = lower_expr(expr.left().as_ref(), self, ast)?;
+                let right = lower_expr(expr.right().as_ref(), self, ast)?;
+                let op = map_binary_op(expr.op()).expect("comparison parquet op should map");
+                ast.binary_operation(op, left, right).map_err(cudf_to_df)
+            }
+            _ => unsupported_parquet_filter(),
+        }
+    }
+
+    fn can_lower_binary(&self, expr: &BinaryExpr) -> bool {
+        match expr.op() {
+            Operator::And | Operator::Or => {
+                can_lower_expr(expr.left().as_ref(), self)
+                    && can_lower_expr(expr.right().as_ref(), self)
+            }
+            Operator::Eq
+            | Operator::NotEq
+            | Operator::Lt
+            | Operator::LtEq
+            | Operator::Gt
+            | Operator::GtEq => {
+                is_supported_parquet_comparison(
+                    expr.left().as_ref(),
+                    expr.right().as_ref(),
+                    self.file_schema,
+                ) && can_lower_expr(expr.left().as_ref(), self)
+                    && can_lower_expr(expr.right().as_ref(), self)
+            }
+            _ => false,
+        }
+    }
+
+    fn lower_cast(
+        &mut self,
+        _cast: &CastExpr,
+        _ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        unsupported_parquet_filter()
+    }
+
+    fn can_lower_cast(&self, _cast: &CastExpr) -> bool {
+        false
+    }
+
+    fn lower_not(
+        &mut self,
+        _not: &NotExpr,
+        _ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        unsupported_parquet_filter()
+    }
+
+    fn can_lower_not(&self, _not: &NotExpr) -> bool {
+        false
+    }
+
+    fn lower_is_null(
+        &mut self,
+        is_null: &IsNullExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        let input = self.lower_column_arg(is_null.arg().as_ref(), ast)?;
+        ast.unary_operation(CuDFAstOperator::IsNull, input)
+            .map_err(cudf_to_df)
+    }
+
+    fn can_lower_is_null(&self, is_null: &IsNullExpr) -> bool {
+        is_null
+            .arg()
+            .as_any()
+            .downcast_ref::<Column>()
+            .is_some_and(|column| self.can_lower_column(column))
+    }
+
+    fn lower_is_not_null(
+        &mut self,
+        is_not_null: &IsNotNullExpr,
+        ast: &mut CuDFAstExpression,
+    ) -> Result<CuDFAstNode, DataFusionError> {
+        let input = self.lower_column_arg(is_not_null.arg().as_ref(), ast)?;
+        let is_null = ast
+            .unary_operation(CuDFAstOperator::IsNull, input)
+            .map_err(cudf_to_df)?;
+        ast.unary_operation(CuDFAstOperator::Not, is_null)
+            .map_err(cudf_to_df)
+    }
+
+    fn can_lower_is_not_null(&self, is_not_null: &IsNotNullExpr) -> bool {
+        is_not_null
+            .arg()
+            .as_any()
+            .downcast_ref::<Column>()
+            .is_some_and(|column| self.can_lower_column(column))
+    }
 }
 
 fn lower_expr(
     expr: &dyn PhysicalExpr,
-    column_indices: &[ColumnIndex],
+    resolver: &mut impl AstColumnResolver,
     ast: &mut CuDFAstExpression,
 ) -> Result<CuDFAstNode, DataFusionError> {
     let any = expr.as_any();
     if let Some(binary) = any.downcast_ref::<BinaryExpr>() {
-        return lower_binary_expr(binary, column_indices, ast);
+        return resolver.lower_binary(binary, ast);
     }
     if let Some(column) = any.downcast_ref::<Column>() {
-        return lower_column_expr(column, column_indices, ast);
+        return resolver.lower_column(column, ast);
     }
     if let Some(literal) = any.downcast_ref::<Literal>() {
         return lower_literal_expr(literal, ast);
     }
     if let Some(cast) = any.downcast_ref::<CastExpr>() {
-        return lower_cast_expr(cast, column_indices, ast);
+        return resolver.lower_cast(cast, ast);
     }
     if let Some(not) = any.downcast_ref::<NotExpr>() {
-        let input = lower_expr(not.arg().as_ref(), column_indices, ast)?;
-        return ast
-            .unary_operation(CuDFAstOperator::Not, input)
-            .map_err(cudf_to_df);
+        return resolver.lower_not(not, ast);
     }
     if let Some(is_null) = any.downcast_ref::<IsNullExpr>() {
-        let input = lower_expr(is_null.arg().as_ref(), column_indices, ast)?;
-        return ast
-            .unary_operation(CuDFAstOperator::IsNull, input)
-            .map_err(cudf_to_df);
+        return resolver.lower_is_null(is_null, ast);
     }
     if let Some(is_not_null) = any.downcast_ref::<IsNotNullExpr>() {
-        let input = lower_expr(is_not_null.arg().as_ref(), column_indices, ast)?;
-        let is_null = ast
-            .unary_operation(CuDFAstOperator::IsNull, input)
-            .map_err(cudf_to_df)?;
-        return ast
-            .unary_operation(CuDFAstOperator::Not, is_null)
-            .map_err(cudf_to_df);
+        return resolver.lower_is_not_null(is_not_null, ast);
     }
 
-    not_impl_err!("Join filter expression {expr} is not supported by cuDF AST")
+    not_impl_err!(
+        "{} expression {expr} is not supported by cuDF AST",
+        resolver.context()
+    )
 }
 
-fn can_lower_expr(expr: &dyn PhysicalExpr, column_indices: &[ColumnIndex]) -> bool {
+fn can_lower_expr(expr: &dyn PhysicalExpr, resolver: &impl AstColumnResolver) -> bool {
     let any = expr.as_any();
     if let Some(binary) = any.downcast_ref::<BinaryExpr>() {
-        return can_lower_expr(binary.left().as_ref(), column_indices)
-            && can_lower_expr(binary.right().as_ref(), column_indices)
-            && (map_binary_op(binary.op()).is_some()
-                || matches!(
-                    binary.op(),
-                    Operator::IsDistinctFrom | Operator::IsNotDistinctFrom
-                ));
+        return resolver.can_lower_binary(binary);
     }
     if let Some(column) = any.downcast_ref::<Column>() {
-        return column_indices
-            .get(column.index())
-            .is_some_and(|column_index| column_index.side != JoinSide::None);
+        return resolver.can_lower_column(column);
     }
     if let Some(literal) = any.downcast_ref::<Literal>() {
         return normalize_scalar_for_cudf(literal.value().clone()).is_ok();
     }
     if let Some(cast) = any.downcast_ref::<CastExpr>() {
-        return matches!(
-            cast.cast_type(),
-            DataType::Int64 | DataType::UInt64 | DataType::Float64
-        ) && can_lower_expr(cast.expr().as_ref(), column_indices);
+        return resolver.can_lower_cast(cast);
     }
     if let Some(not) = any.downcast_ref::<NotExpr>() {
-        return can_lower_expr(not.arg().as_ref(), column_indices);
+        return resolver.can_lower_not(not);
     }
     if let Some(is_null) = any.downcast_ref::<IsNullExpr>() {
-        return can_lower_expr(is_null.arg().as_ref(), column_indices);
+        return resolver.can_lower_is_null(is_null);
     }
     if let Some(is_not_null) = any.downcast_ref::<IsNotNullExpr>() {
-        return can_lower_expr(is_not_null.arg().as_ref(), column_indices);
+        return resolver.can_lower_is_not_null(is_not_null);
     }
 
     false
-}
-
-fn lower_parquet_expr(
-    expr: &dyn PhysicalExpr,
-    file_schema: &Schema,
-    ast: &mut CuDFAstExpression,
-    column_names: &mut Vec<String>,
-) -> Result<CuDFAstNode, DataFusionError> {
-    let any = expr.as_any();
-    if let Some(binary) = any.downcast_ref::<BinaryExpr>() {
-        return lower_parquet_binary_expr(binary, file_schema, ast, column_names);
-    }
-    if let Some(column) = any.downcast_ref::<Column>() {
-        return lower_parquet_column_expr(column, file_schema, ast, column_names);
-    }
-    if let Some(literal) = any.downcast_ref::<Literal>() {
-        return lower_literal_expr(literal, ast);
-    }
-    if let Some(is_null) = any.downcast_ref::<IsNullExpr>() {
-        let input =
-            lower_parquet_column_arg(is_null.arg().as_ref(), file_schema, ast, column_names)?;
-        return ast
-            .unary_operation(CuDFAstOperator::IsNull, input)
-            .map_err(cudf_to_df);
-    }
-    if let Some(is_not_null) = any.downcast_ref::<IsNotNullExpr>() {
-        let input =
-            lower_parquet_column_arg(is_not_null.arg().as_ref(), file_schema, ast, column_names)?;
-        let is_null = ast
-            .unary_operation(CuDFAstOperator::IsNull, input)
-            .map_err(cudf_to_df)?;
-        return ast
-            .unary_operation(CuDFAstOperator::Not, is_null)
-            .map_err(cudf_to_df);
-    }
-
-    unsupported_parquet_filter()
-}
-
-fn lower_parquet_binary_expr(
-    expr: &BinaryExpr,
-    file_schema: &Schema,
-    ast: &mut CuDFAstExpression,
-    column_names: &mut Vec<String>,
-) -> Result<CuDFAstNode, DataFusionError> {
-    match expr.op() {
-        Operator::And | Operator::Or => {
-            let left = lower_parquet_expr(expr.left().as_ref(), file_schema, ast, column_names)?;
-            let right = lower_parquet_expr(expr.right().as_ref(), file_schema, ast, column_names)?;
-            let op = map_binary_op(expr.op()).expect("logical parquet op should map to cuDF AST");
-            ast.binary_operation(op, left, right).map_err(cudf_to_df)
-        }
-        Operator::Eq
-        | Operator::NotEq
-        | Operator::Lt
-        | Operator::LtEq
-        | Operator::Gt
-        | Operator::GtEq => {
-            validate_parquet_comparison(expr.left().as_ref(), expr.right().as_ref(), file_schema)?;
-            let left = lower_parquet_expr(expr.left().as_ref(), file_schema, ast, column_names)?;
-            let right = lower_parquet_expr(expr.right().as_ref(), file_schema, ast, column_names)?;
-            let op =
-                map_binary_op(expr.op()).expect("comparison parquet op should map to cuDF AST");
-            ast.binary_operation(op, left, right).map_err(cudf_to_df)
-        }
-        _ => unsupported_parquet_filter(),
-    }
-}
-
-fn lower_parquet_column_arg(
-    expr: &dyn PhysicalExpr,
-    file_schema: &Schema,
-    ast: &mut CuDFAstExpression,
-    column_names: &mut Vec<String>,
-) -> Result<CuDFAstNode, DataFusionError> {
-    let Some(column) = expr.as_any().downcast_ref::<Column>() else {
-        return unsupported_parquet_filter();
-    };
-    lower_parquet_column_expr(column, file_schema, ast, column_names)
-}
-
-fn lower_parquet_column_expr(
-    column: &Column,
-    file_schema: &Schema,
-    ast: &mut CuDFAstExpression,
-    column_names: &mut Vec<String>,
-) -> Result<CuDFAstNode, DataFusionError> {
-    let Some((name, data_type)) = parquet_column_name_and_type(column, file_schema) else {
-        return unsupported_parquet_filter();
-    };
-    if !is_supported_parquet_filter_type(&data_type) {
-        return unsupported_parquet_filter();
-    }
-    if !column_names.contains(&name) {
-        column_names.push(name.clone());
-    }
-    ast.column_name_reference(name).map_err(cudf_to_df)
 }
 
 fn validate_parquet_comparison(
@@ -261,12 +471,24 @@ fn validate_parquet_comparison(
     right: &dyn PhysicalExpr,
     file_schema: &Schema,
 ) -> Result<(), DataFusionError> {
+    if is_supported_parquet_comparison(left, right, file_schema) {
+        Ok(())
+    } else {
+        unsupported_parquet_filter()
+    }
+}
+
+fn is_supported_parquet_comparison(
+    left: &dyn PhysicalExpr,
+    right: &dyn PhysicalExpr,
+    file_schema: &Schema,
+) -> bool {
     let left_is_column = parquet_column_name_and_type_expr(left, file_schema).is_some();
     let right_is_column = parquet_column_name_and_type_expr(right, file_schema).is_some();
     let left_literal_type = parquet_literal_type(left, file_schema);
     let right_literal_type = parquet_literal_type(right, file_schema);
 
-    let supported = match (
+    match (
         left_is_column,
         right_is_column,
         left_literal_type,
@@ -276,11 +498,6 @@ fn validate_parquet_comparison(
             is_supported_parquet_filter_type(&data_type)
         }
         _ => false,
-    };
-    if supported {
-        Ok(())
-    } else {
-        unsupported_parquet_filter()
     }
 }
 
@@ -340,11 +557,11 @@ fn unsupported_parquet_filter<T>() -> Result<T, DataFusionError> {
 
 fn lower_binary_expr(
     expr: &BinaryExpr,
-    column_indices: &[ColumnIndex],
+    resolver: &mut impl AstColumnResolver,
     ast: &mut CuDFAstExpression,
 ) -> Result<CuDFAstNode, DataFusionError> {
-    let left = lower_expr(expr.left().as_ref(), column_indices, ast)?;
-    let right = lower_expr(expr.right().as_ref(), column_indices, ast)?;
+    let left = lower_expr(expr.left().as_ref(), resolver, ast)?;
+    let right = lower_expr(expr.right().as_ref(), resolver, ast)?;
     let op = match expr.op() {
         Operator::IsNotDistinctFrom => CuDFAstOperator::NullEqual,
         Operator::IsDistinctFrom => {
@@ -357,7 +574,8 @@ fn lower_binary_expr(
         }
         other => map_binary_op(other).ok_or_else(|| {
             DataFusionError::NotImplemented(format!(
-                "Join filter operator {other:?} is not supported by cuDF AST"
+                "{} operator {other:?} is not supported by cuDF AST",
+                resolver.context()
             ))
         })?,
     };
@@ -365,25 +583,14 @@ fn lower_binary_expr(
     ast.binary_operation(op, left, right).map_err(cudf_to_df)
 }
 
-fn lower_column_expr(
-    column: &Column,
-    column_indices: &[ColumnIndex],
-    ast: &mut CuDFAstExpression,
-) -> Result<CuDFAstNode, DataFusionError> {
-    let Some(ColumnIndex { index, side }) = column_indices.get(column.index()) else {
-        return not_impl_err!(
-            "Join filter column {} is outside the filter column index list",
-            column.index()
-        );
-    };
-    let table = match side {
-        JoinSide::Left => CuDFAstTableReference::Left,
-        JoinSide::Right => CuDFAstTableReference::Right,
-        JoinSide::None => {
-            return not_impl_err!("Join filter marker columns are not supported by cuDF AST");
-        }
-    };
-    ast.column_reference(*index, table).map_err(cudf_to_df)
+fn can_lower_binary_expr(expr: &BinaryExpr, resolver: &impl AstColumnResolver) -> bool {
+    can_lower_expr(expr.left().as_ref(), resolver)
+        && can_lower_expr(expr.right().as_ref(), resolver)
+        && (map_binary_op(expr.op()).is_some()
+            || matches!(
+                expr.op(),
+                Operator::IsDistinctFrom | Operator::IsNotDistinctFrom
+            ))
 }
 
 fn lower_literal_expr(
@@ -397,16 +604,19 @@ fn lower_literal_expr(
 
 fn lower_cast_expr(
     cast: &CastExpr,
-    column_indices: &[ColumnIndex],
+    resolver: &mut impl AstColumnResolver,
     ast: &mut CuDFAstExpression,
 ) -> Result<CuDFAstNode, DataFusionError> {
-    let input = lower_expr(cast.expr().as_ref(), column_indices, ast)?;
+    let input = lower_expr(cast.expr().as_ref(), resolver, ast)?;
     let op = match cast.cast_type() {
         DataType::Int64 => CuDFAstOperator::CastToInt64,
         DataType::UInt64 => CuDFAstOperator::CastToUint64,
         DataType::Float64 => CuDFAstOperator::CastToFloat64,
         other => {
-            return not_impl_err!("Join filter cast to {other} is not supported by cuDF AST");
+            return not_impl_err!(
+                "{} cast to {other} is not supported by cuDF AST",
+                resolver.context()
+            );
         }
     };
     ast.unary_operation(op, input).map_err(cudf_to_df)
@@ -433,7 +643,10 @@ fn map_binary_op(op: &Operator) -> Option<CuDFAstOperator> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_join_filter_supported_by_cudf_ast, join_filter_to_cudf_ast};
+    use super::{
+        is_join_filter_supported_by_cudf_ast, join_filter_to_cudf_ast,
+        parquet_filter_to_cudf_filter,
+    };
     use arrow::array::{Array, Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::common::{DataFusionError, JoinSide, ScalarValue};
@@ -562,6 +775,30 @@ mod tests {
         let filter = JoinFilter::new(filter_expr, filter_indices(), schema);
 
         assert!(!is_join_filter_supported_by_cudf_ast(&filter)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parquet_filter_ast_tracks_file_columns() -> Result<(), Box<dyn Error>> {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, false),
+        ]);
+        let filter = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("id", 0)),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(10)))),
+        )) as Arc<dyn PhysicalExpr>;
+
+        let filter = parquet_filter_to_cudf_filter(filter.as_ref(), &schema)?;
+        assert_eq!(filter.column_names, vec!["id"]);
+
+        let mismatched = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("other", 0)),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(10)))),
+        )) as Arc<dyn PhysicalExpr>;
+        assert!(parquet_filter_to_cudf_filter(mismatched.as_ref(), &schema).is_err());
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/cudf_coalesce.rs
+++ b/libcudf-datafusion/src/physical/cudf_coalesce.rs
@@ -1,0 +1,265 @@
+use crate::metrics::CuDFBaselineMetrics;
+use datafusion::common::{assert_eq_or_internal_err, plan_err};
+use datafusion::error::DataFusionError;
+use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::Partitioning;
+use datafusion_physical_plan::execution_plan::{CardinalityEffect, EvaluationType, SchedulingType};
+use datafusion_physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
+use datafusion_physical_plan::stream::{RecordBatchReceiverStream, RecordBatchStreamAdapter};
+use datafusion_physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    Statistics,
+};
+use futures_util::{Stream, StreamExt};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+/// Coalesces cuDF-backed partitions without host-side Arrow buffer inspection.
+#[derive(Debug)]
+pub(crate) struct CuDFCoalescePartitionsExec {
+    input: Arc<dyn ExecutionPlan>,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+    fetch: Option<usize>,
+}
+
+impl CuDFCoalescePartitionsExec {
+    pub(crate) fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        let input_partitions = input.output_partitioning().partition_count();
+        let (evaluation_type, scheduling_type) = if input_partitions > 1 {
+            (EvaluationType::Eager, SchedulingType::Cooperative)
+        } else {
+            (
+                input.properties().evaluation_type,
+                input.properties().scheduling_type,
+            )
+        };
+        let mut eq_properties = input.equivalence_properties().clone();
+        eq_properties.clear_orderings();
+        eq_properties.clear_per_partition_constants();
+        let properties = Arc::new(
+            PlanProperties::new(
+                eq_properties,
+                Partitioning::UnknownPartitioning(1),
+                input.pipeline_behavior(),
+                input.boundedness(),
+            )
+            .with_evaluation_type(evaluation_type)
+            .with_scheduling_type(scheduling_type),
+        );
+
+        Self {
+            input,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+            fetch: None,
+        }
+    }
+
+    pub(crate) fn with_fetch(mut self, fetch: Option<usize>) -> Self {
+        self.fetch = fetch;
+        self
+    }
+}
+
+impl DisplayAs for CuDFCoalescePartitionsExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => match self.fetch {
+                Some(fetch) => write!(f, "CuDFCoalescePartitionsExec: fetch={fetch}"),
+                None => write!(f, "CuDFCoalescePartitionsExec"),
+            },
+            DisplayFormatType::TreeRender => match self.fetch {
+                Some(fetch) => write!(f, "limit: {fetch}"),
+                None => write!(f, ""),
+            },
+        }
+    }
+}
+
+impl ExecutionPlan for CuDFCoalescePartitionsExec {
+    fn name(&self) -> &str {
+        "CuDFCoalescePartitionsExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return plan_err!(
+                "CuDFCoalescePartitionsExec expects exactly 1 child, {} were provided",
+                children.len()
+            );
+        }
+        Ok(Arc::new(
+            Self::new(Arc::clone(&children[0])).with_fetch(self.fetch),
+        ))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> datafusion::common::Result<SendableRecordBatchStream> {
+        assert_eq_or_internal_err!(
+            partition,
+            0,
+            "CuDFCoalescePartitionsExec invalid partition {partition}"
+        );
+
+        let metrics = CuDFBaselineMetrics::new(&self.metrics, partition);
+        if self.fetch == Some(0) {
+            let stream =
+                RecordBatchStreamAdapter::new(self.schema(), futures_util::stream::empty());
+            return Ok(Box::pin(CuDFObservedStream {
+                inner: Box::pin(stream),
+                metrics,
+                fetch: self.fetch,
+                produced: 0,
+            }));
+        }
+
+        let input_partitions = self.input.output_partitioning().partition_count();
+        let stream = match input_partitions {
+            0 => return plan_err!("CuDFCoalescePartitionsExec requires at least one partition"),
+            1 => self.input.execute(0, context)?,
+            _ => {
+                let mut builder =
+                    RecordBatchReceiverStream::builder(self.schema(), input_partitions);
+                for input_partition in 0..input_partitions {
+                    let input = Arc::clone(&self.input);
+                    let context = Arc::clone(&context);
+                    let output = builder.tx();
+                    builder.spawn(async move {
+                        let mut stream = match input.execute(input_partition, context) {
+                            Ok(stream) => stream,
+                            Err(error) => {
+                                output.send(Err(error)).await.ok();
+                                return Ok(());
+                            }
+                        };
+
+                        while let Some(item) = stream.next().await {
+                            let is_err = item.is_err();
+                            if output.send(item).await.is_err() || is_err {
+                                return Ok(());
+                            }
+                        }
+
+                        Ok(())
+                    });
+                }
+                builder.build()
+            }
+        };
+
+        Ok(Box::pin(CuDFObservedStream {
+            inner: stream,
+            metrics,
+            fetch: self.fetch,
+            produced: 0,
+        }))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn partition_statistics(
+        &self,
+        _partition: Option<usize>,
+    ) -> datafusion::common::Result<Statistics> {
+        self.input
+            .partition_statistics(None)?
+            .with_fetch(self.fetch, 0, 1)
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.fetch
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        Some(Arc::new(
+            Self::new(Arc::clone(&self.input)).with_fetch(limit),
+        ))
+    }
+}
+
+struct CuDFObservedStream {
+    inner: SendableRecordBatchStream,
+    metrics: CuDFBaselineMetrics,
+    fetch: Option<usize>,
+    produced: usize,
+}
+
+impl CuDFObservedStream {
+    fn limit_reached(
+        &mut self,
+        poll: Poll<Option<Result<arrow::record_batch::RecordBatch, DataFusionError>>>,
+    ) -> Poll<Option<Result<arrow::record_batch::RecordBatch, DataFusionError>>> {
+        let Some(fetch) = self.fetch else {
+            return poll;
+        };
+
+        if self.produced >= fetch {
+            return Poll::Ready(None);
+        }
+
+        if let Poll::Ready(Some(Ok(batch))) = &poll {
+            if self.produced + batch.num_rows() > fetch {
+                let batch = batch.slice(0, fetch.saturating_sub(self.produced));
+                self.produced += batch.num_rows();
+                return Poll::Ready(Some(Ok(batch)));
+            }
+            self.produced += batch.num_rows();
+        }
+
+        poll
+    }
+}
+
+impl RecordBatchStream for CuDFObservedStream {
+    fn schema(&self) -> arrow_schema::SchemaRef {
+        self.inner.schema()
+    }
+}
+
+impl Stream for CuDFObservedStream {
+    type Item = Result<arrow::record_batch::RecordBatch, DataFusionError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.fetch.is_some_and(|fetch| self.produced >= fetch) {
+            return self.metrics.record_poll(Poll::Ready(None));
+        }
+
+        let mut poll = self.inner.poll_next_unpin(cx);
+        if self.fetch.is_some() {
+            poll = self.limit_reached(poll);
+        }
+        self.metrics.record_poll(poll)
+    }
+}

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
@@ -9,7 +9,10 @@ pub(crate) use self::scan_source::{
 };
 use crate::errors::cudf_to_df;
 use crate::metrics::CuDFBaselineMetrics;
-use crate::planner::DEFAULT_PARQUET_SCAN_FILES_PER_BATCH;
+use crate::planner::{
+    DEFAULT_PARQUET_SCAN_CHUNK_READ_LIMIT, DEFAULT_PARQUET_SCAN_FILES_PER_BATCH,
+    DEFAULT_PARQUET_SCAN_PASS_READ_LIMIT,
+};
 use arrow::array::{Array, ArrayRef};
 use arrow_schema::SchemaRef;
 use datafusion::common::plan_err;
@@ -37,6 +40,8 @@ pub struct CuDFParquetScanConfig {
     projection: Option<Vec<usize>>,
     filter: Option<Arc<CuDFAstExpression>>,
     files_per_batch: usize,
+    chunk_read_limit: usize,
+    pass_read_limit: usize,
 }
 
 impl CuDFParquetScanConfig {
@@ -50,6 +55,8 @@ impl CuDFParquetScanConfig {
             projection: None,
             filter: None,
             files_per_batch: DEFAULT_PARQUET_SCAN_FILES_PER_BATCH,
+            chunk_read_limit: DEFAULT_PARQUET_SCAN_CHUNK_READ_LIMIT,
+            pass_read_limit: DEFAULT_PARQUET_SCAN_PASS_READ_LIMIT,
         }
     }
 
@@ -68,6 +75,13 @@ impl CuDFParquetScanConfig {
     /// Set the maximum number of files per cuDF read.
     pub fn with_files_per_batch(mut self, files_per_batch: usize) -> Self {
         self.files_per_batch = files_per_batch;
+        self
+    }
+
+    /// Set cuDF chunked Parquet reader byte limits.
+    pub fn with_read_limits(mut self, chunk_read_limit: usize, pass_read_limit: usize) -> Self {
+        self.chunk_read_limit = chunk_read_limit;
+        self.pass_read_limit = pass_read_limit;
         self
     }
 
@@ -96,7 +110,11 @@ impl CuDFParquetScanExec {
         if config.files_per_batch == 0 {
             return plan_err!("CuDFParquetScanExec files_per_batch must be greater than zero");
         }
-
+        if config.chunk_read_limit == 0 {
+            return plan_err!(
+                "CuDFParquetScanExec chunk_read_limit must be greater than zero; cuDF treats zero as an unbounded read"
+            );
+        }
         let output_schema = project_schema(&config.file_schema, config.projection.as_ref())?;
         let read_columns = parquet_read_columns(&config)?;
         let properties = Arc::new(PlanProperties::new(
@@ -154,10 +172,12 @@ impl DisplayAs for CuDFParquetScanExec {
             .map_or_else(|| "all".to_string(), |count| count.to_string());
         write!(
             f,
-            "CuDFParquetScanExec: files={}, batches={}, files_per_batch={}, read_columns={}, filter={}",
+            "CuDFParquetScanExec: files={}, batches={}, files_per_batch={}, chunk_read_limit={}, pass_read_limit={}, read_columns={}, filter={}",
             self.read_plan.file_count(),
             self.read_plan.batch_count(),
             self.read_plan.files_per_batch(),
+            self.config.chunk_read_limit,
+            self.config.pass_read_limit,
             read_columns,
             self.config.filter.is_some()
         )
@@ -223,6 +243,8 @@ impl ExecutionPlan for CuDFParquetScanExec {
             Arc::clone(&schema),
             self.read_plan.read_columns(),
             self.config.filter.clone(),
+            self.config.chunk_read_limit,
+            self.config.pass_read_limit,
         );
         let metrics = ScanMetrics::new(&self.metrics, partition);
         let mut builder = RecordBatchReceiverStream::builder(Arc::clone(&schema), 1);
@@ -230,26 +252,42 @@ impl ExecutionPlan for CuDFParquetScanExec {
 
         builder.spawn_blocking(move || {
             for file_batch in scan_partition.batches() {
-                let compute_timer = metrics.baseline.elapsed_compute().timer();
+                let mut compute_timer = Some(metrics.baseline.elapsed_compute().timer());
                 let result: datafusion::common::Result<_> = (|| {
                     metrics.record_file_batch(file_batch);
 
-                    let read_timer = metrics.read_time.timer();
-                    let parquet_batch = reader.read(file_batch)?;
-                    read_timer.done();
+                    let mut read_timer = Some(metrics.read_time.timer());
+                    let continued = reader.read(file_batch, |parquet_batch| {
+                        if let Some(timer) = read_timer.take() {
+                            timer.done();
+                        }
 
-                    let batch = build_record_batch(parquet_batch, &schema, &metrics)?;
-                    metrics.baseline.record_output(&batch);
-                    Ok(batch)
+                        let batch = build_record_batch(parquet_batch, &schema, &metrics)?;
+                        metrics.baseline.record_output(&batch);
+
+                        if let Some(timer) = compute_timer.take() {
+                            timer.done();
+                        }
+                        let send_timer = metrics.output_send_time.timer();
+                        let send_result = output.blocking_send(Ok(batch));
+                        send_timer.done();
+                        let continued = send_result.is_ok();
+                        if continued {
+                            compute_timer = Some(metrics.baseline.elapsed_compute().timer());
+                            read_timer = Some(metrics.read_time.timer());
+                        }
+                        Ok(continued)
+                    });
+                    if let Some(timer) = read_timer.take() {
+                        timer.done();
+                    }
+                    Ok(continued?)
                 })();
-                compute_timer.done();
-                let batch = result?;
-
-                let send_timer = metrics.output_send_time.timer();
-                let send_result = output.blocking_send(Ok(batch));
-                send_timer.done();
-                if send_result.is_err() {
-                    break;
+                if let Some(timer) = compute_timer.take() {
+                    timer.done();
+                }
+                if !result? {
+                    return Ok(());
                 }
             }
 
@@ -331,15 +369,17 @@ impl ScanMetrics {
 
 #[cfg(test)]
 mod tests {
-    use super::{CuDFParquetScanConfig, CuDFParquetScanExec, CuDFParquetSource, RowGroupSelection};
+    use super::{CuDFParquetScanConfig, CuDFParquetScanExec, CuDFParquetSourceBuilder};
     use arrow::array::{Array, ArrayRef, Int32Array, Scalar};
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType, Field, Schema};
+    use datafusion::datasource::listing::PartitionedFile;
     use datafusion::execution::TaskContext;
     use datafusion_physical_plan::{execute_stream, ExecutionPlan};
     use futures_util::TryStreamExt;
     use libcudf_rs::{CuDFAstExpression, CuDFAstOperator, CuDFColumnView, CuDFScalar};
     use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
     use std::fs::{remove_file, File};
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -363,13 +403,13 @@ mod tests {
 
         let filter = Arc::new(greater_than_filter("id", 2)?);
         let projected = execute_scan(
-            scan_config(path.clone(), Arc::clone(&schema))
+            scan_config(path.clone(), Arc::clone(&schema))?
                 .with_projection(Some(vec![0]))
                 .with_filter(Some(Arc::clone(&filter))),
         )
         .await?;
         let empty_projection = execute_scan(
-            scan_config(path.clone(), schema)
+            scan_config(path.clone(), schema)?
                 .with_projection(Some(vec![]))
                 .with_filter(Some(filter)),
         )
@@ -388,6 +428,41 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn small_chunk_limit_emits_multiple_batches() -> Result<(), Box<dyn std::error::Error>> {
+        let path = temp_parquet_file();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from_iter_values(0..8))],
+        )?;
+        write_parquet_with_row_group_size(&path, &batch, 2)?;
+
+        let batches = execute_scan(
+            scan_config(path.clone(), schema)?
+                .with_projection(Some(vec![0]))
+                .with_read_limits(1, 1),
+        )
+        .await?;
+
+        remove_file(path).ok();
+        let values = batches
+            .iter()
+            .map(|batch| cudf_i32_values(batch.column(0)))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        assert!(batches.len() > 1);
+        assert_eq!(values, (0..8).map(Some).collect::<Vec<_>>());
+        Ok(())
+    }
+
     async fn execute_scan(
         config: CuDFParquetScanConfig,
     ) -> Result<Vec<RecordBatch>, Box<dyn std::error::Error>> {
@@ -397,23 +472,47 @@ mod tests {
             .await?)
     }
 
-    fn scan_config(path: PathBuf, schema: Arc<Schema>) -> CuDFParquetScanConfig {
-        CuDFParquetScanConfig::from_source_groups(
-            vec![vec![CuDFParquetSource {
-                path,
-                byte_len: 0,
-                row_groups: RowGroupSelection::All,
-            }]],
+    fn scan_config(
+        path: PathBuf,
+        schema: Arc<Schema>,
+    ) -> Result<CuDFParquetScanConfig, Box<dyn std::error::Error>> {
+        let size = std::fs::metadata(&path)?.len();
+        let file = PartitionedFile::new(path.to_string_lossy(), size);
+        let mut builder = CuDFParquetSourceBuilder::default();
+        let source = builder
+            .try_from_partitioned_file(&file)
+            .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
+        Ok(CuDFParquetScanConfig::from_source_groups(
+            vec![vec![source]],
             schema,
-        )
+        ))
     }
 
     fn write_parquet(
         path: &PathBuf,
         batch: &RecordBatch,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        write_parquet_with_properties(path, batch, None)
+    }
+
+    fn write_parquet_with_row_group_size(
+        path: &PathBuf,
+        batch: &RecordBatch,
+        row_group_size: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let properties = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(row_group_size))
+            .build();
+        write_parquet_with_properties(path, batch, Some(properties))
+    }
+
+    fn write_parquet_with_properties(
+        path: &PathBuf,
+        batch: &RecordBatch,
+        properties: Option<WriterProperties>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let file = File::create(path)?;
-        let mut writer = ArrowWriter::try_new(file, batch.schema(), None)?;
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), properties)?;
         writer.write(batch)?;
         writer.close()?;
         Ok(())

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
@@ -1,0 +1,327 @@
+mod read_plan;
+mod reader;
+mod scan_source;
+
+use self::read_plan::{FileBatch, ReadPlan};
+use self::reader::ParquetBatchReader;
+pub(crate) use self::scan_source::{
+    CuDFParquetSource, CuDFParquetSourceBuilder, CuDFParquetSourceError, RowGroupSelection,
+};
+use crate::errors::cudf_to_df;
+use crate::metrics::CuDFBaselineMetrics;
+use crate::planner::DEFAULT_PARQUET_SCAN_FILES_PER_BATCH;
+use arrow::array::{Array, ArrayRef};
+use arrow_schema::SchemaRef;
+use datafusion::common::plan_err;
+use datafusion::config::ConfigOptions;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion_physical_plan::metrics::{
+    Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet, Time,
+};
+use datafusion_physical_plan::stream::RecordBatchReceiverStream;
+use datafusion_physical_plan::{
+    project_schema, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+};
+use libcudf_rs::{cast, synchronize_default_stream, CuDFAstExpression};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+/// Configuration for a cuDF-backed Parquet scan.
+#[derive(Debug, Clone)]
+pub struct CuDFParquetScanConfig {
+    file_groups: Vec<Vec<CuDFParquetSource>>,
+    file_schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    filter: Option<Arc<CuDFAstExpression>>,
+    files_per_batch: usize,
+}
+
+impl CuDFParquetScanConfig {
+    pub(crate) fn from_source_groups(
+        file_groups: Vec<Vec<CuDFParquetSource>>,
+        file_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            file_groups,
+            file_schema,
+            projection: None,
+            filter: None,
+            files_per_batch: DEFAULT_PARQUET_SCAN_FILES_PER_BATCH,
+        }
+    }
+
+    /// Set an optional projection using file schema column indices.
+    pub fn with_projection(mut self, projection: Option<Vec<usize>>) -> Self {
+        self.projection = projection;
+        self
+    }
+
+    /// Set an optional cuDF AST filter.
+    pub fn with_filter(mut self, filter: Option<Arc<CuDFAstExpression>>) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    /// Set the maximum number of files per cuDF read.
+    pub fn with_files_per_batch(mut self, files_per_batch: usize) -> Self {
+        self.files_per_batch = files_per_batch;
+        self
+    }
+
+    fn with_file_groups(mut self, file_groups: Vec<Vec<CuDFParquetSource>>) -> Self {
+        self.file_groups = file_groups;
+        self
+    }
+}
+
+/// DataFusion execution plan that scans Parquet files directly with cuDF.
+#[derive(Debug)]
+pub struct CuDFParquetScanExec {
+    config: CuDFParquetScanConfig,
+    read_plan: ReadPlan,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl CuDFParquetScanExec {
+    /// Create a cuDF Parquet scan from a validated scan config.
+    pub fn try_new(config: CuDFParquetScanConfig) -> datafusion::common::Result<Self> {
+        let file_count = ReadPlan::source_count(&config.file_groups);
+        if file_count == 0 {
+            return plan_err!("CuDFParquetScanExec requires at least one parquet file");
+        }
+        if config.files_per_batch == 0 {
+            return plan_err!("CuDFParquetScanExec files_per_batch must be greater than zero");
+        }
+
+        let output_schema = project_schema(&config.file_schema, config.projection.as_ref())?;
+        let read_columns = parquet_read_columns(&config)?;
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(super::cudf_schema_compatibility_map(output_schema)),
+            Partitioning::UnknownPartitioning(config.file_groups.len()),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        let read_plan = ReadPlan::new(
+            config.file_groups.clone(),
+            read_columns,
+            config.files_per_batch,
+        );
+
+        Ok(Self {
+            config,
+            read_plan,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+}
+
+fn parquet_read_columns(
+    config: &CuDFParquetScanConfig,
+) -> datafusion::common::Result<Option<Arc<[String]>>> {
+    let Some(projection) = config.projection.as_ref() else {
+        return Ok(None);
+    };
+    if projection.is_empty() && config.filter.is_some() {
+        let Some(field) = config.file_schema.fields().first() else {
+            return Ok(Some(Arc::from(Vec::<String>::new())));
+        };
+        return Ok(Some(Arc::from(vec![field.name().clone()])));
+    }
+
+    let mut columns = Vec::with_capacity(projection.len());
+    for &index in projection {
+        let Some(field) = config.file_schema.fields().get(index) else {
+            return plan_err!(
+                "CuDFParquetScanExec projection index {index} out of bounds for schema with {} fields",
+                config.file_schema.fields().len()
+            );
+        };
+        columns.push(field.name().clone());
+    }
+    Ok(Some(Arc::from(columns)))
+}
+
+impl DisplayAs for CuDFParquetScanExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        let read_columns = self
+            .read_plan
+            .read_column_count()
+            .map_or_else(|| "all".to_string(), |count| count.to_string());
+        write!(
+            f,
+            "CuDFParquetScanExec: files={}, batches={}, files_per_batch={}, read_columns={}, filter={}",
+            self.read_plan.file_count(),
+            self.read_plan.batch_count(),
+            self.read_plan.files_per_batch(),
+            read_columns,
+            self.config.filter.is_some()
+        )
+    }
+}
+
+impl ExecutionPlan for CuDFParquetScanExec {
+    fn name(&self) -> &str {
+        "CuDFParquetScanExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return plan_err!(
+                "CuDFParquetScanExec expects no children, {} were provided",
+                children.len()
+            );
+        }
+        Ok(self)
+    }
+
+    fn repartitioned(
+        &self,
+        target_partitions: usize,
+        _config: &ConfigOptions,
+    ) -> datafusion::common::Result<Option<Arc<dyn ExecutionPlan>>> {
+        let Some(file_groups) =
+            ReadPlan::repartitioned_source_groups(&self.config.file_groups, target_partitions)
+        else {
+            return Ok(None);
+        };
+
+        let config = self.config.clone().with_file_groups(file_groups);
+        Ok(Some(Arc::new(Self::try_new(config)?)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion::common::Result<SendableRecordBatchStream> {
+        let Some(scan_partition) = self.read_plan.partition(partition) else {
+            return plan_err!("CuDFParquetScanExec invalid partition {partition}");
+        };
+
+        let schema = self.schema();
+        let reader = ParquetBatchReader::new(
+            Arc::clone(&schema),
+            self.read_plan.read_columns(),
+            self.config.filter.clone(),
+        );
+        let metrics = ScanMetrics::new(&self.metrics, partition);
+        let mut builder = RecordBatchReceiverStream::builder(Arc::clone(&schema), 1);
+        let output = builder.tx();
+
+        builder.spawn_blocking(move || {
+            for file_batch in scan_partition.batches() {
+                let compute_timer = metrics.baseline.elapsed_compute().timer();
+                let result: datafusion::common::Result<_> = (|| {
+                    metrics.record_file_batch(file_batch);
+
+                    let read_timer = metrics.read_time.timer();
+                    let parquet_batch = reader.read(file_batch)?;
+                    read_timer.done();
+
+                    let sync_timer = metrics.sync_time.timer();
+                    synchronize_default_stream().map_err(cudf_to_df)?;
+                    sync_timer.done();
+
+                    let cast_timer = metrics.cast_time.timer();
+                    let mut cudf_cols: Vec<ArrayRef> =
+                        Vec::with_capacity(parquet_batch.columns.len());
+                    for (column, field) in parquet_batch.columns.into_iter().zip(schema.fields()) {
+                        let view = column.into_view();
+                        let column: ArrayRef = if view.data_type() == field.data_type() {
+                            Arc::new(view)
+                        } else {
+                            let casted = cast(&view, field.data_type()).map_err(cudf_to_df)?;
+                            synchronize_default_stream().map_err(cudf_to_df)?;
+                            Arc::new(casted.into_view())
+                        };
+                        cudf_cols.push(column);
+                    }
+                    cast_timer.done();
+
+                    let output_batch_timer = metrics.output_batch_time.timer();
+                    let batch = libcudf_rs::record_batch_with_schema(
+                        cudf_cols,
+                        &schema,
+                        parquet_batch.num_rows,
+                    )?;
+                    output_batch_timer.done();
+
+                    metrics.baseline.record_output(&batch);
+                    Ok(batch)
+                })();
+                compute_timer.done();
+                let batch = result?;
+
+                let send_timer = metrics.output_send_time.timer();
+                let send_result = output.blocking_send(Ok(batch));
+                send_timer.done();
+                if send_result.is_err() {
+                    break;
+                }
+            }
+
+            Ok(())
+        });
+
+        Ok(builder.build())
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+}
+
+/// Metrics for one executing Parquet scan partition.
+#[derive(Clone)]
+struct ScanMetrics {
+    baseline: CuDFBaselineMetrics,
+    read_time: Time,
+    cast_time: Time,
+    sync_time: Time,
+    output_batch_time: Time,
+    output_send_time: Time,
+    files: Count,
+    file_bytes: Count,
+}
+
+impl ScanMetrics {
+    fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        Self {
+            baseline: CuDFBaselineMetrics::new(metrics, partition),
+            read_time: MetricBuilder::new(metrics).subset_time("read_time", partition),
+            cast_time: MetricBuilder::new(metrics).subset_time("cast_time", partition),
+            sync_time: MetricBuilder::new(metrics).subset_time("sync_time", partition),
+            output_batch_time: MetricBuilder::new(metrics)
+                .subset_time("output_batch_time", partition),
+            output_send_time: MetricBuilder::new(metrics)
+                .subset_time("output_send_time", partition),
+            files: MetricBuilder::new(metrics).counter("files", partition),
+            file_bytes: MetricBuilder::new(metrics).counter("file_bytes", partition),
+        }
+    }
+
+    fn record_file_batch(&self, batch: &FileBatch) {
+        self.files.add(batch.sources().len());
+        self.file_bytes.add(batch.file_bytes());
+    }
+}

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
@@ -238,34 +238,7 @@ impl ExecutionPlan for CuDFParquetScanExec {
                     let parquet_batch = reader.read(file_batch)?;
                     read_timer.done();
 
-                    let sync_timer = metrics.sync_time.timer();
-                    synchronize_default_stream().map_err(cudf_to_df)?;
-                    sync_timer.done();
-
-                    let cast_timer = metrics.cast_time.timer();
-                    let mut cudf_cols: Vec<ArrayRef> =
-                        Vec::with_capacity(parquet_batch.columns.len());
-                    for (column, field) in parquet_batch.columns.into_iter().zip(schema.fields()) {
-                        let view = column.into_view();
-                        let column: ArrayRef = if view.data_type() == field.data_type() {
-                            Arc::new(view)
-                        } else {
-                            let casted = cast(&view, field.data_type()).map_err(cudf_to_df)?;
-                            synchronize_default_stream().map_err(cudf_to_df)?;
-                            Arc::new(casted.into_view())
-                        };
-                        cudf_cols.push(column);
-                    }
-                    cast_timer.done();
-
-                    let output_batch_timer = metrics.output_batch_time.timer();
-                    let batch = libcudf_rs::record_batch_with_schema(
-                        cudf_cols,
-                        &schema,
-                        parquet_batch.num_rows,
-                    )?;
-                    output_batch_timer.done();
-
+                    let batch = build_record_batch(parquet_batch, &schema, &metrics)?;
                     metrics.baseline.record_output(&batch);
                     Ok(batch)
                 })();
@@ -289,6 +262,36 @@ impl ExecutionPlan for CuDFParquetScanExec {
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
+}
+
+fn build_record_batch(
+    parquet_batch: reader::ReadBatch,
+    schema: &SchemaRef,
+    metrics: &ScanMetrics,
+) -> datafusion::common::Result<arrow::record_batch::RecordBatch> {
+    let cast_timer = metrics.cast_time.timer();
+    let mut cudf_cols: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
+    for (column, field) in parquet_batch.columns.into_iter().zip(schema.fields()) {
+        let view = column.into_view();
+        let column: ArrayRef = if view.data_type() == field.data_type() {
+            Arc::new(view)
+        } else {
+            let casted = cast(&view, field.data_type()).map_err(cudf_to_df)?;
+            Arc::new(casted.into_view())
+        };
+        cudf_cols.push(column);
+    }
+    cast_timer.done();
+
+    let sync_timer = metrics.sync_time.timer();
+    synchronize_default_stream().map_err(cudf_to_df)?;
+    sync_timer.done();
+
+    let output_batch_timer = metrics.output_batch_time.timer();
+    let batch = libcudf_rs::record_batch_with_schema(cudf_cols, schema, parquet_batch.num_rows)?;
+    output_batch_timer.done();
+
+    Ok(batch)
 }
 
 /// Metrics for one executing Parquet scan partition.
@@ -323,5 +326,140 @@ impl ScanMetrics {
     fn record_file_batch(&self, batch: &FileBatch) {
         self.files.add(batch.sources().len());
         self.file_bytes.add(batch.file_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CuDFParquetScanConfig, CuDFParquetScanExec, CuDFParquetSource, RowGroupSelection};
+    use arrow::array::{Array, ArrayRef, Int32Array, Scalar};
+    use arrow::record_batch::RecordBatch;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::execution::TaskContext;
+    use datafusion_physical_plan::{execute_stream, ExecutionPlan};
+    use futures_util::TryStreamExt;
+    use libcudf_rs::{CuDFAstExpression, CuDFAstOperator, CuDFColumnView, CuDFScalar};
+    use parquet::arrow::ArrowWriter;
+    use std::fs::{remove_file, File};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[tokio::test]
+    async fn filters_with_column_outside_projection() -> Result<(), Box<dyn std::error::Error>> {
+        let path = temp_parquet_file();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Int32, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            ],
+        )?;
+        write_parquet(&path, &batch)?;
+
+        let filter = Arc::new(greater_than_filter("id", 2)?);
+        let projected = execute_scan(
+            scan_config(path.clone(), Arc::clone(&schema))
+                .with_projection(Some(vec![0]))
+                .with_filter(Some(Arc::clone(&filter))),
+        )
+        .await?;
+        let empty_projection = execute_scan(
+            scan_config(path.clone(), schema)
+                .with_projection(Some(vec![]))
+                .with_filter(Some(filter)),
+        )
+        .await?;
+
+        remove_file(path).ok();
+        assert_eq!(projected.len(), 1);
+        assert_eq!(
+            cudf_i32_values(projected[0].column(0))?,
+            vec![Some(30), Some(40)]
+        );
+        assert_eq!(empty_projection.len(), 1);
+        assert_eq!(empty_projection[0].num_columns(), 0);
+        assert_eq!(empty_projection[0].num_rows(), 2);
+
+        Ok(())
+    }
+
+    async fn execute_scan(
+        config: CuDFParquetScanConfig,
+    ) -> Result<Vec<RecordBatch>, Box<dyn std::error::Error>> {
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(CuDFParquetScanExec::try_new(config)?);
+        Ok(execute_stream(plan, Arc::new(TaskContext::default()))?
+            .try_collect::<Vec<_>>()
+            .await?)
+    }
+
+    fn scan_config(path: PathBuf, schema: Arc<Schema>) -> CuDFParquetScanConfig {
+        CuDFParquetScanConfig::from_source_groups(
+            vec![vec![CuDFParquetSource {
+                path,
+                byte_len: 0,
+                row_groups: RowGroupSelection::All,
+            }]],
+            schema,
+        )
+    }
+
+    fn write_parquet(
+        path: &PathBuf,
+        batch: &RecordBatch,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let file = File::create(path)?;
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None)?;
+        writer.write(batch)?;
+        writer.close()?;
+        Ok(())
+    }
+
+    fn greater_than_filter(
+        column: &str,
+        value: i32,
+    ) -> Result<CuDFAstExpression, Box<dyn std::error::Error>> {
+        let mut filter = CuDFAstExpression::new();
+        let column = filter.column_name_reference(column)?;
+        let value = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![value])))?;
+        let value = filter.literal(value)?;
+        filter.binary_operation(CuDFAstOperator::Greater, column, value)?;
+        Ok(filter)
+    }
+
+    fn cudf_i32_values(column: &ArrayRef) -> Result<Vec<Option<i32>>, Box<dyn std::error::Error>> {
+        let column = column
+            .as_any()
+            .downcast_ref::<CuDFColumnView>()
+            .expect("parquet scan should return cuDF columns");
+        let host = column.to_arrow_host()?;
+        let ints = host
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("column should be Int32");
+        Ok((0..ints.len())
+            .map(|index| {
+                if ints.is_null(index) {
+                    None
+                } else {
+                    Some(ints.value(index))
+                }
+            })
+            .collect())
+    }
+
+    fn temp_parquet_file() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "libcudf-datafusion-scan-{}-{nanos}.parquet",
+            std::process::id()
+        ))
     }
 }

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/mod.rs
@@ -115,6 +115,11 @@ impl CuDFParquetScanExec {
                 "CuDFParquetScanExec chunk_read_limit must be greater than zero; cuDF treats zero as an unbounded read"
             );
         }
+        if config.pass_read_limit == 0 {
+            return plan_err!(
+                "CuDFParquetScanExec pass_read_limit must be greater than zero; cuDF treats zero as an unbounded read"
+            );
+        }
         let output_schema = project_schema(&config.file_schema, config.projection.as_ref())?;
         let read_columns = parquet_read_columns(&config)?;
         let properties = Arc::new(PlanProperties::new(
@@ -382,6 +387,7 @@ mod tests {
     use parquet::file::properties::WriterProperties;
     use std::fs::{remove_file, File};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -463,6 +469,54 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn mixed_schema_missing_projected_column_is_null_filled(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let full_path = temp_parquet_file();
+        let missing_path = temp_parquet_file();
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, true),
+        ]));
+        let full_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, true),
+        ]));
+        let missing_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let full_batch = RecordBatch::try_new(
+            full_schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![Some(10), Some(20)])),
+            ],
+        )?;
+        let missing_batch =
+            RecordBatch::try_new(missing_schema, vec![Arc::new(Int32Array::from(vec![3, 4]))])?;
+        write_parquet(&full_path, &full_batch)?;
+        write_parquet(&missing_path, &missing_batch)?;
+
+        let batches = execute_scan(
+            scan_config_for_paths(
+                &[full_path.clone(), missing_path.clone()],
+                Arc::clone(&output_schema),
+            )?
+            .with_projection(Some(vec![0, 1])),
+        )
+        .await?;
+
+        remove_file(full_path).ok();
+        remove_file(missing_path).ok();
+        assert_eq!(
+            i32_values_from_batches(&batches, 0)?,
+            vec![Some(1), Some(2), Some(3), Some(4)]
+        );
+        assert_eq!(
+            i32_values_from_batches(&batches, 1)?,
+            vec![Some(10), Some(20), None, None]
+        );
+        Ok(())
+    }
+
     async fn execute_scan(
         config: CuDFParquetScanConfig,
     ) -> Result<Vec<RecordBatch>, Box<dyn std::error::Error>> {
@@ -476,14 +530,26 @@ mod tests {
         path: PathBuf,
         schema: Arc<Schema>,
     ) -> Result<CuDFParquetScanConfig, Box<dyn std::error::Error>> {
-        let size = std::fs::metadata(&path)?.len();
-        let file = PartitionedFile::new(path.to_string_lossy(), size);
+        scan_config_for_paths(std::slice::from_ref(&path), schema)
+    }
+
+    fn scan_config_for_paths(
+        paths: &[PathBuf],
+        schema: Arc<Schema>,
+    ) -> Result<CuDFParquetScanConfig, Box<dyn std::error::Error>> {
         let mut builder = CuDFParquetSourceBuilder::default();
-        let source = builder
-            .try_from_partitioned_file(&file)
-            .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
+        let sources = paths
+            .iter()
+            .map(|path| {
+                let size = std::fs::metadata(path)?.len();
+                let file = PartitionedFile::new(path.to_string_lossy(), size);
+                builder
+                    .try_from_partitioned_file(&file)
+                    .map_err(|err| std::io::Error::other(format!("{err:?}")).into())
+            })
+            .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
         Ok(CuDFParquetScanConfig::from_source_groups(
-            vec![vec![source]],
+            vec![sources],
             schema,
         ))
     }
@@ -551,13 +617,29 @@ mod tests {
             .collect())
     }
 
+    fn i32_values_from_batches(
+        batches: &[RecordBatch],
+        column: usize,
+    ) -> Result<Vec<Option<i32>>, Box<dyn std::error::Error>> {
+        Ok(batches
+            .iter()
+            .map(|batch| cudf_i32_values(batch.column(column)))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+
     fn temp_parquet_file() -> PathBuf {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time should be after Unix epoch")
             .as_nanos();
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "libcudf-datafusion-scan-{}-{nanos}.parquet",
+            "libcudf-datafusion-scan-{}-{nanos}-{id}.parquet",
             std::process::id()
         ))
     }

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/read_plan.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/read_plan.rs
@@ -1,0 +1,133 @@
+use super::CuDFParquetSource;
+use std::sync::Arc;
+
+/// Precomputed file layout for a cuDF Parquet scan.
+#[derive(Debug, Clone)]
+pub(super) struct ReadPlan {
+    partitions: Arc<[ReadPartition]>,
+    read_columns: Option<Arc<[String]>>,
+    file_count: usize,
+    files_per_batch: usize,
+}
+
+/// One output partition in the scan.
+#[derive(Debug, Clone)]
+pub(super) struct ReadPartition {
+    batches: Arc<[FileBatch]>,
+}
+
+/// Files read together by one cuDF Parquet call.
+#[derive(Debug, Clone)]
+pub(super) struct FileBatch {
+    sources: Arc<[CuDFParquetSource]>,
+    file_bytes: usize,
+}
+
+impl ReadPlan {
+    pub(super) fn new(
+        file_groups: Vec<Vec<CuDFParquetSource>>,
+        read_columns: Option<Arc<[String]>>,
+        files_per_batch: usize,
+    ) -> Self {
+        let file_count = Self::source_count(&file_groups);
+        let files_per_batch = files_per_batch.min(file_count);
+        let partitions = file_groups
+            .into_iter()
+            .map(|sources| ReadPartition::new(&sources, files_per_batch))
+            .collect::<Vec<_>>()
+            .into();
+
+        Self {
+            partitions,
+            read_columns,
+            file_count,
+            files_per_batch,
+        }
+    }
+
+    pub(super) fn source_count(file_groups: &[Vec<CuDFParquetSource>]) -> usize {
+        file_groups.iter().map(Vec::len).sum()
+    }
+
+    pub(super) fn repartitioned_source_groups(
+        file_groups: &[Vec<CuDFParquetSource>],
+        target_partitions: usize,
+    ) -> Option<Vec<Vec<CuDFParquetSource>>> {
+        if target_partitions <= file_groups.len() {
+            return None;
+        }
+
+        let files = file_groups.iter().flatten().cloned().collect::<Vec<_>>();
+        let partition_count = target_partitions.min(files.len());
+        if partition_count <= file_groups.len() {
+            return None;
+        }
+
+        let mut file_groups = vec![Vec::new(); partition_count];
+        for (index, file) in files.into_iter().enumerate() {
+            file_groups[index % partition_count].push(file);
+        }
+        Some(file_groups)
+    }
+
+    pub(super) fn partition(&self, index: usize) -> Option<ReadPartition> {
+        self.partitions.get(index).cloned()
+    }
+
+    pub(super) fn batch_count(&self) -> usize {
+        self.partitions
+            .iter()
+            .map(|partition| partition.batches.len())
+            .sum()
+    }
+
+    pub(super) fn file_count(&self) -> usize {
+        self.file_count
+    }
+
+    pub(super) fn files_per_batch(&self) -> usize {
+        self.files_per_batch
+    }
+
+    pub(super) fn read_columns(&self) -> Option<Arc<[String]>> {
+        self.read_columns.clone()
+    }
+
+    pub(super) fn read_column_count(&self) -> Option<usize> {
+        self.read_columns.as_ref().map(|columns| columns.len())
+    }
+}
+
+impl ReadPartition {
+    fn new(sources: &[CuDFParquetSource], files_per_batch: usize) -> Self {
+        let batches = sources
+            .chunks(files_per_batch)
+            .map(FileBatch::new)
+            .collect::<Vec<_>>()
+            .into();
+        Self { batches }
+    }
+
+    pub(super) fn batches(&self) -> &[FileBatch] {
+        &self.batches
+    }
+}
+
+impl FileBatch {
+    fn new(sources: &[CuDFParquetSource]) -> Self {
+        let file_bytes = sources.iter().map(CuDFParquetSource::byte_len).sum();
+
+        Self {
+            sources: Arc::from(sources.to_vec()),
+            file_bytes,
+        }
+    }
+
+    pub(super) fn sources(&self) -> &[CuDFParquetSource] {
+        &self.sources
+    }
+
+    pub(super) fn file_bytes(&self) -> usize {
+        self.file_bytes
+    }
+}

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
@@ -16,6 +16,8 @@ pub(super) struct ParquetBatchReader {
     schema: SchemaRef,
     read_columns: Option<Arc<[String]>>,
     filter: Option<Arc<CuDFAstExpression>>,
+    chunk_read_limit: usize,
+    pass_read_limit: usize,
 }
 
 /// cuDF columns plus row count for one output batch.
@@ -29,46 +31,56 @@ impl ParquetBatchReader {
         schema: SchemaRef,
         read_columns: Option<Arc<[String]>>,
         filter: Option<Arc<CuDFAstExpression>>,
+        chunk_read_limit: usize,
+        pass_read_limit: usize,
     ) -> Self {
         Self {
             schema,
             read_columns,
             filter,
+            chunk_read_limit,
+            pass_read_limit,
         }
     }
 
-    pub(super) fn read(&self, batch: &FileBatch) -> datafusion::common::Result<ReadBatch> {
+    pub(super) fn read<F>(&self, batch: &FileBatch, mut emit: F) -> datafusion::common::Result<bool>
+    where
+        F: FnMut(ReadBatch) -> datafusion::common::Result<bool>,
+    {
         let read_columns = self.read_columns.as_deref();
         let filter = self.filter.as_deref();
         if batch_has_no_selected_row_groups(batch) {
-            return empty_read_batch(&self.schema);
+            return emit(empty_read_batch(&self.schema)?);
         }
 
         if self.schema.fields().is_empty() && filter.is_none() {
-            return Ok(ReadBatch {
+            return emit(ReadBatch {
                 columns: vec![],
                 num_rows: parquet_batch_row_count(batch)?,
             });
         }
 
         if batch_has_missing_read_columns(batch, read_columns, &self.schema)? {
-            return read_parquet_sources_individually(batch, read_columns, filter, &self.schema);
+            return read_parquet_sources_individually(
+                batch,
+                read_columns,
+                filter,
+                &self.schema,
+                self.chunk_read_limit,
+                self.pass_read_limit,
+                &mut emit,
+            );
         }
 
-        match read_parquet_sources_together(batch, read_columns, filter) {
-            Ok(read) => {
-                if batch.sources().len() == 1 || contains_all_schema_columns(&read, &self.schema) {
-                    return align_parquet_read(read, &self.schema);
-                }
-            }
-            Err(err) => {
-                if batch.sources().len() == 1 {
-                    return Err(err);
-                }
-            }
-        }
-
-        read_parquet_sources_individually(batch, read_columns, filter, &self.schema)
+        read_parquet_sources_together(
+            batch,
+            read_columns,
+            filter,
+            self.chunk_read_limit,
+            self.pass_read_limit,
+            &self.schema,
+            &mut emit,
+        )
     }
 }
 
@@ -76,9 +88,21 @@ fn read_parquet_sources_together(
     batch: &FileBatch,
     read_columns: Option<&[String]>,
     filter: Option<&CuDFAstExpression>,
-) -> datafusion::common::Result<CuDFParquetReadResult> {
+    chunk_read_limit: usize,
+    pass_read_limit: usize,
+    schema: &SchemaRef,
+    emit: &mut impl FnMut(ReadBatch) -> datafusion::common::Result<bool>,
+) -> datafusion::common::Result<bool> {
     if let [source] = batch.sources() {
-        return read_parquet_source(source, read_columns, filter);
+        return read_parquet_source(
+            source,
+            read_columns,
+            filter,
+            chunk_read_limit,
+            pass_read_limit,
+            schema,
+            emit,
+        );
     }
     let files = batch
         .sources()
@@ -86,15 +110,57 @@ fn read_parquet_sources_together(
         .map(|source| &source.path)
         .collect::<Vec<_>>();
     let row_groups = parquet_batch_row_groups(batch)?;
-    libcudf_rs::CuDFTable::read_parquet_files(CuDFParquetReadOptions {
-        paths: &files,
-        columns: read_columns,
-        row_groups: row_groups.as_deref(),
-        filter,
-        allow_mismatched_pq_schemas: read_columns.is_some(),
-        ignore_missing_columns: true,
-    })
-    .map_err(cudf_to_df)
+    let mut emitted = false;
+    let mut continued = true;
+    let mut callback_error = None;
+    let read_result = libcudf_rs::CuDFTable::for_each_parquet_chunk(
+        CuDFParquetReadOptions {
+            paths: &files,
+            columns: read_columns,
+            row_groups: row_groups.as_deref(),
+            filter,
+            allow_mismatched_pq_schemas: read_columns.is_some(),
+            ignore_missing_columns: true,
+        },
+        chunk_read_limit,
+        pass_read_limit,
+        |read| {
+            emitted = true;
+            match align_parquet_read(read, schema).and_then(&mut *emit) {
+                Ok(keep_reading) => {
+                    continued = keep_reading;
+                    Ok(keep_reading)
+                }
+                Err(err) => {
+                    continued = false;
+                    callback_error = Some(err);
+                    Ok(false)
+                }
+            }
+        },
+    );
+    if let Some(err) = callback_error {
+        return Err(err);
+    }
+    match read_result {
+        Ok(()) => {}
+        Err(err) if !emitted => {
+            return read_parquet_sources_individually(
+                batch,
+                read_columns,
+                filter,
+                schema,
+                chunk_read_limit,
+                pass_read_limit,
+                emit,
+            );
+        }
+        Err(err) => return Err(cudf_to_df(err)),
+    }
+    if !emitted {
+        return emit(empty_read_batch(schema)?);
+    }
+    Ok(continued)
 }
 
 fn parquet_batch_row_groups(
@@ -202,20 +268,52 @@ fn read_parquet_source(
     source: &CuDFParquetSource,
     read_columns: Option<&[String]>,
     filter: Option<&CuDFAstExpression>,
-) -> datafusion::common::Result<CuDFParquetReadResult> {
+    chunk_read_limit: usize,
+    pass_read_limit: usize,
+    schema: &SchemaRef,
+    emit: &mut impl FnMut(ReadBatch) -> datafusion::common::Result<bool>,
+) -> datafusion::common::Result<bool> {
     let row_groups = source
         .row_group_selection()
         .indices()
         .map(|indices| vec![indices.to_vec()]);
-    libcudf_rs::CuDFTable::read_parquet_files(CuDFParquetReadOptions {
-        paths: std::slice::from_ref(&source.path),
-        columns: read_columns,
-        row_groups: row_groups.as_deref(),
-        filter,
-        allow_mismatched_pq_schemas: read_columns.is_some(),
-        ignore_missing_columns: true,
-    })
-    .map_err(cudf_to_df)
+    let mut emitted = false;
+    let mut continued = true;
+    let mut callback_error = None;
+    let read_result = libcudf_rs::CuDFTable::for_each_parquet_chunk(
+        CuDFParquetReadOptions {
+            paths: std::slice::from_ref(&source.path),
+            columns: read_columns,
+            row_groups: row_groups.as_deref(),
+            filter,
+            allow_mismatched_pq_schemas: read_columns.is_some(),
+            ignore_missing_columns: true,
+        },
+        chunk_read_limit,
+        pass_read_limit,
+        |read| {
+            emitted = true;
+            match align_parquet_read(read, schema).and_then(&mut *emit) {
+                Ok(keep_reading) => {
+                    continued = keep_reading;
+                    Ok(keep_reading)
+                }
+                Err(err) => {
+                    continued = false;
+                    callback_error = Some(err);
+                    Ok(false)
+                }
+            }
+        },
+    );
+    if let Some(err) = callback_error {
+        return Err(err);
+    }
+    read_result.map_err(cudf_to_df)?;
+    if !emitted {
+        return emit(empty_read_batch(schema)?);
+    }
+    Ok(continued)
 }
 
 fn read_parquet_sources_individually(
@@ -223,42 +321,37 @@ fn read_parquet_sources_individually(
     read_columns: Option<&[String]>,
     filter: Option<&CuDFAstExpression>,
     schema: &SchemaRef,
-) -> datafusion::common::Result<ReadBatch> {
-    let mut columns_by_field = (0..schema.fields().len())
-        .map(|_| Vec::with_capacity(batch.sources().len()))
-        .collect::<Vec<Vec<CuDFColumn>>>();
-    let mut total_rows = 0usize;
-
+    chunk_read_limit: usize,
+    pass_read_limit: usize,
+    emit: &mut impl FnMut(ReadBatch) -> datafusion::common::Result<bool>,
+) -> datafusion::common::Result<bool> {
+    let mut emitted = false;
     for source in batch.sources() {
         if source.row_group_selection().is_empty() {
             continue;
         }
 
-        let read = read_parquet_source(source, read_columns, filter)?;
-        let aligned = align_parquet_read(read, schema)?;
-        total_rows = total_rows.checked_add(aligned.num_rows).ok_or_else(|| {
-            DataFusionError::Execution("CuDFParquetScanExec row count overflowed usize".to_string())
-        })?;
-        for (index, column) in aligned.columns.into_iter().enumerate() {
-            columns_by_field[index].push(column);
+        let continued = read_parquet_source(
+            source,
+            read_columns,
+            filter,
+            chunk_read_limit,
+            pass_read_limit,
+            schema,
+            &mut |read| {
+                emitted = true;
+                emit(read)
+            },
+        )?;
+        if !continued {
+            return Ok(false);
         }
     }
 
-    let columns = columns_by_field
-        .into_iter()
-        .map(|columns| {
-            let views = columns
-                .into_iter()
-                .map(CuDFColumn::into_view)
-                .collect::<Vec<_>>();
-            CuDFColumn::concat(views).map_err(cudf_to_df)
-        })
-        .collect::<datafusion::common::Result<Vec<_>>>()?;
-
-    Ok(ReadBatch {
-        columns,
-        num_rows: total_rows,
-    })
+    if !emitted {
+        return emit(empty_read_batch(schema)?);
+    }
+    Ok(true)
 }
 
 fn align_parquet_read(
@@ -293,14 +386,6 @@ fn align_parquet_read(
     Ok(ReadBatch {
         columns,
         num_rows: read.num_rows,
-    })
-}
-
-fn contains_all_schema_columns(read: &CuDFParquetReadResult, schema: &SchemaRef) -> bool {
-    schema.fields().iter().all(|field| {
-        read.column_names
-            .iter()
-            .any(|column_name| column_name == field.name())
     })
 }
 

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
@@ -8,7 +8,7 @@ use datafusion::scalar::ScalarValue;
 use libcudf_rs::{
     CuDFAstExpression, CuDFColumn, CuDFParquetReadOptions, CuDFParquetReadResult, CuDFScalar,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Reads cuDF Parquet batches and aligns them to the scan output schema.
@@ -238,17 +238,10 @@ fn batch_has_missing_read_columns(
         if missing {
             return Ok(true);
         }
-        let metadata = source.metadata()?;
-        let available_columns = metadata
-            .file_metadata()
-            .schema_descr()
-            .columns()
-            .iter()
-            .map(|column| column.path().string())
-            .collect::<HashSet<_>>();
+        let available_columns = source.available_columns()?;
         Ok(required_columns
             .iter()
-            .any(|column| !available_columns.contains(column)))
+            .any(|column| !available_columns.contains(column.as_str())))
     })
 }
 

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
@@ -1,0 +1,350 @@
+use super::read_plan::FileBatch;
+use super::{CuDFParquetSource, RowGroupSelection};
+use crate::errors::cudf_to_df;
+use crate::physical::normalize_scalar_for_cudf;
+use arrow_schema::SchemaRef;
+use datafusion::common::{plan_err, DataFusionError};
+use datafusion::scalar::ScalarValue;
+use libcudf_rs::{
+    CuDFAstExpression, CuDFColumn, CuDFParquetReadOptions, CuDFParquetReadResult, CuDFScalar,
+};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Reads cuDF Parquet batches and aligns them to the scan output schema.
+pub(super) struct ParquetBatchReader {
+    schema: SchemaRef,
+    read_columns: Option<Arc<[String]>>,
+    filter: Option<Arc<CuDFAstExpression>>,
+}
+
+/// cuDF columns plus row count for one output batch.
+pub(super) struct ReadBatch {
+    pub(super) columns: Vec<CuDFColumn>,
+    pub(super) num_rows: usize,
+}
+
+impl ParquetBatchReader {
+    pub(super) fn new(
+        schema: SchemaRef,
+        read_columns: Option<Arc<[String]>>,
+        filter: Option<Arc<CuDFAstExpression>>,
+    ) -> Self {
+        Self {
+            schema,
+            read_columns,
+            filter,
+        }
+    }
+
+    pub(super) fn read(&self, batch: &FileBatch) -> datafusion::common::Result<ReadBatch> {
+        let read_columns = self.read_columns.as_deref();
+        let filter = self.filter.as_deref();
+        if batch_has_no_selected_row_groups(batch) {
+            return empty_read_batch(&self.schema);
+        }
+
+        if self.schema.fields().is_empty() && filter.is_none() {
+            return Ok(ReadBatch {
+                columns: vec![],
+                num_rows: parquet_batch_row_count(batch)?,
+            });
+        }
+
+        if batch_has_missing_read_columns(batch, read_columns, &self.schema)? {
+            return read_parquet_sources_individually(batch, read_columns, filter, &self.schema);
+        }
+
+        match read_parquet_sources_together(batch, read_columns, filter) {
+            Ok(read) => {
+                if batch.sources().len() == 1 || contains_all_schema_columns(&read, &self.schema) {
+                    return align_parquet_read(read, &self.schema);
+                }
+            }
+            Err(err) => {
+                if batch.sources().len() == 1 {
+                    return Err(err);
+                }
+            }
+        }
+
+        read_parquet_sources_individually(batch, read_columns, filter, &self.schema)
+    }
+}
+
+fn read_parquet_sources_together(
+    batch: &FileBatch,
+    read_columns: Option<&[String]>,
+    filter: Option<&CuDFAstExpression>,
+) -> datafusion::common::Result<CuDFParquetReadResult> {
+    if let [source] = batch.sources() {
+        return read_parquet_source(source, read_columns, filter);
+    }
+    let files = batch
+        .sources()
+        .iter()
+        .map(|source| &source.path)
+        .collect::<Vec<_>>();
+    let row_groups = parquet_batch_row_groups(batch)?;
+    libcudf_rs::CuDFTable::read_parquet_files(CuDFParquetReadOptions {
+        paths: &files,
+        columns: read_columns,
+        row_groups: row_groups.as_deref(),
+        filter,
+        allow_mismatched_pq_schemas: read_columns.is_some(),
+        ignore_missing_columns: true,
+    })
+    .map_err(cudf_to_df)
+}
+
+fn parquet_batch_row_groups(
+    batch: &FileBatch,
+) -> datafusion::common::Result<Option<Vec<Vec<i32>>>> {
+    if !batch
+        .sources()
+        .iter()
+        .any(|source| !matches!(source.row_group_selection(), RowGroupSelection::All))
+    {
+        return Ok(None);
+    }
+
+    batch
+        .sources()
+        .iter()
+        .map(cudf_row_groups_for_source)
+        .collect::<datafusion::common::Result<Vec<_>>>()
+        .map(Some)
+}
+
+fn cudf_row_groups_for_source(source: &CuDFParquetSource) -> datafusion::common::Result<Vec<i32>> {
+    match source.row_group_selection() {
+        RowGroupSelection::All => all_source_row_groups(source),
+        RowGroupSelection::Indices(indices) => Ok(indices.clone()),
+    }
+}
+
+fn all_source_row_groups(source: &CuDFParquetSource) -> datafusion::common::Result<Vec<i32>> {
+    let metadata = source.metadata()?;
+    (0..metadata.num_row_groups())
+        .map(|index| {
+            i32::try_from(index).map_err(|_| {
+                DataFusionError::Execution(
+                    "CuDFParquetScanExec row group index overflowed i32".to_string(),
+                )
+            })
+        })
+        .collect()
+}
+
+fn batch_has_no_selected_row_groups(batch: &FileBatch) -> bool {
+    batch
+        .sources()
+        .iter()
+        .all(|source| source.row_group_selection().is_empty())
+}
+
+fn batch_has_missing_read_columns(
+    batch: &FileBatch,
+    read_columns: Option<&[String]>,
+    schema: &SchemaRef,
+) -> datafusion::common::Result<bool> {
+    if batch.sources().len() <= 1 {
+        return Ok(false);
+    }
+
+    let schema_columns;
+    let required_columns = match read_columns {
+        Some(columns) => columns,
+        None => {
+            schema_columns = schema
+                .fields()
+                .iter()
+                .map(|field| field.name().clone())
+                .collect::<Vec<_>>();
+            schema_columns.as_slice()
+        }
+    };
+    if required_columns.is_empty() {
+        return Ok(false);
+    }
+
+    batch.sources().iter().try_fold(false, |missing, source| {
+        if missing {
+            return Ok(true);
+        }
+        let metadata = source.metadata()?;
+        let available_columns = metadata
+            .file_metadata()
+            .schema_descr()
+            .columns()
+            .iter()
+            .map(|column| column.path().string())
+            .collect::<HashSet<_>>();
+        Ok(required_columns
+            .iter()
+            .any(|column| !available_columns.contains(column)))
+    })
+}
+
+fn empty_read_batch(schema: &SchemaRef) -> datafusion::common::Result<ReadBatch> {
+    let columns = schema
+        .fields()
+        .iter()
+        .map(|field| null_column(field.data_type(), 0))
+        .collect::<datafusion::common::Result<Vec<_>>>()?;
+    Ok(ReadBatch {
+        columns,
+        num_rows: 0,
+    })
+}
+
+fn read_parquet_source(
+    source: &CuDFParquetSource,
+    read_columns: Option<&[String]>,
+    filter: Option<&CuDFAstExpression>,
+) -> datafusion::common::Result<CuDFParquetReadResult> {
+    let row_groups = source
+        .row_group_selection()
+        .indices()
+        .map(|indices| vec![indices.to_vec()]);
+    libcudf_rs::CuDFTable::read_parquet_files(CuDFParquetReadOptions {
+        paths: std::slice::from_ref(&source.path),
+        columns: read_columns,
+        row_groups: row_groups.as_deref(),
+        filter,
+        allow_mismatched_pq_schemas: read_columns.is_some(),
+        ignore_missing_columns: true,
+    })
+    .map_err(cudf_to_df)
+}
+
+fn read_parquet_sources_individually(
+    batch: &FileBatch,
+    read_columns: Option<&[String]>,
+    filter: Option<&CuDFAstExpression>,
+    schema: &SchemaRef,
+) -> datafusion::common::Result<ReadBatch> {
+    let mut columns_by_field = (0..schema.fields().len())
+        .map(|_| Vec::with_capacity(batch.sources().len()))
+        .collect::<Vec<Vec<CuDFColumn>>>();
+    let mut total_rows = 0usize;
+
+    for source in batch.sources() {
+        if source.row_group_selection().is_empty() {
+            continue;
+        }
+
+        let read = read_parquet_source(source, read_columns, filter)?;
+        let aligned = align_parquet_read(read, schema)?;
+        total_rows = total_rows.checked_add(aligned.num_rows).ok_or_else(|| {
+            DataFusionError::Execution("CuDFParquetScanExec row count overflowed usize".to_string())
+        })?;
+        for (index, column) in aligned.columns.into_iter().enumerate() {
+            columns_by_field[index].push(column);
+        }
+    }
+
+    let columns = columns_by_field
+        .into_iter()
+        .map(|columns| {
+            let views = columns
+                .into_iter()
+                .map(CuDFColumn::into_view)
+                .collect::<Vec<_>>();
+            CuDFColumn::concat(views).map_err(cudf_to_df)
+        })
+        .collect::<datafusion::common::Result<Vec<_>>>()?;
+
+    Ok(ReadBatch {
+        columns,
+        num_rows: total_rows,
+    })
+}
+
+fn align_parquet_read(
+    read: CuDFParquetReadResult,
+    schema: &SchemaRef,
+) -> datafusion::common::Result<ReadBatch> {
+    let columns = read.table.into_columns();
+    if read.column_names.len() != columns.len() {
+        return plan_err!(
+            "cuDF returned {} parquet column names for {} columns",
+            read.column_names.len(),
+            columns.len()
+        );
+    }
+
+    let mut columns_by_name = HashMap::with_capacity(columns.len());
+    for (name, column) in read.column_names.into_iter().zip(columns) {
+        if columns_by_name.insert(name.clone(), column).is_some() {
+            return plan_err!("cuDF parquet read returned duplicate column name '{name}'");
+        }
+    }
+
+    let mut columns = Vec::with_capacity(schema.fields().len());
+    for field in schema.fields() {
+        let column = match columns_by_name.remove(field.name().as_str()) {
+            Some(column) => column,
+            None => null_column(field.data_type(), read.num_rows)?,
+        };
+        columns.push(column);
+    }
+
+    Ok(ReadBatch {
+        columns,
+        num_rows: read.num_rows,
+    })
+}
+
+fn contains_all_schema_columns(read: &CuDFParquetReadResult, schema: &SchemaRef) -> bool {
+    schema.fields().iter().all(|field| {
+        read.column_names
+            .iter()
+            .any(|column_name| column_name == field.name())
+    })
+}
+
+fn null_column(
+    data_type: &arrow_schema::DataType,
+    num_rows: usize,
+) -> datafusion::common::Result<CuDFColumn> {
+    let scalar = normalize_scalar_for_cudf(ScalarValue::try_new_null(data_type)?)?;
+    let scalar = CuDFScalar::from_arrow_host(scalar.to_scalar()?).map_err(cudf_to_df)?;
+    CuDFColumn::from_scalar(&scalar, num_rows).map_err(cudf_to_df)
+}
+
+fn parquet_batch_row_count(batch: &FileBatch) -> datafusion::common::Result<usize> {
+    batch.sources().iter().try_fold(0usize, |rows, source| {
+        rows.checked_add(parquet_source_row_count(source)?)
+            .ok_or_else(|| {
+                DataFusionError::Execution(
+                    "CuDFParquetScanExec row count overflowed usize".to_string(),
+                )
+            })
+    })
+}
+
+fn parquet_source_row_count(source: &CuDFParquetSource) -> datafusion::common::Result<usize> {
+    let metadata = source.metadata()?;
+    let row_count = match source.row_group_selection() {
+        RowGroupSelection::Indices(row_groups) => {
+            row_groups.iter().try_fold(0i64, |rows, &index| {
+                let row_group = usize::try_from(index).map_err(|_| {
+                    DataFusionError::Execution(
+                        "CuDFParquetScanExec row group index was negative".to_string(),
+                    )
+                })?;
+                let row_group = metadata.row_group(row_group);
+                rows.checked_add(row_group.num_rows()).ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "CuDFParquetScanExec row count overflowed i64".to_string(),
+                    )
+                })
+            })?
+        }
+        RowGroupSelection::All => metadata.file_metadata().num_rows(),
+    };
+
+    usize::try_from(row_count)
+        .map_err(|_| DataFusionError::Execution("Parquet file row count was negative".to_string()))
+}

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/reader.rs
@@ -6,9 +6,11 @@ use arrow_schema::SchemaRef;
 use datafusion::common::{plan_err, DataFusionError};
 use datafusion::scalar::ScalarValue;
 use libcudf_rs::{
-    CuDFAstExpression, CuDFColumn, CuDFParquetReadOptions, CuDFParquetReadResult, CuDFScalar,
+    CuDFAstExpression, CuDFColumn, CuDFError, CuDFParquetReadOptions, CuDFParquetReadResult,
+    CuDFScalar,
 };
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 /// Reads cuDF Parquet batches and aligns them to the scan output schema.
@@ -24,6 +26,11 @@ pub(super) struct ParquetBatchReader {
 pub(super) struct ReadBatch {
     pub(super) columns: Vec<CuDFColumn>,
     pub(super) num_rows: usize,
+}
+
+enum ChunkReadOutcome {
+    Finished { emitted: bool, continued: bool },
+    CudfErrorBeforeEmit(CuDFError),
 }
 
 impl ParquetBatchReader {
@@ -84,6 +91,59 @@ impl ParquetBatchReader {
     }
 }
 
+fn read_parquet_chunks<P>(
+    paths: &[P],
+    row_groups: Option<&[Vec<i32>]>,
+    read_columns: Option<&[String]>,
+    filter: Option<&CuDFAstExpression>,
+    chunk_read_limit: usize,
+    pass_read_limit: usize,
+    schema: &SchemaRef,
+    emit: &mut impl FnMut(ReadBatch) -> datafusion::common::Result<bool>,
+) -> datafusion::common::Result<ChunkReadOutcome>
+where
+    P: AsRef<Path>,
+{
+    let mut emitted = false;
+    let mut continued = true;
+    let mut callback_error = None;
+    let read_result = libcudf_rs::CuDFTable::for_each_parquet_chunk(
+        CuDFParquetReadOptions {
+            paths,
+            columns: read_columns,
+            row_groups,
+            filter,
+            allow_mismatched_pq_schemas: read_columns.is_some(),
+            ignore_missing_columns: true,
+        },
+        chunk_read_limit,
+        pass_read_limit,
+        |read| {
+            emitted = true;
+            match align_parquet_read(read, schema).and_then(&mut *emit) {
+                Ok(keep_reading) => {
+                    continued = keep_reading;
+                    Ok(keep_reading)
+                }
+                Err(err) => {
+                    continued = false;
+                    callback_error = Some(err);
+                    Ok(false)
+                }
+            }
+        },
+    );
+
+    if let Some(err) = callback_error {
+        return Err(err);
+    }
+    match read_result {
+        Ok(()) => Ok(ChunkReadOutcome::Finished { emitted, continued }),
+        Err(err) if !emitted => Ok(ChunkReadOutcome::CudfErrorBeforeEmit(err)),
+        Err(err) => Err(cudf_to_df(err)),
+    }
+}
+
 fn read_parquet_sources_together(
     batch: &FileBatch,
     read_columns: Option<&[String]>,
@@ -109,43 +169,29 @@ fn read_parquet_sources_together(
         .iter()
         .map(|source| &source.path)
         .collect::<Vec<_>>();
-    let row_groups = parquet_batch_row_groups(batch)?;
-    let mut emitted = false;
-    let mut continued = true;
-    let mut callback_error = None;
-    let read_result = libcudf_rs::CuDFTable::for_each_parquet_chunk(
-        CuDFParquetReadOptions {
-            paths: &files,
-            columns: read_columns,
-            row_groups: row_groups.as_deref(),
-            filter,
-            allow_mismatched_pq_schemas: read_columns.is_some(),
-            ignore_missing_columns: true,
-        },
+    let row_groups = explicit_row_groups_for_batch(batch)?;
+
+    match read_parquet_chunks(
+        &files,
+        row_groups.as_deref(),
+        read_columns,
+        filter,
         chunk_read_limit,
         pass_read_limit,
-        |read| {
-            emitted = true;
-            match align_parquet_read(read, schema).and_then(&mut *emit) {
-                Ok(keep_reading) => {
-                    continued = keep_reading;
-                    Ok(keep_reading)
-                }
-                Err(err) => {
-                    continued = false;
-                    callback_error = Some(err);
-                    Ok(false)
-                }
+        schema,
+        emit,
+    )? {
+        ChunkReadOutcome::Finished { emitted, continued } => {
+            if !emitted {
+                return emit(empty_read_batch(schema)?);
             }
-        },
-    );
-    if let Some(err) = callback_error {
-        return Err(err);
-    }
-    match read_result {
-        Ok(()) => {}
-        Err(err) if !emitted => {
-            return read_parquet_sources_individually(
+            Ok(continued)
+        }
+        ChunkReadOutcome::CudfErrorBeforeEmit(_) => {
+            // Multi-file cuDF reads can fail when files have schema differences
+            // that are still valid under DataFusion's schema adaptation rules.
+            // Retry per source so missing columns can be null-filled independently.
+            read_parquet_sources_individually(
                 batch,
                 read_columns,
                 filter,
@@ -153,19 +199,17 @@ fn read_parquet_sources_together(
                 chunk_read_limit,
                 pass_read_limit,
                 emit,
-            );
+            )
         }
-        Err(err) => return Err(cudf_to_df(err)),
     }
-    if !emitted {
-        return emit(empty_read_batch(schema)?);
-    }
-    Ok(continued)
 }
 
-fn parquet_batch_row_groups(
+fn explicit_row_groups_for_batch(
     batch: &FileBatch,
 ) -> datafusion::common::Result<Option<Vec<Vec<i32>>>> {
+    // cuDF expects either no row-group argument for all row groups in every file,
+    // or one explicit row-group vector per file. If any source is pruned, expand
+    // unpruned sources to explicit indices so mixed batches stay aligned.
     if !batch
         .sources()
         .iter()
@@ -177,19 +221,21 @@ fn parquet_batch_row_groups(
     batch
         .sources()
         .iter()
-        .map(cudf_row_groups_for_source)
+        .map(explicit_row_groups_for_source)
         .collect::<datafusion::common::Result<Vec<_>>>()
         .map(Some)
 }
 
-fn cudf_row_groups_for_source(source: &CuDFParquetSource) -> datafusion::common::Result<Vec<i32>> {
+fn explicit_row_groups_for_source(
+    source: &CuDFParquetSource,
+) -> datafusion::common::Result<Vec<i32>> {
     match source.row_group_selection() {
-        RowGroupSelection::All => all_source_row_groups(source),
+        RowGroupSelection::All => all_row_group_indices(source),
         RowGroupSelection::Indices(indices) => Ok(indices.clone()),
     }
 }
 
-fn all_source_row_groups(source: &CuDFParquetSource) -> datafusion::common::Result<Vec<i32>> {
+fn all_row_group_indices(source: &CuDFParquetSource) -> datafusion::common::Result<Vec<i32>> {
     let metadata = source.metadata()?;
     (0..metadata.num_row_groups())
         .map(|index| {
@@ -270,43 +316,24 @@ fn read_parquet_source(
         .row_group_selection()
         .indices()
         .map(|indices| vec![indices.to_vec()]);
-    let mut emitted = false;
-    let mut continued = true;
-    let mut callback_error = None;
-    let read_result = libcudf_rs::CuDFTable::for_each_parquet_chunk(
-        CuDFParquetReadOptions {
-            paths: std::slice::from_ref(&source.path),
-            columns: read_columns,
-            row_groups: row_groups.as_deref(),
-            filter,
-            allow_mismatched_pq_schemas: read_columns.is_some(),
-            ignore_missing_columns: true,
-        },
+    match read_parquet_chunks(
+        std::slice::from_ref(&source.path),
+        row_groups.as_deref(),
+        read_columns,
+        filter,
         chunk_read_limit,
         pass_read_limit,
-        |read| {
-            emitted = true;
-            match align_parquet_read(read, schema).and_then(&mut *emit) {
-                Ok(keep_reading) => {
-                    continued = keep_reading;
-                    Ok(keep_reading)
-                }
-                Err(err) => {
-                    continued = false;
-                    callback_error = Some(err);
-                    Ok(false)
-                }
+        schema,
+        emit,
+    )? {
+        ChunkReadOutcome::Finished { emitted, continued } => {
+            if !emitted {
+                return emit(empty_read_batch(schema)?);
             }
-        },
-    );
-    if let Some(err) = callback_error {
-        return Err(err);
+            Ok(continued)
+        }
+        ChunkReadOutcome::CudfErrorBeforeEmit(err) => Err(cudf_to_df(err)),
     }
-    read_result.map_err(cudf_to_df)?;
-    if !emitted {
-        return emit(empty_read_batch(schema)?);
-    }
-    Ok(continued)
 }
 
 fn read_parquet_sources_individually(

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
@@ -1,0 +1,214 @@
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::listing::{FileRange, PartitionedFile};
+use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroupAccessPlanFilter};
+use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use datafusion::parquet::file::metadata::ParquetMetaData;
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Local Parquet file accepted by the v1 cuDF scan.
+#[derive(Debug, Clone)]
+pub(crate) struct CuDFParquetSource {
+    /// Local filesystem path.
+    pub(crate) path: PathBuf,
+    pub(crate) byte_len: usize,
+    pub(crate) row_groups: RowGroupSelection,
+}
+
+/// Parquet row groups selected for one source file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RowGroupSelection {
+    /// Read every row group from the file.
+    All,
+    /// Read only these row group indices.
+    Indices(Vec<i32>),
+}
+
+/// Reason a DataFusion Parquet file could not become a cuDF scan source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CuDFParquetSourceError {
+    /// Partition columns would need host-side value materialization.
+    PartitionValues,
+    /// File extensions may carry access plans that v1 does not map to cuDF.
+    FileExtensions,
+    /// File size does not fit this platform's `usize`.
+    FileSizeOverflow,
+    /// Parquet metadata could not be read.
+    FileMetadata,
+    /// A Parquet row group index does not fit cuDF's `size_type`.
+    RowGroupIndexOverflow,
+    /// File byte range does not fit this platform's `usize`.
+    FileRangeOverflow,
+}
+
+/// Converts DataFusion Parquet files into cuDF scan sources.
+#[derive(Debug, Default)]
+pub(crate) struct CuDFParquetSourceBuilder {
+    metadata_by_path: HashMap<PathBuf, Arc<ParquetMetaData>>,
+}
+
+impl CuDFParquetSource {
+    pub(crate) fn byte_len(&self) -> usize {
+        if self.byte_len > 0 {
+            return self.byte_len;
+        }
+        std::fs::metadata(&self.path)
+            .ok()
+            .and_then(|metadata| usize::try_from(metadata.len()).ok())
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn row_group_selection(&self) -> &RowGroupSelection {
+        &self.row_groups
+    }
+
+    pub(crate) fn metadata(&self) -> Result<Arc<ParquetMetaData>> {
+        parquet_metadata(&self.path)
+    }
+}
+
+impl CuDFParquetSourceBuilder {
+    pub(crate) fn try_from_partitioned_file(
+        &mut self,
+        file: &PartitionedFile,
+    ) -> std::result::Result<CuDFParquetSource, CuDFParquetSourceError> {
+        if !file.partition_values.is_empty() {
+            return Err(CuDFParquetSourceError::PartitionValues);
+        }
+        if file.extensions.is_some() {
+            return Err(CuDFParquetSourceError::FileExtensions);
+        }
+
+        let path = local_path(file.object_meta.location.as_ref());
+        let row_groups = file
+            .range
+            .as_ref()
+            .map(|range| self.row_groups_in_range(&path, range))
+            .transpose()?
+            .map(RowGroupSelection::Indices)
+            .unwrap_or(RowGroupSelection::All);
+        let byte_len = partitioned_file_byte_len(file)?;
+
+        Ok(CuDFParquetSource {
+            path,
+            byte_len,
+            row_groups,
+        })
+    }
+
+    fn row_groups_in_range(
+        &mut self,
+        path: &Path,
+        range: &FileRange,
+    ) -> std::result::Result<Vec<i32>, CuDFParquetSourceError> {
+        let metadata = self.metadata(path)?;
+        row_groups_in_range(&metadata, range)
+    }
+
+    fn metadata(
+        &mut self,
+        path: &Path,
+    ) -> std::result::Result<Arc<ParquetMetaData>, CuDFParquetSourceError> {
+        if let Some(metadata) = self.metadata_by_path.get(path) {
+            return Ok(Arc::clone(metadata));
+        }
+
+        let metadata = parquet_metadata(path).map_err(|_| CuDFParquetSourceError::FileMetadata)?;
+        self.metadata_by_path
+            .insert(path.to_path_buf(), Arc::clone(&metadata));
+        Ok(metadata)
+    }
+}
+
+impl RowGroupSelection {
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self, Self::Indices(indices) if indices.is_empty())
+    }
+
+    pub(crate) fn indices(&self) -> Option<&[i32]> {
+        match self {
+            Self::All => None,
+            Self::Indices(indices) => Some(indices),
+        }
+    }
+}
+
+fn local_path(location: &str) -> PathBuf {
+    if location.starts_with('/') {
+        location.into()
+    } else {
+        PathBuf::from("/").join(location)
+    }
+}
+
+fn parquet_metadata(path: &Path) -> Result<Arc<ParquetMetaData>> {
+    let file = File::open(path).map_err(|err| {
+        DataFusionError::Execution(format!(
+            "failed to open parquet metadata for {}: {err}",
+            path.display()
+        ))
+    })?;
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    Ok(Arc::clone(reader.metadata()))
+}
+
+fn partitioned_file_byte_len(
+    file: &PartitionedFile,
+) -> std::result::Result<usize, CuDFParquetSourceError> {
+    match &file.range {
+        Some(range) => {
+            let byte_len = range
+                .end
+                .checked_sub(range.start)
+                .filter(|byte_len| *byte_len >= 0)
+                .ok_or(CuDFParquetSourceError::FileRangeOverflow)?;
+            usize::try_from(byte_len).map_err(|_| CuDFParquetSourceError::FileRangeOverflow)
+        }
+        None => usize::try_from(file.object_meta.size)
+            .map_err(|_| CuDFParquetSourceError::FileSizeOverflow),
+    }
+}
+
+fn row_groups_in_range(
+    metadata: &ParquetMetaData,
+    range: &FileRange,
+) -> std::result::Result<Vec<i32>, CuDFParquetSourceError> {
+    let access_plan = ParquetAccessPlan::new_all(metadata.num_row_groups());
+    let mut filter = RowGroupAccessPlanFilter::new(access_plan);
+    filter.prune_by_range(metadata.row_groups(), range);
+
+    filter
+        .build()
+        .row_group_indexes()
+        .into_iter()
+        .map(|index| {
+            i32::try_from(index).map_err(|_| CuDFParquetSourceError::RowGroupIndexOverflow)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{partitioned_file_byte_len, RowGroupSelection};
+    use datafusion::datasource::listing::PartitionedFile;
+    use std::path::PathBuf;
+
+    #[test]
+    fn partitioned_file_byte_len_uses_file_range() -> Result<(), Box<dyn std::error::Error>> {
+        let path = weather_file("result-000000.parquet");
+        let size = std::fs::metadata(&path)?.len();
+        let file = PartitionedFile::new(path.to_string_lossy(), size).with_range(10, 25);
+        let byte_len = partitioned_file_byte_len(&file)
+            .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
+
+        assert_eq!(byte_len, 15);
+        assert_eq!(RowGroupSelection::Indices(vec![]).indices(), Some(&[][..]));
+        Ok(())
+    }
+
+    fn weather_file(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("../testdata/weather/{name}"))
+    }
+}

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
@@ -5,7 +5,7 @@ use datafusion::datasource::physical_plan::parquet::{
 };
 use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use datafusion::parquet::file::metadata::ParquetMetaData;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -18,6 +18,7 @@ pub(crate) struct CuDFParquetSource {
     pub(crate) byte_len: usize,
     pub(crate) row_groups: RowGroupSelection,
     metadata: Arc<OnceLock<Arc<ParquetMetaData>>>,
+    columns: Arc<OnceLock<Arc<HashSet<String>>>>,
 }
 
 /// Parquet row groups selected for one source file.
@@ -52,6 +53,7 @@ pub(crate) enum CuDFParquetSourceError {
 #[derive(Debug, Default)]
 pub(crate) struct CuDFParquetSourceBuilder {
     metadata_by_path: HashMap<PathBuf, Arc<OnceLock<Arc<ParquetMetaData>>>>,
+    columns_by_path: HashMap<PathBuf, Arc<OnceLock<Arc<HashSet<String>>>>>,
 }
 
 impl CuDFParquetSource {
@@ -60,12 +62,14 @@ impl CuDFParquetSource {
         byte_len: usize,
         row_groups: RowGroupSelection,
         metadata: Arc<OnceLock<Arc<ParquetMetaData>>>,
+        columns: Arc<OnceLock<Arc<HashSet<String>>>>,
     ) -> Self {
         Self {
             path,
             byte_len,
             row_groups,
             metadata,
+            columns,
         }
     }
 
@@ -86,6 +90,10 @@ impl CuDFParquetSource {
     pub(crate) fn metadata(&self) -> Result<Arc<ParquetMetaData>> {
         parquet_metadata_cached(&self.path, &self.metadata)
     }
+
+    pub(crate) fn available_columns(&self) -> Result<Arc<HashSet<String>>> {
+        parquet_columns_cached(self, &self.columns)
+    }
 }
 
 impl CuDFParquetSourceBuilder {
@@ -101,8 +109,9 @@ impl CuDFParquetSourceBuilder {
         let byte_len = partitioned_file_byte_len(file)?;
 
         let metadata = self.metadata_cache(&path);
+        let columns = self.columns_cache(&path);
         Ok(CuDFParquetSource::with_metadata_cache(
-            path, byte_len, row_groups, metadata,
+            path, byte_len, row_groups, metadata, columns,
         ))
     }
 
@@ -135,6 +144,14 @@ impl CuDFParquetSourceBuilder {
                 .or_insert_with(|| Arc::new(OnceLock::new())),
         )
     }
+
+    fn columns_cache(&mut self, path: &Path) -> Arc<OnceLock<Arc<HashSet<String>>>> {
+        Arc::clone(
+            self.columns_by_path
+                .entry(path.to_path_buf())
+                .or_insert_with(|| Arc::new(OnceLock::new())),
+        )
+    }
 }
 
 impl RowGroupSelection {
@@ -151,10 +168,13 @@ impl RowGroupSelection {
 }
 
 fn local_path(location: &str) -> PathBuf {
-    if location.starts_with('/') {
-        location.into()
+    let path = location
+        .strip_prefix("file://")
+        .map_or_else(|| PathBuf::from(location), PathBuf::from);
+    if path.is_absolute() || path.exists() {
+        path
     } else {
-        PathBuf::from("/").join(location)
+        PathBuf::from("/").join(path)
     }
 }
 
@@ -182,6 +202,30 @@ fn parquet_metadata_cached(
     Ok(cache
         .get()
         .map_or(metadata, |metadata| Arc::clone(metadata)))
+}
+
+fn parquet_columns_cached(
+    source: &CuDFParquetSource,
+    cache: &OnceLock<Arc<HashSet<String>>>,
+) -> Result<Arc<HashSet<String>>> {
+    if let Some(columns) = cache.get() {
+        return Ok(Arc::clone(columns));
+    }
+
+    let metadata = source.metadata()?;
+    let columns = Arc::new(parquet_columns(&metadata));
+    let _ = cache.set(Arc::clone(&columns));
+    Ok(cache.get().map_or(columns, |columns| Arc::clone(columns)))
+}
+
+fn parquet_columns(metadata: &ParquetMetaData) -> HashSet<String> {
+    metadata
+        .file_metadata()
+        .schema_descr()
+        .columns()
+        .iter()
+        .map(|column| column.path().string())
+        .collect()
 }
 
 fn partitioned_file_byte_len(
@@ -251,7 +295,9 @@ fn row_group_selection_from_access_plan(
 
 #[cfg(test)]
 mod tests {
-    use super::{partitioned_file_byte_len, CuDFParquetSourceBuilder, RowGroupSelection};
+    use super::{
+        local_path, partitioned_file_byte_len, CuDFParquetSourceBuilder, RowGroupSelection,
+    };
     use datafusion::datasource::listing::PartitionedFile;
     use datafusion::datasource::physical_plan::parquet::ParquetAccessPlan;
     use datafusion::parquet::arrow::arrow_reader::{RowSelection, RowSelector};
@@ -272,6 +318,24 @@ mod tests {
     }
 
     #[test]
+    fn local_path_resolves_relative_and_absolute_local_paths(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let weather = weather_file("result-000000.parquet");
+        let stripped_absolute = weather
+            .strip_prefix("/")
+            .expect("weather path should be absolute")
+            .to_string_lossy();
+
+        assert_eq!(local_path("Cargo.toml"), PathBuf::from("Cargo.toml"));
+        assert_eq!(local_path(stripped_absolute.as_ref()), weather);
+        assert_eq!(
+            local_path("file:///tmp/file.parquet"),
+            PathBuf::from("/tmp/file.parquet")
+        );
+        Ok(())
+    }
+
+    #[test]
     fn source_metadata_is_loaded_once() -> Result<(), Box<dyn std::error::Error>> {
         let path = weather_file("result-000000.parquet");
         let source = source_for_path(&path)?;
@@ -280,6 +344,19 @@ mod tests {
         let second = source.metadata()?;
 
         assert!(Arc::ptr_eq(&first, &second));
+        Ok(())
+    }
+
+    #[test]
+    fn source_available_columns_are_loaded_once() -> Result<(), Box<dyn std::error::Error>> {
+        let path = weather_file("result-000000.parquet");
+        let source = source_for_path(&path)?;
+
+        let first = source.available_columns()?;
+        let second = source.available_columns()?;
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(!first.is_empty());
         Ok(())
     }
 
@@ -296,6 +373,10 @@ mod tests {
             .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
 
         assert!(Arc::ptr_eq(&first.metadata()?, &second.metadata()?));
+        assert!(Arc::ptr_eq(
+            &first.available_columns()?,
+            &second.available_columns()?
+        ));
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
@@ -6,7 +6,7 @@ use datafusion::parquet::file::metadata::ParquetMetaData;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Local Parquet file accepted by the v1 cuDF scan.
 #[derive(Debug, Clone)]
@@ -15,6 +15,7 @@ pub(crate) struct CuDFParquetSource {
     pub(crate) path: PathBuf,
     pub(crate) byte_len: usize,
     pub(crate) row_groups: RowGroupSelection,
+    metadata: Arc<OnceLock<Arc<ParquetMetaData>>>,
 }
 
 /// Parquet row groups selected for one source file.
@@ -46,10 +47,24 @@ pub(crate) enum CuDFParquetSourceError {
 /// Converts DataFusion Parquet files into cuDF scan sources.
 #[derive(Debug, Default)]
 pub(crate) struct CuDFParquetSourceBuilder {
-    metadata_by_path: HashMap<PathBuf, Arc<ParquetMetaData>>,
+    metadata_by_path: HashMap<PathBuf, Arc<OnceLock<Arc<ParquetMetaData>>>>,
 }
 
 impl CuDFParquetSource {
+    fn with_metadata_cache(
+        path: PathBuf,
+        byte_len: usize,
+        row_groups: RowGroupSelection,
+        metadata: Arc<OnceLock<Arc<ParquetMetaData>>>,
+    ) -> Self {
+        Self {
+            path,
+            byte_len,
+            row_groups,
+            metadata,
+        }
+    }
+
     pub(crate) fn byte_len(&self) -> usize {
         if self.byte_len > 0 {
             return self.byte_len;
@@ -65,7 +80,7 @@ impl CuDFParquetSource {
     }
 
     pub(crate) fn metadata(&self) -> Result<Arc<ParquetMetaData>> {
-        parquet_metadata(&self.path)
+        parquet_metadata_cached(&self.path, &self.metadata)
     }
 }
 
@@ -91,11 +106,10 @@ impl CuDFParquetSourceBuilder {
             .unwrap_or(RowGroupSelection::All);
         let byte_len = partitioned_file_byte_len(file)?;
 
-        Ok(CuDFParquetSource {
-            path,
-            byte_len,
-            row_groups,
-        })
+        let metadata = self.metadata_cache(&path);
+        Ok(CuDFParquetSource::with_metadata_cache(
+            path, byte_len, row_groups, metadata,
+        ))
     }
 
     fn row_groups_in_range(
@@ -111,14 +125,16 @@ impl CuDFParquetSourceBuilder {
         &mut self,
         path: &Path,
     ) -> std::result::Result<Arc<ParquetMetaData>, CuDFParquetSourceError> {
-        if let Some(metadata) = self.metadata_by_path.get(path) {
-            return Ok(Arc::clone(metadata));
-        }
+        parquet_metadata_cached(path, &self.metadata_cache(path))
+            .map_err(|_| CuDFParquetSourceError::FileMetadata)
+    }
 
-        let metadata = parquet_metadata(path).map_err(|_| CuDFParquetSourceError::FileMetadata)?;
-        self.metadata_by_path
-            .insert(path.to_path_buf(), Arc::clone(&metadata));
-        Ok(metadata)
+    fn metadata_cache(&mut self, path: &Path) -> Arc<OnceLock<Arc<ParquetMetaData>>> {
+        Arc::clone(
+            self.metadata_by_path
+                .entry(path.to_path_buf())
+                .or_insert_with(|| Arc::new(OnceLock::new())),
+        )
     }
 }
 
@@ -152,6 +168,21 @@ fn parquet_metadata(path: &Path) -> Result<Arc<ParquetMetaData>> {
     })?;
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)?;
     Ok(Arc::clone(reader.metadata()))
+}
+
+fn parquet_metadata_cached(
+    path: &Path,
+    cache: &OnceLock<Arc<ParquetMetaData>>,
+) -> Result<Arc<ParquetMetaData>> {
+    if let Some(metadata) = cache.get() {
+        return Ok(Arc::clone(metadata));
+    }
+
+    let metadata = parquet_metadata(path)?;
+    let _ = cache.set(Arc::clone(&metadata));
+    Ok(cache
+        .get()
+        .map_or(metadata, |metadata| Arc::clone(metadata)))
 }
 
 fn partitioned_file_byte_len(
@@ -191,9 +222,10 @@ fn row_groups_in_range(
 
 #[cfg(test)]
 mod tests {
-    use super::{partitioned_file_byte_len, RowGroupSelection};
+    use super::{partitioned_file_byte_len, CuDFParquetSourceBuilder, RowGroupSelection};
     use datafusion::datasource::listing::PartitionedFile;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[test]
     fn partitioned_file_byte_len_uses_file_range() -> Result<(), Box<dyn std::error::Error>> {
@@ -208,7 +240,52 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn source_metadata_is_loaded_once() -> Result<(), Box<dyn std::error::Error>> {
+        let path = weather_file("result-000000.parquet");
+        let source = source_for_path(&path)?;
+
+        let first = source.metadata()?;
+        let second = source.metadata()?;
+
+        assert!(Arc::ptr_eq(&first, &second));
+        Ok(())
+    }
+
+    #[test]
+    fn builder_sources_share_metadata_cache() -> Result<(), Box<dyn std::error::Error>> {
+        let path = weather_file("result-000000.parquet");
+        let mut builder = CuDFParquetSourceBuilder::default();
+
+        let first = builder
+            .try_from_partitioned_file(&partitioned_file(&path)?)
+            .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
+        let second = builder
+            .try_from_partitioned_file(&partitioned_file(&path)?)
+            .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
+
+        assert!(Arc::ptr_eq(&first.metadata()?, &second.metadata()?));
+        Ok(())
+    }
+
+    fn source_for_path(
+        path: &PathBuf,
+    ) -> Result<super::CuDFParquetSource, Box<dyn std::error::Error>> {
+        let mut builder = CuDFParquetSourceBuilder::default();
+        builder
+            .try_from_partitioned_file(&partitioned_file(path)?)
+            .map_err(|err| std::io::Error::other(format!("{err:?}")).into())
+    }
+
+    fn partitioned_file(path: &PathBuf) -> Result<PartitionedFile, Box<dyn std::error::Error>> {
+        let size = std::fs::metadata(path)?.len();
+        Ok(PartitionedFile::new(path.to_string_lossy(), size))
+    }
+
     fn weather_file(name: &str) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("../testdata/weather/{name}"))
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(format!("../testdata/weather/{name}"))
+            .canonicalize()
+            .expect("weather test file should exist")
     }
 }

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
@@ -1,6 +1,8 @@
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::listing::{FileRange, PartitionedFile};
-use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroupAccessPlanFilter};
+use datafusion::datasource::physical_plan::parquet::{
+    ParquetAccessPlan, RowGroupAccess, RowGroupAccessPlanFilter,
+};
 use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use datafusion::parquet::file::metadata::ParquetMetaData;
 use std::collections::HashMap;
@@ -32,8 +34,10 @@ pub(crate) enum RowGroupSelection {
 pub(crate) enum CuDFParquetSourceError {
     /// Partition columns would need host-side value materialization.
     PartitionValues,
-    /// File extensions may carry access plans that v1 does not map to cuDF.
+    /// File extensions carry unsupported reader-specific behavior.
     FileExtensions,
+    /// Parquet access plan contains row selections that cuDF cannot represent.
+    PartialRowSelection,
     /// File size does not fit this platform's `usize`.
     FileSizeOverflow,
     /// Parquet metadata could not be read.
@@ -92,18 +96,8 @@ impl CuDFParquetSourceBuilder {
         if !file.partition_values.is_empty() {
             return Err(CuDFParquetSourceError::PartitionValues);
         }
-        if file.extensions.is_some() {
-            return Err(CuDFParquetSourceError::FileExtensions);
-        }
-
         let path = local_path(file.object_meta.location.as_ref());
-        let row_groups = file
-            .range
-            .as_ref()
-            .map(|range| self.row_groups_in_range(&path, range))
-            .transpose()?
-            .map(RowGroupSelection::Indices)
-            .unwrap_or(RowGroupSelection::All);
+        let row_groups = self.row_group_selection(&path, file)?;
         let byte_len = partitioned_file_byte_len(file)?;
 
         let metadata = self.metadata_cache(&path);
@@ -112,13 +106,18 @@ impl CuDFParquetSourceBuilder {
         ))
     }
 
-    fn row_groups_in_range(
+    fn row_group_selection(
         &mut self,
         path: &Path,
-        range: &FileRange,
-    ) -> std::result::Result<Vec<i32>, CuDFParquetSourceError> {
+        file: &PartitionedFile,
+    ) -> std::result::Result<RowGroupSelection, CuDFParquetSourceError> {
+        if file.extensions.is_none() && file.range.is_none() {
+            return Ok(RowGroupSelection::All);
+        }
+
         let metadata = self.metadata(path)?;
-        row_groups_in_range(&metadata, range)
+        let access_plan = access_plan_from_extension(file, metadata.num_row_groups())?;
+        row_group_selection_from_access_plan(&metadata, file.range.as_ref(), access_plan)
     }
 
     fn metadata(
@@ -202,28 +201,60 @@ fn partitioned_file_byte_len(
     }
 }
 
-fn row_groups_in_range(
-    metadata: &ParquetMetaData,
-    range: &FileRange,
-) -> std::result::Result<Vec<i32>, CuDFParquetSourceError> {
-    let access_plan = ParquetAccessPlan::new_all(metadata.num_row_groups());
-    let mut filter = RowGroupAccessPlanFilter::new(access_plan);
-    filter.prune_by_range(metadata.row_groups(), range);
+fn access_plan_from_extension(
+    file: &PartitionedFile,
+    row_group_count: usize,
+) -> std::result::Result<ParquetAccessPlan, CuDFParquetSourceError> {
+    let Some(extensions) = &file.extensions else {
+        return Ok(ParquetAccessPlan::new_all(row_group_count));
+    };
+    let Some(access_plan) = extensions.downcast_ref::<ParquetAccessPlan>() else {
+        return Err(CuDFParquetSourceError::FileExtensions);
+    };
+    if access_plan.len() != row_group_count {
+        return Err(CuDFParquetSourceError::FileExtensions);
+    }
+    if access_plan
+        .inner()
+        .iter()
+        .any(|access| matches!(access, RowGroupAccess::Selection(_)))
+    {
+        return Err(CuDFParquetSourceError::PartialRowSelection);
+    }
+    Ok(access_plan.clone())
+}
 
-    filter
-        .build()
+fn row_group_selection_from_access_plan(
+    metadata: &ParquetMetaData,
+    range: Option<&FileRange>,
+    access_plan: ParquetAccessPlan,
+) -> std::result::Result<RowGroupSelection, CuDFParquetSourceError> {
+    let mut filter = RowGroupAccessPlanFilter::new(access_plan);
+    if let Some(range) = range {
+        filter.prune_by_range(metadata.row_groups(), range);
+    }
+
+    let access_plan = filter.build();
+    if access_plan.row_group_indexes().len() == metadata.num_row_groups() {
+        return Ok(RowGroupSelection::All);
+    }
+
+    access_plan
         .row_group_indexes()
         .into_iter()
         .map(|index| {
             i32::try_from(index).map_err(|_| CuDFParquetSourceError::RowGroupIndexOverflow)
         })
-        .collect()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map(RowGroupSelection::Indices)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{partitioned_file_byte_len, CuDFParquetSourceBuilder, RowGroupSelection};
     use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::physical_plan::parquet::ParquetAccessPlan;
+    use datafusion::parquet::arrow::arrow_reader::{RowSelection, RowSelector};
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -265,6 +296,52 @@ mod tests {
             .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
 
         assert!(Arc::ptr_eq(&first.metadata()?, &second.metadata()?));
+        Ok(())
+    }
+
+    #[test]
+    fn parquet_access_plan_selects_whole_row_groups() -> Result<(), Box<dyn std::error::Error>> {
+        let path = weather_file("result-000000.parquet");
+        let mut builder = CuDFParquetSourceBuilder::default();
+        let row_group_count = source_for_path(&path)?.metadata()?.num_row_groups();
+        let mut access_plan = ParquetAccessPlan::new_all(row_group_count);
+        access_plan.skip(0);
+
+        let source = builder
+            .try_from_partitioned_file(
+                &partitioned_file(&path)?.with_extensions(Arc::new(access_plan)),
+            )
+            .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
+
+        let expected = (1..row_group_count)
+            .map(i32::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            source.row_group_selection(),
+            &RowGroupSelection::Indices(expected)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parquet_access_plan_with_row_selection_is_unsupported(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let path = weather_file("result-000000.parquet");
+        let mut builder = CuDFParquetSourceBuilder::default();
+        let row_group_count = source_for_path(&path)?.metadata()?.num_row_groups();
+        let mut access_plan = ParquetAccessPlan::new_all(row_group_count);
+        access_plan.scan_selection(
+            0,
+            RowSelection::from(vec![RowSelector::select(1), RowSelector::skip(1)]),
+        );
+
+        let err = builder
+            .try_from_partitioned_file(
+                &partitioned_file(&path)?.with_extensions(Arc::new(access_plan)),
+            )
+            .expect_err("partial row selections should remain on the DataFusion path");
+
+        assert_eq!(err, super::CuDFParquetSourceError::PartialRowSelection);
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
+++ b/libcudf-datafusion/src/physical/cudf_parquet_scan/scan_source.rs
@@ -17,8 +17,7 @@ pub(crate) struct CuDFParquetSource {
     pub(crate) path: PathBuf,
     pub(crate) byte_len: usize,
     pub(crate) row_groups: RowGroupSelection,
-    metadata: Arc<OnceLock<Arc<ParquetMetaData>>>,
-    columns: Arc<OnceLock<Arc<HashSet<String>>>>,
+    cache: Arc<SourceCache>,
 }
 
 /// Parquet row groups selected for one source file.
@@ -52,24 +51,29 @@ pub(crate) enum CuDFParquetSourceError {
 /// Converts DataFusion Parquet files into cuDF scan sources.
 #[derive(Debug, Default)]
 pub(crate) struct CuDFParquetSourceBuilder {
-    metadata_by_path: HashMap<PathBuf, Arc<OnceLock<Arc<ParquetMetaData>>>>,
-    columns_by_path: HashMap<PathBuf, Arc<OnceLock<Arc<HashSet<String>>>>>,
+    cache_by_path: HashMap<PathBuf, Arc<SourceCache>>,
+}
+
+#[derive(Debug, Default)]
+struct SourceCache {
+    // Shared per-path metadata cache. Source builders can create multiple scan
+    // sources for the same file when ranges or access plans split work.
+    metadata: OnceLock<Arc<ParquetMetaData>>,
+    columns: OnceLock<Arc<HashSet<String>>>,
 }
 
 impl CuDFParquetSource {
-    fn with_metadata_cache(
+    fn new(
         path: PathBuf,
         byte_len: usize,
         row_groups: RowGroupSelection,
-        metadata: Arc<OnceLock<Arc<ParquetMetaData>>>,
-        columns: Arc<OnceLock<Arc<HashSet<String>>>>,
+        cache: Arc<SourceCache>,
     ) -> Self {
         Self {
             path,
             byte_len,
             row_groups,
-            metadata,
-            columns,
+            cache,
         }
     }
 
@@ -88,11 +92,11 @@ impl CuDFParquetSource {
     }
 
     pub(crate) fn metadata(&self) -> Result<Arc<ParquetMetaData>> {
-        parquet_metadata_cached(&self.path, &self.metadata)
+        parquet_metadata_cached(&self.path, &self.cache.metadata)
     }
 
     pub(crate) fn available_columns(&self) -> Result<Arc<HashSet<String>>> {
-        parquet_columns_cached(self, &self.columns)
+        parquet_columns_cached(self, &self.cache.columns)
     }
 }
 
@@ -104,15 +108,12 @@ impl CuDFParquetSourceBuilder {
         if !file.partition_values.is_empty() {
             return Err(CuDFParquetSourceError::PartitionValues);
         }
-        let path = local_path(file.object_meta.location.as_ref());
+        let path = local_filesystem_path(file.object_meta.location.as_ref());
         let row_groups = self.row_group_selection(&path, file)?;
         let byte_len = partitioned_file_byte_len(file)?;
 
-        let metadata = self.metadata_cache(&path);
-        let columns = self.columns_cache(&path);
-        Ok(CuDFParquetSource::with_metadata_cache(
-            path, byte_len, row_groups, metadata, columns,
-        ))
+        let cache = self.cache(&path);
+        Ok(CuDFParquetSource::new(path, byte_len, row_groups, cache))
     }
 
     fn row_group_selection(
@@ -133,23 +134,15 @@ impl CuDFParquetSourceBuilder {
         &mut self,
         path: &Path,
     ) -> std::result::Result<Arc<ParquetMetaData>, CuDFParquetSourceError> {
-        parquet_metadata_cached(path, &self.metadata_cache(path))
+        parquet_metadata_cached(path, &self.cache(path).metadata)
             .map_err(|_| CuDFParquetSourceError::FileMetadata)
     }
 
-    fn metadata_cache(&mut self, path: &Path) -> Arc<OnceLock<Arc<ParquetMetaData>>> {
+    fn cache(&mut self, path: &Path) -> Arc<SourceCache> {
         Arc::clone(
-            self.metadata_by_path
+            self.cache_by_path
                 .entry(path.to_path_buf())
-                .or_insert_with(|| Arc::new(OnceLock::new())),
-        )
-    }
-
-    fn columns_cache(&mut self, path: &Path) -> Arc<OnceLock<Arc<HashSet<String>>>> {
-        Arc::clone(
-            self.columns_by_path
-                .entry(path.to_path_buf())
-                .or_insert_with(|| Arc::new(OnceLock::new())),
+                .or_insert_with(|| Arc::new(SourceCache::default())),
         )
     }
 }
@@ -167,10 +160,11 @@ impl RowGroupSelection {
     }
 }
 
-fn local_path(location: &str) -> PathBuf {
+fn local_filesystem_path(location: &str) -> PathBuf {
     let path = location
         .strip_prefix("file://")
         .map_or_else(|| PathBuf::from(location), PathBuf::from);
+    // DataFusion may store local object paths without a leading slash.
     if path.is_absolute() || path.exists() {
         path
     } else {
@@ -263,6 +257,8 @@ fn access_plan_from_extension(
         .iter()
         .any(|access| matches!(access, RowGroupAccess::Selection(_)))
     {
+        // cuDF can select whole row groups but cannot represent DataFusion's
+        // row-level selections here, so keep those plans on the DataFusion path.
         return Err(CuDFParquetSourceError::PartialRowSelection);
     }
     Ok(access_plan.clone())
@@ -296,7 +292,8 @@ fn row_group_selection_from_access_plan(
 #[cfg(test)]
 mod tests {
     use super::{
-        local_path, partitioned_file_byte_len, CuDFParquetSourceBuilder, RowGroupSelection,
+        local_filesystem_path, partitioned_file_byte_len, CuDFParquetSourceBuilder,
+        RowGroupSelection,
     };
     use datafusion::datasource::listing::PartitionedFile;
     use datafusion::datasource::physical_plan::parquet::ParquetAccessPlan;
@@ -313,12 +310,11 @@ mod tests {
             .map_err(|err| std::io::Error::other(format!("{err:?}")))?;
 
         assert_eq!(byte_len, 15);
-        assert_eq!(RowGroupSelection::Indices(vec![]).indices(), Some(&[][..]));
         Ok(())
     }
 
     #[test]
-    fn local_path_resolves_relative_and_absolute_local_paths(
+    fn local_filesystem_path_resolves_relative_and_absolute_paths(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let weather = weather_file("result-000000.parquet");
         let stripped_absolute = weather
@@ -326,37 +322,15 @@ mod tests {
             .expect("weather path should be absolute")
             .to_string_lossy();
 
-        assert_eq!(local_path("Cargo.toml"), PathBuf::from("Cargo.toml"));
-        assert_eq!(local_path(stripped_absolute.as_ref()), weather);
         assert_eq!(
-            local_path("file:///tmp/file.parquet"),
+            local_filesystem_path("Cargo.toml"),
+            PathBuf::from("Cargo.toml")
+        );
+        assert_eq!(local_filesystem_path(stripped_absolute.as_ref()), weather);
+        assert_eq!(
+            local_filesystem_path("file:///tmp/file.parquet"),
             PathBuf::from("/tmp/file.parquet")
         );
-        Ok(())
-    }
-
-    #[test]
-    fn source_metadata_is_loaded_once() -> Result<(), Box<dyn std::error::Error>> {
-        let path = weather_file("result-000000.parquet");
-        let source = source_for_path(&path)?;
-
-        let first = source.metadata()?;
-        let second = source.metadata()?;
-
-        assert!(Arc::ptr_eq(&first, &second));
-        Ok(())
-    }
-
-    #[test]
-    fn source_available_columns_are_loaded_once() -> Result<(), Box<dyn std::error::Error>> {
-        let path = weather_file("result-000000.parquet");
-        let source = source_for_path(&path)?;
-
-        let first = source.available_columns()?;
-        let second = source.available_columns()?;
-
-        assert!(Arc::ptr_eq(&first, &second));
-        assert!(!first.is_empty());
         Ok(())
     }
 
@@ -423,6 +397,22 @@ mod tests {
             .expect_err("partial row selections should remain on the DataFusion path");
 
         assert_eq!(err, super::CuDFParquetSourceError::PartialRowSelection);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_partitioned_file_extension_is_unsupported() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let path = weather_file("result-000000.parquet");
+        let mut builder = CuDFParquetSourceBuilder::default();
+
+        let err = builder
+            .try_from_partitioned_file(
+                &partitioned_file(&path)?.with_extensions(Arc::new("unsupported".to_string())),
+            )
+            .expect_err("unknown extensions should remain on the DataFusion path");
+
+        assert_eq!(err, super::CuDFParquetSourceError::FileExtensions);
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/mod.rs
+++ b/libcudf-datafusion/src/physical/mod.rs
@@ -1,15 +1,22 @@
 use crate::aggregate::CuDFAggregateExec;
 use datafusion_physical_plan::ExecutionPlan;
 
+mod cudf_coalesce;
 mod cudf_load;
+mod cudf_parquet_scan;
 mod cudf_unload;
 mod filter;
 mod hash_join;
 mod projection;
 mod sort;
 
-pub(crate) use cudf_load::normalize_scalar_for_cudf;
+pub(crate) use cudf_coalesce::CuDFCoalescePartitionsExec;
 pub use cudf_load::CuDFLoadExec;
+pub(crate) use cudf_load::{cudf_schema_compatibility_map, normalize_scalar_for_cudf};
+pub use cudf_parquet_scan::{CuDFParquetScanConfig, CuDFParquetScanExec};
+pub(crate) use cudf_parquet_scan::{
+    CuDFParquetSource, CuDFParquetSourceBuilder, CuDFParquetSourceError,
+};
 pub use cudf_unload::CuDFUnloadExec;
 pub use filter::CuDFFilterExec;
 pub use hash_join::{try_as_cudf_hash_join, CuDFHashJoinExec};
@@ -20,8 +27,10 @@ pub fn is_cudf_plan(plan: &dyn ExecutionPlan) -> bool {
     let any = plan.as_any();
     any.is::<CuDFAggregateExec>()
         || any.is::<CuDFFilterExec>()
+        || any.is::<CuDFCoalescePartitionsExec>()
         || any.is::<CuDFHashJoinExec>()
         || any.is::<CuDFLoadExec>()
+        || any.is::<CuDFParquetScanExec>()
         || any.is::<CuDFUnloadExec>()
         || any.is::<CuDFProjectionExec>()
         || any.is::<CuDFSortExec>()

--- a/libcudf-datafusion/src/planner/config.rs
+++ b/libcudf-datafusion/src/planner/config.rs
@@ -25,6 +25,41 @@ impl ConfigExtension for CuDFConfig {
 }
 
 impl CuDFConfig {
+    /// Return a copy with cuDF optimizations enabled or disabled.
+    #[must_use]
+    pub fn with_enable(mut self, enable: bool) -> Self {
+        self.enable = enable;
+        self
+    }
+
+    /// Return a copy with the aggregate chunk target size set.
+    #[must_use]
+    pub fn with_aggregate_chunk_target_bytes(mut self, bytes: usize) -> Self {
+        self.aggregate_chunk_target_bytes = bytes;
+        self
+    }
+
+    /// Return a copy with the GPU upload batch row target set.
+    #[must_use]
+    pub fn with_batch_size(mut self, rows: usize) -> Self {
+        self.batch_size = rows;
+        self
+    }
+
+    /// Return a copy with direct cuDF Parquet scans enabled or disabled.
+    #[must_use]
+    pub fn with_parquet_scan(mut self, parquet_scan: bool) -> Self {
+        self.parquet_scan = parquet_scan;
+        self
+    }
+
+    /// Return a copy with the maximum files per cuDF Parquet read set.
+    #[must_use]
+    pub fn with_parquet_scan_files_per_batch(mut self, files_per_batch: usize) -> Self {
+        self.parquet_scan_files_per_batch = files_per_batch;
+        self
+    }
+
     /// Gets the [CuDFConfig] from the [ConfigOptions]'s extensions.
     pub fn from_config_options(cfg: &ConfigOptions) -> Result<&Self, DataFusionError> {
         let Some(distributed_cfg) = cfg.extensions.get::<CuDFConfig>() else {

--- a/libcudf-datafusion/src/planner/config.rs
+++ b/libcudf-datafusion/src/planner/config.rs
@@ -1,6 +1,8 @@
 use datafusion::common::{extensions_options, plan_err, DataFusionError};
 use datafusion::config::{ConfigExtension, ConfigOptions};
 
+pub(crate) const DEFAULT_PARQUET_SCAN_FILES_PER_BATCH: usize = 8;
+
 extensions_options! {
     pub struct CuDFConfig {
         /// Enables CuDF optimizations.
@@ -11,6 +13,10 @@ extensions_options! {
         /// coalesced per partition up to this size to amortize cuDF's per-batch
         /// kernel-launch overhead.
         pub batch_size: usize, default = 512_000
+        /// Enables experimental local Parquet file scans with cuDF-backed scans.
+        pub parquet_scan: bool, default = false
+        /// Maximum number of files included in each cuDF Parquet read.
+        pub parquet_scan_files_per_batch: usize, default = DEFAULT_PARQUET_SCAN_FILES_PER_BATCH
     }
 }
 

--- a/libcudf-datafusion/src/planner/config.rs
+++ b/libcudf-datafusion/src/planner/config.rs
@@ -2,6 +2,8 @@ use datafusion::common::{extensions_options, plan_err, DataFusionError};
 use datafusion::config::{ConfigExtension, ConfigOptions};
 
 pub(crate) const DEFAULT_PARQUET_SCAN_FILES_PER_BATCH: usize = 8;
+pub(crate) const DEFAULT_PARQUET_SCAN_CHUNK_READ_LIMIT: usize = 256 * 1024 * 1024;
+pub(crate) const DEFAULT_PARQUET_SCAN_PASS_READ_LIMIT: usize = 256 * 1024 * 1024;
 
 extensions_options! {
     pub struct CuDFConfig {
@@ -17,6 +19,13 @@ extensions_options! {
         pub parquet_scan: bool, default = false
         /// Maximum number of files included in each cuDF Parquet read.
         pub parquet_scan_files_per_batch: usize, default = DEFAULT_PARQUET_SCAN_FILES_PER_BATCH
+        /// Maximum approximate bytes returned by each cuDF chunked Parquet read.
+        ///
+        /// cuDF treats 0 as "no limit"; direct DataFusion scans reject 0 so this
+        /// path remains bounded.
+        pub parquet_scan_chunk_read_limit: usize, default = DEFAULT_PARQUET_SCAN_CHUNK_READ_LIMIT
+        /// Maximum approximate temporary read/decompression bytes for each cuDF Parquet pass.
+        pub parquet_scan_pass_read_limit: usize, default = DEFAULT_PARQUET_SCAN_PASS_READ_LIMIT
     }
 }
 
@@ -57,6 +66,23 @@ impl CuDFConfig {
     #[must_use]
     pub fn with_parquet_scan_files_per_batch(mut self, files_per_batch: usize) -> Self {
         self.parquet_scan_files_per_batch = files_per_batch;
+        self
+    }
+
+    /// Return a copy with the cuDF Parquet chunk read byte limit set.
+    ///
+    /// cuDF treats 0 as "no limit"; `CuDFParquetScanExec` rejects 0 to avoid
+    /// accidental unbounded direct scans.
+    #[must_use]
+    pub fn with_parquet_scan_chunk_read_limit(mut self, bytes: usize) -> Self {
+        self.parquet_scan_chunk_read_limit = bytes;
+        self
+    }
+
+    /// Return a copy with the cuDF Parquet pass read byte limit set.
+    #[must_use]
+    pub fn with_parquet_scan_pass_read_limit(mut self, bytes: usize) -> Self {
+        self.parquet_scan_pass_read_limit = bytes;
         self
     }
 

--- a/libcudf-datafusion/src/planner/host_to_cudf.rs
+++ b/libcudf-datafusion/src/planner/host_to_cudf.rs
@@ -3,6 +3,7 @@ use crate::physical::{
     is_cudf_plan, try_as_cudf_hash_join, CuDFFilterExec, CuDFLoadExec, CuDFProjectionExec,
     CuDFSortExec, CuDFUnloadExec,
 };
+use crate::planner::parquet_scan::try_as_cudf_parquet_scan;
 use crate::planner::CuDFConfig;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
@@ -74,10 +75,16 @@ impl PhysicalOptimizerRule for HostToCuDFRule {
             let plan_is_cudf = is_cudf_plan(plan.as_ref());
             let children = plan.children();
             let mut new_children: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(children.len());
-            for child in children.iter() {
+            for child in children {
                 let child_is_cudf = is_cudf_plan(child.as_ref());
 
                 if plan_is_cudf && !child_is_cudf && !plan.as_any().is::<CuDFLoadExec>() {
+                    if let Some(scan) = try_as_cudf_parquet_scan(child, cudf_config)? {
+                        new_children.push(scan);
+                        changed = true;
+                        continue;
+                    }
+
                     if let Some(cp) = child.as_any().downcast_ref::<CoalescePartitionsExec>() {
                         new_children.push(Arc::new(CuDFLoadExec::try_new(Arc::clone(cp.input()))?));
                     } else {

--- a/libcudf-datafusion/src/planner/mod.rs
+++ b/libcudf-datafusion/src/planner/mod.rs
@@ -1,7 +1,9 @@
 mod config;
 mod host_to_cudf;
+mod parquet_scan;
 mod rescale_leafs;
 mod session_state_builder_ext;
 
 pub use config::CuDFConfig;
+pub(crate) use config::DEFAULT_PARQUET_SCAN_FILES_PER_BATCH;
 pub use session_state_builder_ext::SessionStateBuilderExt;

--- a/libcudf-datafusion/src/planner/mod.rs
+++ b/libcudf-datafusion/src/planner/mod.rs
@@ -5,5 +5,8 @@ mod rescale_leafs;
 mod session_state_builder_ext;
 
 pub use config::CuDFConfig;
-pub(crate) use config::DEFAULT_PARQUET_SCAN_FILES_PER_BATCH;
+pub(crate) use config::{
+    DEFAULT_PARQUET_SCAN_CHUNK_READ_LIMIT, DEFAULT_PARQUET_SCAN_FILES_PER_BATCH,
+    DEFAULT_PARQUET_SCAN_PASS_READ_LIMIT,
+};
 pub use session_state_builder_ext::SessionStateBuilderExt;

--- a/libcudf-datafusion/src/planner/parquet_scan.rs
+++ b/libcudf-datafusion/src/planner/parquet_scan.rs
@@ -194,6 +194,7 @@ fn supported_parquet_options(options: &TableParquetOptions) -> bool {
     let default = TableParquetOptions::default();
     let mut normalized = options.clone();
     normalized.global.pushdown_filters = default.global.pushdown_filters;
+    normalized.global.binary_as_string = default.global.binary_as_string;
     normalized == default
 }
 
@@ -306,4 +307,19 @@ pub(crate) fn try_as_cudf_parquet_scan(
 
     let scan = Arc::new(CuDFParquetScanExec::try_new(scan_config)?) as Arc<dyn ExecutionPlan>;
     Ok(Some(candidate.wrap_scan(scan)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supported_parquet_options;
+    use datafusion::common::config::TableParquetOptions;
+
+    #[test]
+    fn parquet_options_allow_reader_only_schema_flags() -> Result<(), Box<dyn std::error::Error>> {
+        let mut options = TableParquetOptions::default();
+        options.global.binary_as_string = true;
+
+        assert!(supported_parquet_options(&options));
+        Ok(())
+    }
 }

--- a/libcudf-datafusion/src/planner/parquet_scan.rs
+++ b/libcudf-datafusion/src/planner/parquet_scan.rs
@@ -17,7 +17,6 @@ use datafusion_expr::Operator;
 use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::ExecutionPlan;
 use libcudf_rs::CuDFAstExpression;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 struct ParquetScanCandidate<'a> {
@@ -214,19 +213,12 @@ fn validate_filter_columns(
         if source.row_group_selection().is_empty() {
             continue;
         }
-        let metadata = source
-            .metadata()
+        let available_columns = source
+            .available_columns()
             .map_err(|_| UnsupportedReason::FileMetadata)?;
-        let available_columns = metadata
-            .file_metadata()
-            .schema_descr()
-            .columns()
-            .iter()
-            .map(|column| column.path().string())
-            .collect::<HashSet<_>>();
         if column_names
             .iter()
-            .any(|column| !available_columns.contains(column))
+            .any(|column| !available_columns.contains(column.as_str()))
         {
             return Err(UnsupportedReason::Predicate);
         }

--- a/libcudf-datafusion/src/planner/parquet_scan.rs
+++ b/libcudf-datafusion/src/planner/parquet_scan.rs
@@ -1,0 +1,309 @@
+use crate::expr::ast::parquet_filter_to_cudf_filter;
+use crate::physical::{
+    CuDFCoalescePartitionsExec, CuDFParquetScanConfig, CuDFParquetScanExec, CuDFParquetSource,
+    CuDFParquetSourceBuilder, CuDFParquetSourceError,
+};
+use crate::planner::CuDFConfig;
+use datafusion::common::config::TableParquetOptions;
+use datafusion::common::Result;
+use datafusion::datasource::physical_plan::{FileScanConfig, FileSource, ParquetSource};
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::physical_expr::expressions::{
+    BinaryExpr, Column, DynamicFilterPhysicalExpr, Literal,
+};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::scalar::ScalarValue;
+use datafusion_expr::Operator;
+use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion_physical_plan::ExecutionPlan;
+use libcudf_rs::CuDFAstExpression;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+struct ParquetScanCandidate<'a> {
+    file_scan: &'a FileScanConfig,
+    source: &'a ParquetSource,
+    coalesce_fetch: Option<Option<usize>>,
+}
+
+impl<'a> ParquetScanCandidate<'a> {
+    fn try_from_plan(plan: &'a Arc<dyn ExecutionPlan>) -> Result<Option<Self>> {
+        let (plan, coalesce_fetch) = match plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+            Some(coalesce) => (coalesce.input(), Some(coalesce.fetch())),
+            None => (plan, None),
+        };
+
+        let Some(data_source) = plan.as_any().downcast_ref::<DataSourceExec>() else {
+            return Ok(None);
+        };
+
+        let Some((file_scan, source)) = data_source.downcast_to_file_source::<ParquetSource>()
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self {
+            file_scan,
+            source,
+            coalesce_fetch,
+        }))
+    }
+
+    fn try_scan_config(
+        &self,
+        cudf_config: &CuDFConfig,
+    ) -> std::result::Result<CuDFParquetScanConfig, UnsupportedReason> {
+        self.validate_scan_options()?;
+
+        let table_schema = self.source.table_schema();
+        let file_groups = self.local_file_groups()?;
+        let filter = self.cudf_filter(&file_groups)?;
+        let scan_config = CuDFParquetScanConfig::from_source_groups(
+            file_groups,
+            Arc::clone(table_schema.file_schema()),
+        );
+
+        Ok(scan_config
+            .with_projection(self.projected_file_columns()?)
+            .with_filter(filter)
+            .with_files_per_batch(cudf_config.parquet_scan_files_per_batch))
+    }
+
+    fn wrap_scan(&self, scan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        match self.coalesce_fetch {
+            Some(fetch) => Arc::new(CuDFCoalescePartitionsExec::new(scan).with_fetch(fetch)),
+            None => scan,
+        }
+    }
+
+    fn validate_scan_options(&self) -> std::result::Result<(), UnsupportedReason> {
+        use UnsupportedReason::*;
+
+        let table_schema = self.source.table_schema();
+
+        for (unsupported, reason) in [
+            (
+                !table_schema.table_partition_cols().is_empty(),
+                PartitionColumns,
+            ),
+            (self.file_scan.limit.is_some(), Limit),
+            (self.file_scan.preserve_order, PreserveOrder),
+            (!self.file_scan.output_ordering.is_empty(), OutputOrdering),
+            (
+                !supported_parquet_options(self.source.table_parquet_options()),
+                ParquetOptions,
+            ),
+            (self.file_scan.expr_adapter_factory.is_some(), ExprAdapter),
+            (
+                self.file_scan.file_compression_type.is_compressed(),
+                CompressedFile,
+            ),
+        ] {
+            if unsupported {
+                return Err(reason);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn cudf_filter(
+        &self,
+        file_groups: &[Vec<CuDFParquetSource>],
+    ) -> std::result::Result<Option<Arc<CuDFAstExpression>>, UnsupportedReason> {
+        if !self.source.table_parquet_options().global.pushdown_filters {
+            return Ok(None);
+        }
+
+        let Some(predicate) = self.source.filter() else {
+            return Ok(None);
+        };
+        if is_noop_scan_predicate(&predicate) {
+            return Ok(None);
+        }
+
+        let file_schema = self.source.table_schema().file_schema();
+        let filter = parquet_filter_to_cudf_filter(predicate.as_ref(), file_schema)
+            .map_err(|_| UnsupportedReason::Predicate)?;
+        validate_filter_columns(file_groups, &filter.column_names)?;
+        Ok(Some(Arc::new(filter.expression)))
+    }
+
+    fn local_file_groups(
+        &self,
+    ) -> std::result::Result<Vec<Vec<CuDFParquetSource>>, UnsupportedReason> {
+        if self.file_scan.object_store_url.as_str() != "file:///" {
+            return Err(UnsupportedReason::NonLocalObjectStore);
+        }
+
+        let mut file_groups = Vec::with_capacity(self.file_scan.file_groups.len());
+        let mut file_count = 0usize;
+        let mut source_builder = CuDFParquetSourceBuilder::default();
+        for group in &self.file_scan.file_groups {
+            let mut files = Vec::with_capacity(group.len());
+            for file in group.iter() {
+                files.push(
+                    source_builder
+                        .try_from_partitioned_file(file)
+                        .map_err(UnsupportedReason::from)?,
+                );
+                file_count += 1;
+            }
+            file_groups.push(files);
+        }
+
+        if file_count == 0 {
+            Err(UnsupportedReason::EmptyFiles)
+        } else {
+            Ok(file_groups)
+        }
+    }
+
+    fn projected_file_columns(&self) -> std::result::Result<Option<Vec<usize>>, UnsupportedReason> {
+        let Some(projection) = self.source.projection() else {
+            return Ok(None);
+        };
+
+        let file_schema = self.source.table_schema().file_schema();
+        let mut indices = Vec::new();
+        for expr in projection.as_ref() {
+            let Some(column) = expr.expr.as_any().downcast_ref::<Column>() else {
+                return Err(UnsupportedReason::Projection);
+            };
+            let Some(field) = file_schema.fields().get(column.index()) else {
+                return Err(UnsupportedReason::Projection);
+            };
+            if expr.alias != field.name().as_str() || column.name() != field.name() {
+                return Err(UnsupportedReason::Projection);
+            }
+            indices.push(column.index());
+        }
+
+        let is_full_file_projection = indices.len() == file_schema.fields().len()
+            && indices.iter().copied().eq(0..file_schema.fields().len());
+
+        if is_full_file_projection {
+            Ok(None)
+        } else {
+            Ok(Some(indices))
+        }
+    }
+}
+
+fn supported_parquet_options(options: &TableParquetOptions) -> bool {
+    let default = TableParquetOptions::default();
+    let mut normalized = options.clone();
+    normalized.global.pushdown_filters = default.global.pushdown_filters;
+    normalized == default
+}
+
+fn validate_filter_columns(
+    file_groups: &[Vec<CuDFParquetSource>],
+    column_names: &[String],
+) -> std::result::Result<(), UnsupportedReason> {
+    if column_names.is_empty() {
+        return Ok(());
+    }
+
+    for source in file_groups.iter().flatten() {
+        if source.row_group_selection().is_empty() {
+            continue;
+        }
+        let metadata = source
+            .metadata()
+            .map_err(|_| UnsupportedReason::FileMetadata)?;
+        let available_columns = metadata
+            .file_metadata()
+            .schema_descr()
+            .columns()
+            .iter()
+            .map(|column| column.path().string())
+            .collect::<HashSet<_>>();
+        if column_names
+            .iter()
+            .any(|column| !available_columns.contains(column))
+        {
+            return Err(UnsupportedReason::Predicate);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_noop_scan_predicate(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    if is_true_literal(expr) {
+        return true;
+    }
+    if let Some(dynamic) = expr.as_any().downcast_ref::<DynamicFilterPhysicalExpr>() {
+        return dynamic
+            .current()
+            .is_ok_and(|current| is_true_literal(&current));
+    }
+    if let Some(binary) = expr.as_any().downcast_ref::<BinaryExpr>() {
+        return matches!(binary.op(), Operator::And)
+            && is_noop_scan_predicate(binary.left())
+            && is_noop_scan_predicate(binary.right());
+    }
+    false
+}
+
+fn is_true_literal(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    expr.as_any()
+        .downcast_ref::<Literal>()
+        .is_some_and(|literal| matches!(literal.value(), ScalarValue::Boolean(Some(true))))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnsupportedReason {
+    PartitionColumns,
+    Limit,
+    PreserveOrder,
+    OutputOrdering,
+    ParquetOptions,
+    ExprAdapter,
+    CompressedFile,
+    NonLocalObjectStore,
+    PartitionValues,
+    FileExtensions,
+    FileSizeOverflow,
+    FileRangeOverflow,
+    FileMetadata,
+    RowGroupIndexOverflow,
+    EmptyFiles,
+    Projection,
+    Predicate,
+}
+
+impl From<CuDFParquetSourceError> for UnsupportedReason {
+    fn from(error: CuDFParquetSourceError) -> Self {
+        match error {
+            CuDFParquetSourceError::PartitionValues => Self::PartitionValues,
+            CuDFParquetSourceError::FileExtensions => Self::FileExtensions,
+            CuDFParquetSourceError::FileSizeOverflow => Self::FileSizeOverflow,
+            CuDFParquetSourceError::FileMetadata => Self::FileMetadata,
+            CuDFParquetSourceError::RowGroupIndexOverflow => Self::RowGroupIndexOverflow,
+            CuDFParquetSourceError::FileRangeOverflow => Self::FileRangeOverflow,
+        }
+    }
+}
+
+pub(crate) fn try_as_cudf_parquet_scan(
+    plan: &Arc<dyn ExecutionPlan>,
+    cudf_config: &CuDFConfig,
+) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+    if !cudf_config.parquet_scan {
+        return Ok(None);
+    }
+
+    let Some(candidate) = ParquetScanCandidate::try_from_plan(plan)? else {
+        return Ok(None);
+    };
+
+    let scan_config = match candidate.try_scan_config(cudf_config) {
+        Ok(scan_config) => scan_config,
+        Err(_) => return Ok(None),
+    };
+
+    let scan = Arc::new(CuDFParquetScanExec::try_new(scan_config)?) as Arc<dyn ExecutionPlan>;
+    Ok(Some(candidate.wrap_scan(scan)))
+}

--- a/libcudf-datafusion/src/planner/parquet_scan.rs
+++ b/libcudf-datafusion/src/planner/parquet_scan.rs
@@ -66,7 +66,11 @@ impl<'a> ParquetScanCandidate<'a> {
         Ok(scan_config
             .with_projection(self.projected_file_columns()?)
             .with_filter(filter)
-            .with_files_per_batch(cudf_config.parquet_scan_files_per_batch))
+            .with_files_per_batch(cudf_config.parquet_scan_files_per_batch)
+            .with_read_limits(
+                cudf_config.parquet_scan_chunk_read_limit,
+                cudf_config.parquet_scan_pass_read_limit,
+            ))
     }
 
     fn wrap_scan(&self, scan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {

--- a/libcudf-datafusion/src/planner/parquet_scan.rs
+++ b/libcudf-datafusion/src/planner/parquet_scan.rs
@@ -270,6 +270,7 @@ enum UnsupportedReason {
     NonLocalObjectStore,
     PartitionValues,
     FileExtensions,
+    PartialRowSelection,
     FileSizeOverflow,
     FileRangeOverflow,
     FileMetadata,
@@ -284,6 +285,7 @@ impl From<CuDFParquetSourceError> for UnsupportedReason {
         match error {
             CuDFParquetSourceError::PartitionValues => Self::PartitionValues,
             CuDFParquetSourceError::FileExtensions => Self::FileExtensions,
+            CuDFParquetSourceError::PartialRowSelection => Self::PartialRowSelection,
             CuDFParquetSourceError::FileSizeOverflow => Self::FileSizeOverflow,
             CuDFParquetSourceError::FileMetadata => Self::FileMetadata,
             CuDFParquetSourceError::RowGroupIndexOverflow => Self::RowGroupIndexOverflow,

--- a/libcudf-datafusion/src/planner/parquet_scan.rs
+++ b/libcudf-datafusion/src/planner/parquet_scan.rs
@@ -158,6 +158,14 @@ impl<'a> ParquetScanCandidate<'a> {
         if file_count == 0 {
             Err(UnsupportedReason::EmptyFiles)
         } else {
+            // TODO: DataFusion may split one local Parquet file into multiple
+            // byte-range PartitionedFiles. cuDF reads by path plus row-group
+            // selection, so preserving those split sources can reopen/register
+            // the same file repeatedly. Compacting sources by path is tempting,
+            // but it changes scan partitioning and can violate downstream
+            // distribution assumptions (for example CollectLeft hash joins).
+            // Fix this with a partitioning-aware compaction strategy or by
+            // re-enforcing distribution after direct scan replacement.
             Ok(file_groups)
         }
     }
@@ -309,15 +317,45 @@ pub(crate) fn try_as_cudf_parquet_scan(
 
 #[cfg(test)]
 mod tests {
-    use super::supported_parquet_options;
-    use datafusion::common::config::TableParquetOptions;
+    use super::try_as_cudf_parquet_scan;
+    use crate::planner::CuDFConfig;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::object_store::ObjectStoreUrl;
+    use datafusion::datasource::physical_plan::{FileScanConfigBuilder, ParquetSource};
+    use datafusion::datasource::source::DataSourceExec;
+    use datafusion_physical_plan::{displayable, ExecutionPlan};
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[test]
-    fn parquet_options_allow_reader_only_schema_flags() -> Result<(), Box<dyn std::error::Error>> {
-        let mut options = TableParquetOptions::default();
-        options.global.binary_as_string = true;
+    fn direct_parquet_scan_replaces_local_datasource() -> Result<(), Box<dyn std::error::Error>> {
+        let file = weather_file("result-000000.parquet");
+        let size = std::fs::metadata(&file)?.len();
+        let source = Arc::new(ParquetSource::new(Arc::new(Schema::new(vec![Field::new(
+            "station",
+            DataType::Utf8,
+            true,
+        )]))));
+        let scan = FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source)
+            .with_file(PartitionedFile::new(file.to_string_lossy(), size))
+            .build();
+        let plan: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(scan);
 
-        assert!(supported_parquet_options(&options));
+        let replaced =
+            try_as_cudf_parquet_scan(&plan, &CuDFConfig::default().with_parquet_scan(true))?
+                .expect("local Parquet DataSourceExec should become a cuDF scan");
+        let display = displayable(replaced.as_ref()).indent(true).to_string();
+
+        assert!(display.contains("CuDFParquetScanExec"), "{display}");
+        assert!(!display.contains("DataSourceExec"), "{display}");
         Ok(())
+    }
+
+    fn weather_file(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(format!("../testdata/weather/{name}"))
+            .canonicalize()
+            .expect("weather test file should exist")
     }
 }

--- a/libcudf-datafusion/tests/clickbench_correctness.rs
+++ b/libcudf-datafusion/tests/clickbench_correctness.rs
@@ -5,7 +5,7 @@ mod tests {
     use datafusion::prelude::{SessionConfig, SessionContext};
     use futures::TryStreamExt;
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-    use libcudf_datafusion::SessionStateBuilderExt;
+    use libcudf_datafusion::{CuDFConfig, SessionStateBuilderExt};
     use libcudf_datafusion_benchmarks::datasets::{
         apply_query_settings, clickbench, register_tables,
     };
@@ -268,7 +268,11 @@ mod tests {
         let gpu_ctx = SessionContext::from(
             SessionStateBuilder::new()
                 .with_default_features()
-                .with_config(SessionConfig::new().with_target_partitions(PARTITIONS))
+                .with_config(
+                    SessionConfig::new()
+                        .with_target_partitions(PARTITIONS)
+                        .with_option_extension(parquet_scan_config()),
+                )
                 .with_cudf_planner()
                 .build(),
         );
@@ -303,6 +307,10 @@ mod tests {
         ctx.register_udaf((*max()).clone());
         ctx.register_udaf((*min()).clone());
         ctx.register_udaf((*sum()).clone());
+    }
+
+    fn parquet_scan_config() -> CuDFConfig {
+        CuDFConfig::default().with_parquet_scan(true)
     }
 
     static INIT_TEST_CLICKBENCH_TABLES: OnceCell<()> = OnceCell::const_new();

--- a/libcudf-datafusion/tests/clickbench_correctness.rs
+++ b/libcudf-datafusion/tests/clickbench_correctness.rs
@@ -9,6 +9,7 @@ mod tests {
     use libcudf_datafusion_benchmarks::datasets::{
         apply_query_settings, clickbench, register_tables,
     };
+    use std::env;
     use std::error::Error;
     use std::fmt::Display;
     use std::ops::Range;
@@ -17,6 +18,7 @@ mod tests {
 
     const PARTITIONS: usize = 6;
     const FILE_RANGE: Range<usize> = 0..3;
+    const DIRECT_PARQUET_SCAN_TEST_ENV: &str = "LIBCUDF_DATAFUSION_DIRECT_PARQUET_SCAN_TESTS";
 
     #[tokio::test]
     #[ignore = "Arrow error: Column 'count(Int64(1))' is declared as non-nullable but contains null values"]
@@ -310,7 +312,16 @@ mod tests {
     }
 
     fn parquet_scan_config() -> CuDFConfig {
-        CuDFConfig::default().with_parquet_scan(true)
+        CuDFConfig::default().with_parquet_scan(correctness_parquet_scan_enabled())
+    }
+
+    fn correctness_parquet_scan_enabled() -> bool {
+        env::var(DIRECT_PARQUET_SCAN_TEST_ENV).is_ok_and(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
     }
 
     static INIT_TEST_CLICKBENCH_TABLES: OnceCell<()> = OnceCell::const_new();

--- a/libcudf-datafusion/tests/clickbench_plans.rs
+++ b/libcudf-datafusion/tests/clickbench_plans.rs
@@ -4,7 +4,7 @@ mod tests {
     use datafusion::prelude::{SessionConfig, SessionContext};
     use datafusion_physical_plan::displayable;
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-    use libcudf_datafusion::{assert_snapshot, SessionStateBuilderExt};
+    use libcudf_datafusion::{assert_snapshot, CuDFConfig, SessionStateBuilderExt};
     use libcudf_datafusion_benchmarks::datasets::{
         apply_query_settings, clickbench, register_tables,
     };
@@ -15,6 +15,16 @@ mod tests {
 
     const PARTITIONS: usize = 6;
     const FILE_RANGE: Range<usize> = 0..3;
+
+    #[tokio::test]
+    async fn test_clickbench_parquet_scan_plan() -> Result<(), Box<dyn Error>> {
+        let plan = test_clickbench_query_with_config("q1", parquet_scan_config()).await?;
+
+        assert_plan_contains(&plan, "CuDFParquetScanExec");
+        assert_plan_contains(&plan, "files_per_batch=8");
+        assert_plan_not_contains(&plan, "DataSourceExec");
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_clickbench_0() -> Result<(), Box<dyn Error>> {
@@ -668,10 +678,21 @@ mod tests {
     }
 
     async fn test_clickbench_query(query_id: &str) -> Result<String, Box<dyn Error>> {
+        test_clickbench_query_with_config(query_id, CuDFConfig::default()).await
+    }
+
+    async fn test_clickbench_query_with_config(
+        query_id: &str,
+        cudf_config: CuDFConfig,
+    ) -> Result<String, Box<dyn Error>> {
         let ctx = SessionContext::from(
             SessionStateBuilder::new()
                 .with_default_features()
-                .with_config(SessionConfig::new().with_target_partitions(PARTITIONS))
+                .with_config(
+                    SessionConfig::new()
+                        .with_target_partitions(PARTITIONS)
+                        .with_option_extension(cudf_config),
+                )
                 .with_cudf_planner()
                 .build(),
         );
@@ -687,6 +708,24 @@ mod tests {
         let plan = df.create_physical_plan().await?;
         let display = displayable(plan.as_ref()).indent(true).to_string();
         Ok(display)
+    }
+
+    fn parquet_scan_config() -> CuDFConfig {
+        CuDFConfig::default().with_parquet_scan(true)
+    }
+
+    fn assert_plan_contains(plan: &str, needle: &str) {
+        assert!(
+            plan.contains(needle),
+            "expected plan to contain `{needle}`:\n{plan}"
+        );
+    }
+
+    fn assert_plan_not_contains(plan: &str, needle: &str) {
+        assert!(
+            !plan.contains(needle),
+            "expected plan not to contain `{needle}`:\n{plan}"
+        );
     }
 
     fn register_cudf_aggregate_udfs(ctx: &SessionContext) {

--- a/libcudf-datafusion/tests/clickbench_plans.rs
+++ b/libcudf-datafusion/tests/clickbench_plans.rs
@@ -15,17 +15,6 @@ mod tests {
 
     const PARTITIONS: usize = 6;
     const FILE_RANGE: Range<usize> = 0..3;
-
-    #[tokio::test]
-    async fn test_clickbench_parquet_scan_plan() -> Result<(), Box<dyn Error>> {
-        let plan = test_clickbench_query_with_config("q1", parquet_scan_config()).await?;
-
-        assert_plan_contains(&plan, "CuDFParquetScanExec");
-        assert_plan_contains(&plan, "files_per_batch=8");
-        assert_plan_not_contains(&plan, "DataSourceExec");
-        Ok(())
-    }
-
     #[tokio::test]
     async fn test_clickbench_0() -> Result<(), Box<dyn Error>> {
         let plan = test_clickbench_query("q0").await?;
@@ -708,24 +697,6 @@ mod tests {
         let plan = df.create_physical_plan().await?;
         let display = displayable(plan.as_ref()).indent(true).to_string();
         Ok(display)
-    }
-
-    fn parquet_scan_config() -> CuDFConfig {
-        CuDFConfig::default().with_parquet_scan(true)
-    }
-
-    fn assert_plan_contains(plan: &str, needle: &str) {
-        assert!(
-            plan.contains(needle),
-            "expected plan to contain `{needle}`:\n{plan}"
-        );
-    }
-
-    fn assert_plan_not_contains(plan: &str, needle: &str) {
-        assert!(
-            !plan.contains(needle),
-            "expected plan not to contain `{needle}`:\n{plan}"
-        );
     }
 
     fn register_cudf_aggregate_udfs(ctx: &SessionContext) {

--- a/libcudf-datafusion/tests/tpch_correctness.rs
+++ b/libcudf-datafusion/tests/tpch_correctness.rs
@@ -5,7 +5,7 @@ mod tests {
     use datafusion::prelude::{SessionConfig, SessionContext};
     use futures::TryStreamExt;
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-    use libcudf_datafusion::SessionStateBuilderExt;
+    use libcudf_datafusion::{CuDFConfig, SessionStateBuilderExt};
     use libcudf_datafusion_benchmarks::datasets::{register_tables, tpch};
     use std::error::Error;
     use std::fmt::Display;
@@ -139,7 +139,11 @@ mod tests {
         let gpu_ctx = SessionContext::from(
             SessionStateBuilder::new()
                 .with_default_features()
-                .with_config(SessionConfig::new().with_target_partitions(PARTITIONS))
+                .with_config(
+                    SessionConfig::new()
+                        .with_target_partitions(PARTITIONS)
+                        .with_option_extension(parquet_scan_config()),
+                )
                 .with_cudf_planner()
                 .build(),
         );
@@ -193,6 +197,10 @@ mod tests {
         ctx.register_udaf((*max()).clone());
         ctx.register_udaf((*min()).clone());
         ctx.register_udaf((*sum()).clone());
+    }
+
+    fn parquet_scan_config() -> CuDFConfig {
+        CuDFConfig::default().with_parquet_scan(true)
     }
 
     static INIT_TEST_TPCH_TABLES: OnceCell<()> = OnceCell::const_new();

--- a/libcudf-datafusion/tests/tpch_correctness.rs
+++ b/libcudf-datafusion/tests/tpch_correctness.rs
@@ -7,6 +7,7 @@ mod tests {
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
     use libcudf_datafusion::{CuDFConfig, SessionStateBuilderExt};
     use libcudf_datafusion_benchmarks::datasets::{register_tables, tpch};
+    use std::env;
     use std::error::Error;
     use std::fmt::Display;
     use std::fs;
@@ -16,6 +17,7 @@ mod tests {
     const PARTITIONS: usize = 6;
     const TPCH_SCALE_FACTOR: f64 = 1.0;
     const TPCH_DATA_PARTS: i32 = 16;
+    const DIRECT_PARQUET_SCAN_TEST_ENV: &str = "LIBCUDF_DATAFUSION_DIRECT_PARQUET_SCAN_TESTS";
 
     #[tokio::test]
     async fn test_tpch_1() -> Result<(), Box<dyn Error>> {
@@ -200,7 +202,16 @@ mod tests {
     }
 
     fn parquet_scan_config() -> CuDFConfig {
-        CuDFConfig::default().with_parquet_scan(true)
+        CuDFConfig::default().with_parquet_scan(correctness_parquet_scan_enabled())
+    }
+
+    fn correctness_parquet_scan_enabled() -> bool {
+        env::var(DIRECT_PARQUET_SCAN_TEST_ENV).is_ok_and(|value| {
+            matches!(
+                value.as_str(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
     }
 
     static INIT_TEST_TPCH_TABLES: OnceCell<()> = OnceCell::const_new();

--- a/libcudf-datafusion/tests/tpch_plans.rs
+++ b/libcudf-datafusion/tests/tpch_plans.rs
@@ -4,7 +4,7 @@ mod tests {
     use datafusion::prelude::{SessionConfig, SessionContext};
     use datafusion_physical_plan::displayable;
     use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-    use libcudf_datafusion::{assert_snapshot, SessionStateBuilderExt};
+    use libcudf_datafusion::{assert_snapshot, CuDFConfig, SessionStateBuilderExt};
     use libcudf_datafusion_benchmarks::datasets::{register_tables, tpch};
     use std::error::Error;
     use std::fs;
@@ -14,6 +14,16 @@ mod tests {
     const PARTITIONS: usize = 6;
     const TPCH_SCALE_FACTOR: f64 = 0.02;
     const TPCH_DATA_PARTS: i32 = 16;
+
+    #[tokio::test]
+    async fn test_tpch_parquet_scan_plan() -> Result<(), Box<dyn Error>> {
+        let plan = test_tpch_query_with_config("q1", parquet_scan_config()).await?;
+
+        assert_plan_contains(&plan, "CuDFParquetScanExec");
+        assert_plan_contains(&plan, "files_per_batch=8");
+        assert_plan_not_contains(&plan, "DataSourceExec");
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_tpch_1() -> Result<(), Box<dyn Error>> {
@@ -628,10 +638,21 @@ mod tests {
     }
 
     async fn test_tpch_query(query_id: &str) -> Result<String, Box<dyn Error>> {
+        test_tpch_query_with_config(query_id, CuDFConfig::default()).await
+    }
+
+    async fn test_tpch_query_with_config(
+        query_id: &str,
+        cudf_config: CuDFConfig,
+    ) -> Result<String, Box<dyn Error>> {
         let ctx = SessionContext::from(
             SessionStateBuilder::new()
                 .with_default_features()
-                .with_config(SessionConfig::new().with_target_partitions(PARTITIONS))
+                .with_config(
+                    SessionConfig::new()
+                        .with_target_partitions(PARTITIONS)
+                        .with_option_extension(cudf_config),
+                )
                 .with_cudf_planner()
                 .build(),
         );
@@ -663,6 +684,24 @@ mod tests {
         };
         let display = displayable(plan.as_ref()).indent(true).to_string();
         Ok(display)
+    }
+
+    fn parquet_scan_config() -> CuDFConfig {
+        CuDFConfig::default().with_parquet_scan(true)
+    }
+
+    fn assert_plan_contains(plan: &str, needle: &str) {
+        assert!(
+            plan.contains(needle),
+            "expected plan to contain `{needle}`:\n{plan}"
+        );
+    }
+
+    fn assert_plan_not_contains(plan: &str, needle: &str) {
+        assert!(
+            !plan.contains(needle),
+            "expected plan not to contain `{needle}`:\n{plan}"
+        );
     }
 
     fn register_cudf_aggregate_udfs(ctx: &SessionContext) {

--- a/libcudf-datafusion/tests/tpch_plans.rs
+++ b/libcudf-datafusion/tests/tpch_plans.rs
@@ -14,17 +14,6 @@ mod tests {
     const PARTITIONS: usize = 6;
     const TPCH_SCALE_FACTOR: f64 = 0.02;
     const TPCH_DATA_PARTS: i32 = 16;
-
-    #[tokio::test]
-    async fn test_tpch_parquet_scan_plan() -> Result<(), Box<dyn Error>> {
-        let plan = test_tpch_query_with_config("q1", parquet_scan_config()).await?;
-
-        assert_plan_contains(&plan, "CuDFParquetScanExec");
-        assert_plan_contains(&plan, "files_per_batch=8");
-        assert_plan_not_contains(&plan, "DataSourceExec");
-        Ok(())
-    }
-
     #[tokio::test]
     async fn test_tpch_1() -> Result<(), Box<dyn Error>> {
         let plan = test_tpch_query("q1").await?;
@@ -684,24 +673,6 @@ mod tests {
         };
         let display = displayable(plan.as_ref()).indent(true).to_string();
         Ok(display)
-    }
-
-    fn parquet_scan_config() -> CuDFConfig {
-        CuDFConfig::default().with_parquet_scan(true)
-    }
-
-    fn assert_plan_contains(plan: &str, needle: &str) {
-        assert!(
-            plan.contains(needle),
-            "expected plan to contain `{needle}`:\n{plan}"
-        );
-    }
-
-    fn assert_plan_not_contains(plan: &str, needle: &str) {
-        assert!(
-            !plan.contains(needle),
-            "expected plan not to contain `{needle}`:\n{plan}"
-        );
     }
 
     fn register_cudf_aggregate_udfs(ctx: &SessionContext) {

--- a/libcudf-sys/src/ast.cpp
+++ b/libcudf-sys/src/ast.cpp
@@ -26,6 +26,15 @@ std::size_t ast_expression_tree_add_column_reference(
     return tree.inner.size() - 1;
 }
 
+std::size_t ast_expression_tree_add_column_name_reference(
+    AstExpressionTree& tree,
+    rust::Str column_name)
+{
+    tree.inner.emplace<cudf::ast::column_name_reference>(
+        std::string(column_name.data(), column_name.size()));
+    return tree.inner.size() - 1;
+}
+
 std::size_t ast_expression_tree_add_literal(AstExpressionTree& tree, const Scalar& scalar)
 {
     if (!scalar.inner) {

--- a/libcudf-sys/src/ast.h
+++ b/libcudf-sys/src/ast.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "scalar.h"
+#include "rust/cxx.h"
 
 #include <cudf/ast/expressions.hpp>
 
@@ -23,6 +24,10 @@ namespace libcudf_bridge {
         AstExpressionTree& tree,
         int32_t column_index,
         int32_t table_reference);
+
+    std::size_t ast_expression_tree_add_column_name_reference(
+        AstExpressionTree& tree,
+        rust::Str column_name);
 
     std::size_t ast_expression_tree_add_literal(
         AstExpressionTree& tree,

--- a/libcudf-sys/src/io.cpp
+++ b/libcudf-sys/src/io.cpp
@@ -2,6 +2,7 @@
 #include "libcudf-sys/src/lib.rs.h"
 
 #include <cudf/io/parquet.hpp>
+#include <stdexcept>
 
 namespace libcudf_bridge {
     namespace {
@@ -14,6 +15,37 @@ namespace libcudf_bridge {
             result.reserve(values.size());
             for (const auto& value: values) {
                 result.emplace_back(static_cast<std::string>(value));
+            }
+            return result;
+        }
+
+        std::vector<std::vector<cudf::size_type>> to_row_groups(
+            const rust::Vec<int32_t>& row_group_indices,
+            const rust::Vec<size_t>& source_offsets) {
+            if (source_offsets.empty() || source_offsets.front() != 0) {
+                throw std::invalid_argument("row group source offsets must start at zero");
+            }
+
+            std::vector<std::vector<cudf::size_type>> result;
+            result.reserve(source_offsets.size() - 1);
+            size_t previous = 0;
+            for (size_t offset_index = 1; offset_index < source_offsets.size(); ++offset_index) {
+                auto next = source_offsets[offset_index];
+                if (next < previous || next > row_group_indices.size()) {
+                    throw std::invalid_argument("invalid row group source offset");
+                }
+
+                std::vector<cudf::size_type> groups;
+                groups.reserve(next - previous);
+                for (size_t index = previous; index < next; ++index) {
+                    groups.push_back(static_cast<cudf::size_type>(row_group_indices[index]));
+                }
+                result.push_back(std::move(groups));
+                previous = next;
+            }
+
+            if (previous != row_group_indices.size()) {
+                throw std::invalid_argument("row group source offsets do not cover all indices");
             }
             return result;
         }
@@ -54,6 +86,27 @@ namespace libcudf_bridge {
         inner.set_columns(to_std_strings(col_names));
     }
 
+    void ParquetReaderOptions::set_row_groups(
+        rust::Vec<int32_t> row_group_indices,
+        rust::Vec<size_t> source_offsets) {
+        inner.set_row_groups(to_row_groups(row_group_indices, source_offsets));
+    }
+
+    void ParquetReaderOptions::set_filter(const AstExpressionTree& filter) {
+        if (filter.inner.size() == 0) {
+            throw std::runtime_error("Cannot set an empty AST filter on ParquetReaderOptions");
+        }
+        inner.set_filter(filter.inner.back());
+    }
+
+    void ParquetReaderOptions::enable_allow_mismatched_pq_schemas(bool val) {
+        inner.enable_allow_mismatched_pq_schemas(val);
+    }
+
+    void ParquetReaderOptions::enable_ignore_missing_columns(bool val) {
+        inner.enable_ignore_missing_columns(val);
+    }
+
     ParquetWriterOptions::ParquetWriterOptions() : inner() {}
 
     ParquetWriterOptions::ParquetWriterOptions(cudf::io::parquet_writer_options options)
@@ -82,6 +135,14 @@ namespace libcudf_bridge {
 
     int32_t TableWithMetadata::num_input_row_groups() const {
         return inner.metadata.num_input_row_groups;
+    }
+
+    size_t TableWithMetadata::schema_info_count() const {
+        return inner.metadata.schema_info.size();
+    }
+
+    rust::String TableWithMetadata::schema_info_name(size_t index) const {
+        return inner.metadata.schema_info.at(index).name;
     }
 
     HostByteVector::HostByteVector(std::unique_ptr<std::vector<uint8_t>> bytes)

--- a/libcudf-sys/src/io.cpp
+++ b/libcudf-sys/src/io.cpp
@@ -99,12 +99,44 @@ namespace libcudf_bridge {
         inner.set_filter(filter.inner.back());
     }
 
+    void ParquetReaderOptions::enable_convert_strings_to_categories(bool val) {
+        inner.enable_convert_strings_to_categories(val);
+    }
+
+    void ParquetReaderOptions::enable_use_pandas_metadata(bool val) {
+        inner.enable_use_pandas_metadata(val);
+    }
+
+    void ParquetReaderOptions::enable_use_arrow_schema(bool val) {
+        inner.enable_use_arrow_schema(val);
+    }
+
     void ParquetReaderOptions::enable_allow_mismatched_pq_schemas(bool val) {
         inner.enable_allow_mismatched_pq_schemas(val);
     }
 
     void ParquetReaderOptions::enable_ignore_missing_columns(bool val) {
         inner.enable_ignore_missing_columns(val);
+    }
+
+    void ParquetReaderOptions::set_skip_rows(int64_t val) {
+        inner.set_skip_rows(val);
+    }
+
+    void ParquetReaderOptions::set_num_rows(int64_t val) {
+        inner.set_num_rows(val);
+    }
+
+    void ParquetReaderOptions::set_skip_bytes(size_t val) {
+        inner.set_skip_bytes(val);
+    }
+
+    void ParquetReaderOptions::set_num_bytes(size_t val) {
+        inner.set_num_bytes(val);
+    }
+
+    void ParquetReaderOptions::set_timestamp_type(const DataType& type) {
+        inner.set_timestamp_type(type.inner);
     }
 
     ChunkedParquetReader::ChunkedParquetReader(

--- a/libcudf-sys/src/io.cpp
+++ b/libcudf-sys/src/io.cpp
@@ -107,6 +107,33 @@ namespace libcudf_bridge {
         inner.enable_ignore_missing_columns(val);
     }
 
+    ChunkedParquetReader::ChunkedParquetReader(
+        size_t chunk_read_limit,
+        size_t pass_read_limit,
+        const ParquetReaderOptions& options,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr)
+        : inner(std::make_unique<cudf::io::chunked_parquet_reader>(
+              chunk_read_limit,
+              pass_read_limit,
+              options.inner,
+              stream.inner,
+              mr.inner)) {}
+
+    ChunkedParquetReader::~ChunkedParquetReader() = default;
+
+    bool ChunkedParquetReader::has_next() const {
+        return inner && inner->has_next();
+    }
+
+    std::unique_ptr<TableWithMetadata> ChunkedParquetReader::read_chunk() const {
+        if (!inner) {
+            throw std::runtime_error("Cannot read from a null chunked Parquet reader");
+        }
+        auto result = inner->read_chunk();
+        return std::make_unique<TableWithMetadata>(std::move(result));
+    }
+
     ParquetWriterOptions::ParquetWriterOptions() : inner() {}
 
     ParquetWriterOptions::ParquetWriterOptions(cudf::io::parquet_writer_options options)
@@ -188,6 +215,20 @@ namespace libcudf_bridge {
         const DeviceAsyncResourceRef& mr) {
         auto result = cudf::io::read_parquet(options.inner, stream.inner, mr.inner);
         return std::make_unique<TableWithMetadata>(std::move(result));
+    }
+
+    std::unique_ptr<ChunkedParquetReader> chunked_parquet_reader_create(
+        size_t chunk_read_limit,
+        size_t pass_read_limit,
+        const ParquetReaderOptions& options,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr) {
+        return std::make_unique<ChunkedParquetReader>(
+            chunk_read_limit,
+            pass_read_limit,
+            options,
+            stream,
+            mr);
     }
 
     std::unique_ptr<HostByteVector> write_parquet(

--- a/libcudf-sys/src/io.h
+++ b/libcudf-sys/src/io.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "ast.h"
 #include "memory_resource.h"
 #include "rust/cxx.h"
 #include "stream.h"
@@ -51,6 +52,14 @@ namespace libcudf_bridge {
         void set_source(const SourceInfo& source);
 
         void set_columns(rust::Vec<rust::String> col_names);
+
+        void set_row_groups(rust::Vec<int32_t> row_group_indices, rust::Vec<size_t> source_offsets);
+
+        void set_filter(const AstExpressionTree& filter);
+
+        void enable_allow_mismatched_pq_schemas(bool val);
+
+        void enable_ignore_missing_columns(bool val);
     };
 
     // Opaque wrapper for cudf::io::parquet_writer_options.
@@ -79,6 +88,10 @@ namespace libcudf_bridge {
         [[nodiscard]] size_t num_rows_per_source(size_t index) const;
 
         [[nodiscard]] int32_t num_input_row_groups() const;
+
+        [[nodiscard]] size_t schema_info_count() const;
+
+        [[nodiscard]] rust::String schema_info_name(size_t index) const;
     };
 
     // Opaque owning wrapper for the file metadata byte vector returned by write_parquet.

--- a/libcudf-sys/src/io.h
+++ b/libcudf-sys/src/io.h
@@ -13,6 +13,8 @@
 #include <cudf/io/parquet.hpp>
 
 namespace libcudf_bridge {
+    struct TableWithMetadata;
+
     // Opaque wrapper for cudf::io::source_info.
     struct SourceInfo {
         cudf::io::source_info inner;
@@ -60,6 +62,24 @@ namespace libcudf_bridge {
         void enable_allow_mismatched_pq_schemas(bool val);
 
         void enable_ignore_missing_columns(bool val);
+    };
+
+    // Opaque wrapper for cudf::io::chunked_parquet_reader.
+    struct ChunkedParquetReader {
+        std::unique_ptr<cudf::io::chunked_parquet_reader> inner;
+
+        ChunkedParquetReader(
+            size_t chunk_read_limit,
+            size_t pass_read_limit,
+            const ParquetReaderOptions& options,
+            const CudaStreamView& stream,
+            const DeviceAsyncResourceRef& mr);
+
+        ~ChunkedParquetReader();
+
+        [[nodiscard]] bool has_next() const;
+
+        std::unique_ptr<TableWithMetadata> read_chunk() const;
     };
 
     // Opaque wrapper for cudf::io::parquet_writer_options.
@@ -120,6 +140,13 @@ namespace libcudf_bridge {
         const TableView& table);
 
     std::unique_ptr<TableWithMetadata> read_parquet(
+        const ParquetReaderOptions& options,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+
+    std::unique_ptr<ChunkedParquetReader> chunked_parquet_reader_create(
+        size_t chunk_read_limit,
+        size_t pass_read_limit,
         const ParquetReaderOptions& options,
         const CudaStreamView& stream,
         const DeviceAsyncResourceRef& mr);

--- a/libcudf-sys/src/io.h
+++ b/libcudf-sys/src/io.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "ast.h"
+#include "data_type.h"
 #include "memory_resource.h"
 #include "rust/cxx.h"
 #include "stream.h"
@@ -59,9 +60,25 @@ namespace libcudf_bridge {
 
         void set_filter(const AstExpressionTree& filter);
 
+        void enable_convert_strings_to_categories(bool val);
+
+        void enable_use_pandas_metadata(bool val);
+
+        void enable_use_arrow_schema(bool val);
+
         void enable_allow_mismatched_pq_schemas(bool val);
 
         void enable_ignore_missing_columns(bool val);
+
+        void set_skip_rows(int64_t val);
+
+        void set_num_rows(int64_t val);
+
+        void set_skip_bytes(size_t val);
+
+        void set_num_bytes(size_t val);
+
+        void set_timestamp_type(const DataType& type);
     };
 
     // Opaque wrapper for cudf::io::chunked_parquet_reader.

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -522,11 +522,35 @@ pub mod ffi {
             filter: &AstExpressionTree,
         ) -> Result<()>;
 
+        /// Enable conversion of strings to categories.
+        fn enable_convert_strings_to_categories(self: Pin<&mut ParquetReaderOptions>, val: bool);
+
+        /// Enable reading pandas metadata.
+        fn enable_use_pandas_metadata(self: Pin<&mut ParquetReaderOptions>, val: bool);
+
+        /// Enable reading Arrow schema metadata.
+        fn enable_use_arrow_schema(self: Pin<&mut ParquetReaderOptions>, val: bool);
+
         /// Enable reading matching projected and filter columns from mismatched Parquet sources.
         fn enable_allow_mismatched_pq_schemas(self: Pin<&mut ParquetReaderOptions>, val: bool);
 
         /// Enable ignoring non-existent projected columns while reading.
         fn enable_ignore_missing_columns(self: Pin<&mut ParquetReaderOptions>, val: bool);
+
+        /// Set number of rows to skip.
+        fn set_skip_rows(self: Pin<&mut ParquetReaderOptions>, val: i64);
+
+        /// Set number of rows to read.
+        fn set_num_rows(self: Pin<&mut ParquetReaderOptions>, val: i64);
+
+        /// Set bytes to skip before starting row group reads.
+        fn set_skip_bytes(self: Pin<&mut ParquetReaderOptions>, val: usize);
+
+        /// Set number of bytes after skipping to end row group reads at.
+        fn set_num_bytes(self: Pin<&mut ParquetReaderOptions>, val: usize);
+
+        /// Set timestamp type used to cast timestamp columns.
+        fn set_timestamp_type(self: Pin<&mut ParquetReaderOptions>, typ: &DataType);
 
         /// Take ownership of the table from `cudf::io::table_with_metadata`.
         fn release_table(self: Pin<&mut TableWithMetadata>) -> UniquePtr<Table>;

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -84,6 +84,9 @@ pub mod ffi {
         /// cuDF Parquet reader options.
         type ParquetReaderOptions;
 
+        /// cuDF chunked Parquet reader.
+        type ChunkedParquetReader;
+
         /// cuDF Parquet writer options.
         type ParquetWriterOptions;
 
@@ -549,6 +552,21 @@ pub mod ffi {
             stream: &CudaStreamView,
             mr: &DeviceAsyncResourceRef,
         ) -> Result<UniquePtr<TableWithMetadata>>;
+
+        /// Create a cuDF chunked Parquet reader.
+        fn chunked_parquet_reader_create(
+            chunk_read_limit: usize,
+            pass_read_limit: usize,
+            options: &ParquetReaderOptions,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<UniquePtr<ChunkedParquetReader>>;
+
+        /// Return whether a chunked Parquet reader has unread rows.
+        fn has_next(self: &ChunkedParquetReader) -> bool;
+
+        /// Read the next chunk from a chunked Parquet reader.
+        fn read_chunk(self: &ChunkedParquetReader) -> Result<UniquePtr<TableWithMetadata>>;
 
         /// Return the size of the returned host byte vector.
         fn size(self: &HostByteVector) -> usize;

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -150,6 +150,12 @@ pub mod ffi {
             table_reference: i32,
         ) -> Result<usize>;
 
+        /// Add a column-name reference expression to an AST tree.
+        fn ast_expression_tree_add_column_name_reference(
+            tree: Pin<&mut AstExpressionTree>,
+            column_name: &str,
+        ) -> Result<usize>;
+
         /// Add a scalar literal expression to an AST tree.
         fn ast_expression_tree_add_literal(
             tree: Pin<&mut AstExpressionTree>,
@@ -498,6 +504,27 @@ pub mod ffi {
         /// Set projected columns on `cudf::io::parquet_reader_options`.
         fn set_columns(self: Pin<&mut ParquetReaderOptions>, col_names: Vec<String>);
 
+        /// Set per-source row groups on `cudf::io::parquet_reader_options`.
+        ///
+        /// This is a flat FFI representation of cuDF's nested row group vector.
+        fn set_row_groups(
+            self: Pin<&mut ParquetReaderOptions>,
+            row_group_indices: Vec<i32>,
+            source_offsets: Vec<usize>,
+        );
+
+        /// Set AST filter on `cudf::io::parquet_reader_options`.
+        fn set_filter(
+            self: Pin<&mut ParquetReaderOptions>,
+            filter: &AstExpressionTree,
+        ) -> Result<()>;
+
+        /// Enable reading matching projected and filter columns from mismatched Parquet sources.
+        fn enable_allow_mismatched_pq_schemas(self: Pin<&mut ParquetReaderOptions>, val: bool);
+
+        /// Enable ignoring non-existent projected columns while reading.
+        fn enable_ignore_missing_columns(self: Pin<&mut ParquetReaderOptions>, val: bool);
+
         /// Take ownership of the table from `cudf::io::table_with_metadata`.
         fn release_table(self: Pin<&mut TableWithMetadata>) -> UniquePtr<Table>;
 
@@ -509,6 +536,12 @@ pub mod ffi {
 
         /// Return the total number of input row groups.
         fn num_input_row_groups(self: &TableWithMetadata) -> i32;
+
+        /// Return the number of entries in `table_metadata::schema_info`.
+        fn schema_info_count(self: &TableWithMetadata) -> usize;
+
+        /// Return `table_metadata::schema_info[index].name`.
+        fn schema_info_name(self: &TableWithMetadata, index: usize) -> String;
 
         /// Read Parquet using explicit reader options, CUDA stream, and device resource.
         fn read_parquet(

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,6 +2,7 @@ use crate::{CuDFError, CuDFScalar};
 use arrow::error::ArrowError;
 use cxx::UniquePtr;
 use libcudf_sys::{ffi, AstOperator, AstTableReference};
+use std::fmt;
 
 /// A node index inside a [`CuDFAstExpression`] tree.
 pub type CuDFAstNode = usize;
@@ -116,6 +117,12 @@ pub struct CuDFAstExpression {
     literals: Vec<CuDFScalar>,
 }
 
+impl fmt::Debug for CuDFAstExpression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CuDFAstExpression").finish_non_exhaustive()
+    }
+}
+
 impl CuDFAstExpression {
     /// Create an empty cuDF AST expression tree.
     pub fn new() -> Self {
@@ -148,6 +155,20 @@ impl CuDFAstExpression {
                 )))
             })?,
             table.into_sys() as i32,
+        )?)
+    }
+
+    /// Add a column-name reference node.
+    ///
+    /// cuDF Parquet filters use names so filter columns do not need to be
+    /// present in the projected output.
+    pub fn column_name_reference(
+        &mut self,
+        column_name: impl AsRef<str>,
+    ) -> Result<CuDFAstNode, CuDFError> {
+        Ok(ffi::ast_expression_tree_add_column_name_reference(
+            self.inner.pin_mut(),
+            column_name.as_ref(),
         )?)
     }
 

--- a/src/column.rs
+++ b/src/column.rs
@@ -1,7 +1,7 @@
 use crate::data_type::arrow_type_to_cudf;
 use crate::device_resource::resource_ref;
 use crate::stream::stream_ref;
-use crate::{CuDFColumnView, CuDFError};
+use crate::{CuDFColumnView, CuDFError, CuDFScalar};
 use arrow::array::Array;
 use arrow::ffi::FFI_ArrowArray;
 use arrow_schema::ffi::FFI_ArrowSchema;
@@ -72,6 +72,23 @@ impl CuDFColumn {
             )
         }?;
         Ok(Self { inner })
+    }
+
+    /// Create a column by repeating a scalar value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the column cannot be allocated on the GPU.
+    pub fn from_scalar(scalar: &CuDFScalar, len: usize) -> Result<Self, CuDFError> {
+        crate::config::ensure_pools_configured();
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        Ok(Self::new(ffi::make_column_from_scalar(
+            scalar.inner(),
+            len,
+            stream_ref(&stream)?,
+            resource_ref(&mr)?,
+        )?))
     }
 
     /// Return a [CuDFColumnView] pointing to this [CuDFColumn]. The current [CuDFColumn] will

--- a/src/table.rs
+++ b/src/table.rs
@@ -25,7 +25,7 @@ pub struct CuDFParquetReadResult {
     pub table: CuDFTable,
     /// Top-level column names returned by the cuDF reader, in table order.
     pub column_names: Vec<String>,
-    /// Number of rows read from all input sources.
+    /// Number of rows returned after row group and filter pruning.
     pub num_rows: usize,
 }
 
@@ -272,16 +272,8 @@ impl CuDFTable {
         let column_names = (0..result.schema_info_count())
             .map(|index| result.schema_info_name(index))
             .collect();
-        let num_rows =
-            (0..result.num_rows_per_source_count()).try_fold(0usize, |rows, index| {
-                rows.checked_add(result.num_rows_per_source(index))
-                    .ok_or_else(|| {
-                        ArrowError::InvalidArgumentError(
-                            "Parquet row count overflowed usize".to_string(),
-                        )
-                    })
-            })?;
         let inner = result.pin_mut().release_table();
+        let num_rows = inner.num_rows();
         Ok(CuDFParquetReadResult {
             table: Self { inner },
             column_names,

--- a/src/table.rs
+++ b/src/table.rs
@@ -2,7 +2,7 @@ use crate::cudf_array::is_cudf_array;
 use crate::device_resource::resource_ref;
 use crate::stream::stream_ref;
 use crate::table_view::CuDFTableView;
-use crate::{CuDFColumn, CuDFError};
+use crate::{CuDFAstExpression, CuDFColumn, CuDFError};
 use arrow::array::{Array, ArrayData, StructArray};
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow::record_batch::RecordBatch;
@@ -17,6 +17,36 @@ use std::sync::Arc;
 /// This is a safe wrapper around cuDF's table type.
 pub struct CuDFTable {
     pub(crate) inner: UniquePtr<ffi::Table>,
+}
+
+/// Result of reading Parquet with cuDF, including metadata needed for schema adaptation.
+pub struct CuDFParquetReadResult {
+    /// Table returned by cuDF.
+    pub table: CuDFTable,
+    /// Top-level column names returned by the cuDF reader, in table order.
+    pub column_names: Vec<String>,
+    /// Number of rows read from all input sources.
+    pub num_rows: usize,
+}
+
+/// Options for reading one or more Parquet files with cuDF.
+pub struct CuDFParquetReadOptions<'a, P, S>
+where
+    P: AsRef<Path>,
+    S: AsRef<str>,
+{
+    /// Parquet file paths to read.
+    pub paths: &'a [P],
+    /// Optional projected column names.
+    pub columns: Option<&'a [S]>,
+    /// Optional row group indices per input file.
+    pub row_groups: Option<&'a [Vec<i32>]>,
+    /// Optional cuDF AST filter applied by the Parquet reader.
+    pub filter: Option<&'a CuDFAstExpression>,
+    /// Whether cuDF should read matching columns from mismatched Parquet sources.
+    pub allow_mismatched_pq_schemas: bool,
+    /// Whether cuDF should ignore projected columns missing from an input source.
+    pub ignore_missing_columns: bool,
 }
 
 impl CuDFTable {
@@ -94,7 +124,46 @@ impl CuDFTable {
         P: AsRef<Path>,
         S: AsRef<str>,
     {
+        Ok(Self::read_parquet_files_with_columns(paths, columns)?.table)
+    }
+
+    /// Read selected columns from one or more Parquet files with cuDF metadata.
+    pub fn read_parquet_files_with_columns<P, S>(
+        paths: &[P],
+        columns: Option<&[S]>,
+    ) -> Result<CuDFParquetReadResult, CuDFError>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+    {
+        Self::read_parquet_files(CuDFParquetReadOptions {
+            paths,
+            columns,
+            row_groups: None,
+            filter: None,
+            allow_mismatched_pq_schemas: false,
+            ignore_missing_columns: true,
+        })
+    }
+
+    /// Read Parquet files with cuDF metadata.
+    pub fn read_parquet_files<P, S>(
+        read_options: CuDFParquetReadOptions<'_, P, S>,
+    ) -> Result<CuDFParquetReadResult, CuDFError>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+    {
         crate::config::ensure_pools_configured();
+        let CuDFParquetReadOptions {
+            paths,
+            columns,
+            row_groups,
+            filter,
+            allow_mismatched_pq_schemas,
+            ignore_missing_columns,
+        } = read_options;
+
         if paths.is_empty() {
             return Err(ArrowError::InvalidArgumentError(
                 "at least one Parquet file is required".to_string(),
@@ -117,6 +186,25 @@ impl CuDFTable {
         let source = ffi::source_info_from_file_paths(path_strings);
         let source = source.as_ref().expect("source_info should not be null");
         let mut options = ffi::parquet_reader_options_create(source);
+        Self::set_parquet_columns(&mut options, columns);
+        Self::set_parquet_row_groups(&mut options, row_groups, paths.len())?;
+        Self::set_parquet_filter(&mut options, filter)?;
+        options
+            .pin_mut()
+            .enable_allow_mismatched_pq_schemas(allow_mismatched_pq_schemas);
+        options
+            .pin_mut()
+            .enable_ignore_missing_columns(ignore_missing_columns);
+
+        Self::read_parquet_options_with_metadata(options)
+    }
+
+    fn set_parquet_columns<S>(
+        options: &mut UniquePtr<ffi::ParquetReaderOptions>,
+        columns: Option<&[S]>,
+    ) where
+        S: AsRef<str>,
+    {
         if let Some(columns) = columns {
             options.pin_mut().set_columns(
                 columns
@@ -125,7 +213,53 @@ impl CuDFTable {
                     .collect(),
             );
         }
+    }
 
+    fn set_parquet_row_groups(
+        options: &mut UniquePtr<ffi::ParquetReaderOptions>,
+        row_groups: Option<&[Vec<i32>]>,
+        path_count: usize,
+    ) -> Result<(), CuDFError> {
+        let Some(row_groups) = row_groups else {
+            return Ok(());
+        };
+        if row_groups.len() != path_count {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "expected row groups for {path_count} Parquet files, got {}",
+                row_groups.len()
+            ))
+            .into());
+        }
+
+        let mut indices = Vec::new();
+        let mut offsets = Vec::with_capacity(row_groups.len() + 1);
+        offsets.push(0);
+        for source_groups in row_groups {
+            indices.extend(source_groups.iter().copied());
+            offsets.push(indices.len());
+        }
+        options.pin_mut().set_row_groups(indices, offsets);
+        Ok(())
+    }
+
+    fn set_parquet_filter(
+        options: &mut UniquePtr<ffi::ParquetReaderOptions>,
+        filter: Option<&CuDFAstExpression>,
+    ) -> Result<(), CuDFError> {
+        if let Some(filter) = filter {
+            options.pin_mut().set_filter(
+                filter
+                    .inner()
+                    .as_ref()
+                    .expect("ast_expression_tree should not be null"),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn read_parquet_options_with_metadata(
+        options: UniquePtr<ffi::ParquetReaderOptions>,
+    ) -> Result<CuDFParquetReadResult, CuDFError> {
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
         let mut result = ffi::read_parquet(
@@ -135,8 +269,24 @@ impl CuDFTable {
             stream.as_ref().expect("default stream should not be null"),
             mr.as_ref().expect("device resource should not be null"),
         )?;
+        let column_names = (0..result.schema_info_count())
+            .map(|index| result.schema_info_name(index))
+            .collect();
+        let num_rows =
+            (0..result.num_rows_per_source_count()).try_fold(0usize, |rows, index| {
+                rows.checked_add(result.num_rows_per_source(index))
+                    .ok_or_else(|| {
+                        ArrowError::InvalidArgumentError(
+                            "Parquet row count overflowed usize".to_string(),
+                        )
+                    })
+            })?;
         let inner = result.pin_mut().release_table();
-        Ok(Self { inner })
+        Ok(CuDFParquetReadResult {
+            table: Self { inner },
+            column_names,
+            num_rows,
+        })
     }
 
     /// Write the table to a Parquet file

--- a/src/table.rs
+++ b/src/table.rs
@@ -42,6 +42,9 @@ where
     /// Optional row group indices per input file.
     pub row_groups: Option<&'a [Vec<i32>]>,
     /// Optional cuDF AST filter applied by the Parquet reader.
+    ///
+    /// cuDF stores this as a borrowed AST expression reference, so the filter
+    /// must outlive the synchronous read or chunked read call using it.
     pub filter: Option<&'a CuDFAstExpression>,
     /// Whether cuDF should read matching columns from mismatched Parquet sources.
     pub allow_mismatched_pq_schemas: bool,
@@ -154,6 +157,58 @@ impl CuDFTable {
         P: AsRef<Path>,
         S: AsRef<str>,
     {
+        let options = Self::parquet_reader_options(read_options)?;
+        Self::read_parquet_options_with_metadata(options)
+    }
+
+    /// Read all Parquet chunks with cuDF metadata for each chunk.
+    ///
+    /// This convenience method collects all chunks. Use
+    /// [`Self::for_each_parquet_chunk`] to process chunks as they are read.
+    pub fn read_parquet_files_chunked<P, S>(
+        read_options: CuDFParquetReadOptions<'_, P, S>,
+        chunk_read_limit: usize,
+        pass_read_limit: usize,
+    ) -> Result<Vec<CuDFParquetReadResult>, CuDFError>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+    {
+        let mut chunks = Vec::new();
+        Self::for_each_parquet_chunk(read_options, chunk_read_limit, pass_read_limit, |chunk| {
+            chunks.push(chunk);
+            Ok(true)
+        })?;
+        Ok(chunks)
+    }
+
+    /// Read Parquet files in cuDF chunks, invoking `callback` for each chunk.
+    ///
+    /// Returning `Ok(false)` from the callback stops reading early. If `filter`
+    /// is set in `read_options`, the filter expression must remain alive until
+    /// this method returns because cuDF stores a borrowed AST reference.
+    pub fn for_each_parquet_chunk<P, S, F>(
+        read_options: CuDFParquetReadOptions<'_, P, S>,
+        chunk_read_limit: usize,
+        pass_read_limit: usize,
+        callback: F,
+    ) -> Result<(), CuDFError>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+        F: FnMut(CuDFParquetReadResult) -> Result<bool, CuDFError>,
+    {
+        let options = Self::parquet_reader_options(read_options)?;
+        Self::for_each_parquet_options_chunk(options, chunk_read_limit, pass_read_limit, callback)
+    }
+
+    fn parquet_reader_options<P, S>(
+        read_options: CuDFParquetReadOptions<'_, P, S>,
+    ) -> Result<UniquePtr<ffi::ParquetReaderOptions>, CuDFError>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+    {
         crate::config::ensure_pools_configured();
         let CuDFParquetReadOptions {
             paths,
@@ -196,7 +251,7 @@ impl CuDFTable {
             .pin_mut()
             .enable_ignore_missing_columns(ignore_missing_columns);
 
-        Self::read_parquet_options_with_metadata(options)
+        Ok(options)
     }
 
     fn set_parquet_columns<S>(
@@ -279,6 +334,51 @@ impl CuDFTable {
             column_names,
             num_rows,
         })
+    }
+
+    fn for_each_parquet_options_chunk<F>(
+        options: UniquePtr<ffi::ParquetReaderOptions>,
+        chunk_read_limit: usize,
+        pass_read_limit: usize,
+        mut callback: F,
+    ) -> Result<(), CuDFError>
+    where
+        F: FnMut(CuDFParquetReadResult) -> Result<bool, CuDFError>,
+    {
+        let stream = ffi::get_default_stream();
+        let mr = ffi::get_current_device_resource_ref();
+        let reader = ffi::chunked_parquet_reader_create(
+            chunk_read_limit,
+            pass_read_limit,
+            options
+                .as_ref()
+                .expect("parquet_reader_options should not be null"),
+            stream.as_ref().expect("default stream should not be null"),
+            mr.as_ref().expect("device resource should not be null"),
+        )?;
+
+        while reader.has_next() {
+            let mut result = reader.read_chunk()?;
+            if !callback(Self::parquet_read_result_from_metadata(&mut result))? {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn parquet_read_result_from_metadata(
+        result: &mut UniquePtr<ffi::TableWithMetadata>,
+    ) -> CuDFParquetReadResult {
+        let column_names = (0..result.schema_info_count())
+            .map(|index| result.schema_info_name(index))
+            .collect();
+        let inner = result.pin_mut().release_table();
+        let num_rows = inner.num_rows();
+        CuDFParquetReadResult {
+            table: Self { inner },
+            column_names,
+            num_rows,
+        }
     }
 
     /// Write the table to a Parquet file


### PR DESCRIPTION
## Summary

Adds an experimental, opt-in cuDF-backed Parquet scan path for local DataFusion Parquet scans.

The branch includes:

- cuDF Parquet reader and chunked reader plumbing in `libcudf-sys` / `libcudf-rs`
- a `CuDFParquetScanExec` physical plan with chunked reads, projection handling, row-group selection, and schema alignment
- planner replacement for supported local `DataSourceExec` Parquet scans feeding cuDF operators
- Parquet scan predicate lowering into cuDF AST filters where supported
- cuDF-safe coalesce/fetch handling for direct scan outputs
- benchmark harness flags and report metadata for direct scan experiments

## Enable / Disable

Default behavior is unchanged: direct Parquet scan is disabled by default.

Programmatic config:

```rust
CuDFConfig::default().with_parquet_scan(true)
```

DataFusion config key:

```text
cudf.parquet_scan = true
```

Benchmark CLI:

```bash
target/release/dfbench run \
  --dataset tpch_sf1 \
  --query q22 \
  --iterations 3 \
  --gpu \
  --enable-cudf-parquet-scan
```

Harness CLI, GPU leg only:

```bash
target/release/dfbench harness \
  --dataset tpch_sf1 \
  --query q22 \
  --iterations 3 \
  --enable-cudf-parquet-scan
```

Tuning knobs:

- `cudf.parquet_scan_files_per_batch`, default `8`
- `cudf.parquet_scan_chunk_read_limit`, default `256 MiB`
- `cudf.parquet_scan_pass_read_limit`, default `256 MiB`
- `--cudf-parquet-scan-files-per-batch <n>` for benchmark CLI/harness

The scan currently accepts local Parquet files only and falls back to the existing DataFusion scan path for unsupported shapes/options.

## Benchmark Reports

Harness reports were run with 3 iterations, warmup enabled, GPU execution batch size `65536`, Tesla T4 15 GiB.

The harness does not compare query outputs; correctness is covered by tests. Report rows did match CPU/GPU row counts for all paired queries below.

### TPCH SF1

Reports:

- Disabled: `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/sf1_parquet_scan_disabled_warmup/report.md`
- Enabled: `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/sf1_parquet_scan_enabled_warmup/report.md`

Summary:

| Mode | GPU total avg | GPU speedup by total avg | Geomean speedup | Paired queries |
|---|---:|---:|---:|---:|
| direct scan disabled | 3245.3 ms | 0.64x | 0.67x | 22 |
| direct scan enabled | 3003.9 ms | 0.71x | 0.78x | 22 |

Direct scan reduced GPU total avg by about 7.4% on this run.

### TPCH SF10

Reports:

- Disabled: `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf10/sf10_parquet_scan_disabled_warmup_rerun/report.md`
- Enabled: `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf10/sf10_parquet_scan_enabled_warmup_rerun/report.md`

Summary:

| Mode | GPU total avg | GPU speedup by total avg | Geomean speedup | Paired queries |
|---|---:|---:|---:|---:|
| direct scan disabled | 26779.1 ms | 0.56x | 0.56x | 22 |
| direct scan enabled | 23044.5 ms | 0.66x | 0.72x | 22 |

Direct scan reduced GPU total avg by about 13.9% on this run.

## Validation

```bash
cargo fmt --check
cargo test -p libcudf-datafusion direct_parquet_scan_replaces_local_datasource -- --nocapture
```