### PR TITLE
Reuse aggregate state for AVG outputs

### DIFF
--- a/libcudf-datafusion/src/expr/column.rs
+++ b/libcudf-datafusion/src/expr/column.rs
@@ -17,6 +17,10 @@ impl CuDFColumnExpr {
     pub fn from_host(inner: Column) -> Self {
         Self { inner }
     }
+
+    pub(crate) fn host_column(&self) -> &Column {
+        &self.inner
+    }
 }
 
 impl Display for CuDFColumnExpr {

--- a/libcudf-datafusion/src/expr/mod.rs
+++ b/libcudf-datafusion/src/expr/mod.rs
@@ -1,5 +1,4 @@
 use crate::expr::binary::CuDFBinaryExpr;
-use crate::expr::column::CuDFColumnExpr;
 use crate::expr::literal::CuDFLiteral;
 use arrow::array::Array;
 use datafusion::common::{exec_err, not_impl_err};
@@ -15,6 +14,8 @@ pub(crate) mod ast;
 mod binary;
 mod column;
 mod literal;
+
+pub(crate) use column::CuDFColumnExpr;
 
 pub(crate) fn columnar_value_to_cudf(
     c: ColumnarValue,

--- a/libcudf-datafusion/src/physical/aggregate/mod.rs
+++ b/libcudf-datafusion/src/physical/aggregate/mod.rs
@@ -1,4 +1,5 @@
 use crate::expr::expr_to_cudf_expr;
+use crate::expr::CuDFColumnExpr;
 use crate::physical::aggregate::op::count::CuDFCount;
 use crate::planner::CuDFConfig;
 use arrow_schema::{DataType, Schema, SchemaRef};
@@ -16,6 +17,7 @@ use datafusion_physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, InputOrderMode, PhysicalExpr, PlanProperties,
 };
 use std::any::{type_name, Any};
+use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -35,21 +37,58 @@ pub(crate) use op::CuDFAggregationOp;
 pub(crate) struct PreparedCuDFAggregate {
     mode: AggregateMode,
     group_by: PhysicalGroupBy,
-    aggs: Vec<PreparedAggregate>,
+    /// Physical cuDF aggregate requests. These produce the flat state columns
+    /// consumed by `outputs`, not every physical aggregate is emitted directly.
+    aggs: Vec<PreparedPhysicalAggregate>,
+    /// DataFusion aggregate output columns in schema order. Outputs may point at
+    /// physical state directly or derive from state produced by other aggregates.
+    outputs: Vec<PreparedAggregateOutput>,
 }
 
-/// One aggregate expression with all cuDF execution details resolved.
+/// One physical cuDF aggregate request and state slice.
 #[derive(Debug, Clone)]
-pub(crate) struct PreparedAggregate {
+pub(crate) struct PreparedPhysicalAggregate {
+    pub(crate) op: Arc<dyn CuDFAggregationOp>,
+    pub(crate) args: Vec<Arc<dyn PhysicalExpr>>,
+    pub(crate) output_type: DataType,
+}
+
+/// One DataFusion aggregate output column, in schema order.
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedAggregateOutput {
     expr: Arc<AggregateFunctionExpr>,
-    op: Arc<dyn CuDFAggregationOp>,
-    args: Vec<Arc<dyn PhysicalExpr>>,
-    output_type: DataType,
+    kind: PreparedAggregateOutputKind,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum PreparedAggregateOutputKind {
+    Direct {
+        physical: usize,
+    },
+    Derived {
+        op: Arc<dyn CuDFAggregationOp>,
+        state: Vec<StateColumnRef>,
+        output_type: DataType,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StateColumnRef {
+    pub(crate) aggregate: usize,
+    pub(crate) column: usize,
+}
+
+pub(crate) struct DerivedAggregateOutput {
+    pub(crate) state: Vec<StateColumnRef>,
+    pub(crate) output_type: DataType,
 }
 
 impl PreparedCuDFAggregate {
     fn aggr_expr(&self) -> Vec<Arc<AggregateFunctionExpr>> {
-        self.aggs.iter().map(|agg| agg.expr.clone()).collect()
+        self.outputs
+            .iter()
+            .map(|output| output.expr.clone())
+            .collect()
     }
 }
 
@@ -153,11 +192,11 @@ impl DisplayAs for CuDFAggregateExec {
             write!(f, "{}@{}", alias, expr)?;
         }
         write!(f, "], aggr_expr=[")?;
-        for (i, agg) in self.prepared.aggs.iter().enumerate() {
+        for (i, output) in self.prepared.outputs.iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{}", agg.expr.name())?;
+            write!(f, "{}", output.expr.name())?;
         }
         write!(f, "]")
     }
@@ -252,63 +291,330 @@ fn prepare_cudf_aggregate_parts(
 
     let aggregate_args = aggregate_expressions(&aggr_expr, &mode, group_by.expr().len())?;
 
-    let mut aggs = Vec::with_capacity(aggregate_args.len());
+    let mut candidates = Vec::with_capacity(aggr_expr.len());
     for (expr, args) in aggr_expr.into_iter().zip(aggregate_args) {
-        let Some(udf) = expr
-            .fun()
-            .inner()
-            .as_any()
-            .downcast_ref::<CuDFAggregateUDF>()
-        else {
+        let Some(candidate) = prepare_aggregate_candidate(expr, args, mode, input_schema)? else {
             return Ok(None);
         };
-        let mut op = udf.gpu().clone();
-
-        if !original_aggregate_args_supported(&expr)? {
-            return Ok(None);
-        }
-
-        let output_type = expr.field().data_type().clone();
-        let arg_types = args
-            .iter()
-            .map(|arg| arg.data_type(input_schema))
-            .collect::<Result<Vec<DataType>>>()?;
-        if !op.supports_input_types(mode, &arg_types, &output_type) {
-            return Ok(None);
-        }
-
-        let count_star = is_count_star(&expr);
-        let mut converted = Vec::with_capacity(args.len());
-        for arg in args {
-            let Some(arg) = expr_to_cudf_aggregate_arg(arg)? else {
-                return Ok(None);
-            };
-            converted.push(arg);
-        }
-        if count_star && !matches!(mode, AggregateMode::Final | AggregateMode::FinalPartitioned) {
-            let Some((arg, _)) = group_by.expr().first() else {
-                return Ok(None);
-            };
-            op = Arc::new(CuDFCount::count_all());
-            converted = vec![arg.clone()];
-        }
-        aggs.push(PreparedAggregate {
-            expr,
-            op,
-            args: converted,
-            output_type,
-        });
+        candidates.push(candidate);
     }
 
-    Ok(Some(PreparedCuDFAggregate {
-        mode,
-        group_by,
-        aggs,
+    let plan = if can_reuse_derived_state(mode) {
+        prepare_cudf_aggregate_with_reuse(mode, group_by, candidates, input_schema)?
+    } else {
+        prepare_cudf_aggregate_direct(mode, group_by, candidates)
+    };
+
+    Ok(Some(plan))
+}
+
+fn prepare_aggregate_candidate(
+    expr: Arc<AggregateFunctionExpr>,
+    args: Vec<Arc<dyn PhysicalExpr>>,
+    mode: AggregateMode,
+    input_schema: &SchemaRef,
+) -> Result<Option<AggregateCandidate>> {
+    let Some(udf) = expr
+        .fun()
+        .inner()
+        .as_any()
+        .downcast_ref::<CuDFAggregateUDF>()
+    else {
+        return Ok(None);
+    };
+    let op = udf.gpu().clone();
+
+    if !original_aggregate_args_supported(&expr)? {
+        return Ok(None);
+    }
+
+    let output_type = expr.field().data_type().clone();
+    let arg_types = args
+        .iter()
+        .map(|arg| arg.data_type(input_schema))
+        .collect::<Result<Vec<DataType>>>()?;
+    if !op.supports_input_types(mode, &arg_types, &output_type) {
+        return Ok(None);
+    }
+
+    let mut converted = Vec::with_capacity(args.len());
+    for arg in args {
+        let Some(arg) = expr_to_cudf_aggregate_arg(arg)? else {
+            return Ok(None);
+        };
+        converted.push(arg);
+    }
+
+    Ok(Some(AggregateCandidate {
+        kind: AggregateCandidateKind::from_expr(&expr, mode),
+        expr,
+        op,
+        args: converted,
+        output_type,
     }))
 }
 
+fn prepare_cudf_aggregate_direct(
+    mode: AggregateMode,
+    group_by: PhysicalGroupBy,
+    candidates: Vec<AggregateCandidate>,
+) -> PreparedCuDFAggregate {
+    let mut aggs = Vec::with_capacity(candidates.len());
+    let mut outputs = Vec::with_capacity(candidates.len());
+    let count_star_arg = group_by.expr()[0].0.clone();
+    for candidate in &candidates {
+        let physical = push_physical_aggregate(&mut aggs, candidate, &count_star_arg);
+        outputs.push(PreparedAggregateOutput {
+            expr: candidate.expr.clone(),
+            kind: PreparedAggregateOutputKind::Direct { physical },
+        });
+    }
+
+    PreparedCuDFAggregate {
+        mode,
+        group_by,
+        aggs,
+        outputs,
+    }
+}
+
+fn prepare_cudf_aggregate_with_reuse(
+    mode: AggregateMode,
+    group_by: PhysicalGroupBy,
+    candidates: Vec<AggregateCandidate>,
+    input_schema: &SchemaRef,
+) -> Result<PreparedCuDFAggregate> {
+    let mut aggs = Vec::with_capacity(candidates.len());
+    let mut outputs_by_candidate = Vec::with_capacity(candidates.len());
+    let mut state_registry = StateRegistry::default();
+    let count_star_arg = group_by.expr()[0].0.clone();
+
+    for candidate in &candidates {
+        if candidate.op.can_derive_from_reusable_state() {
+            outputs_by_candidate.push(None);
+            continue;
+        }
+
+        let physical = push_physical_aggregate(&mut aggs, candidate, &count_star_arg);
+        for (key, column) in candidate.reusable_state_keys(input_schema)? {
+            state_registry.insert(
+                key,
+                StateColumnRef {
+                    aggregate: physical,
+                    column,
+                },
+            );
+        }
+        outputs_by_candidate.push(Some(physical));
+    }
+
+    let mut outputs = Vec::with_capacity(candidates.len());
+    for (candidate, physical) in candidates.iter().zip(outputs_by_candidate) {
+        let derived = {
+            let mut state = AggregateStatePlanner::new(&mut aggs, &mut state_registry);
+            candidate.op.try_prepare_derived_output(
+                &candidate.args,
+                &candidate.output_type,
+                input_schema,
+                &mut state,
+            )?
+        };
+        if let Some(derived) = derived {
+            outputs.push(PreparedAggregateOutput {
+                expr: candidate.expr.clone(),
+                kind: PreparedAggregateOutputKind::Derived {
+                    op: candidate.op.clone(),
+                    state: derived.state,
+                    output_type: derived.output_type,
+                },
+            });
+            continue;
+        }
+
+        let physical = match physical {
+            Some(physical) => physical,
+            None => push_physical_aggregate(&mut aggs, candidate, &count_star_arg),
+        };
+        outputs.push(PreparedAggregateOutput {
+            expr: candidate.expr.clone(),
+            kind: PreparedAggregateOutputKind::Direct { physical },
+        });
+    }
+
+    Ok(PreparedCuDFAggregate {
+        mode,
+        group_by,
+        aggs,
+        outputs,
+    })
+}
+
+fn push_physical_aggregate(
+    aggs: &mut Vec<PreparedPhysicalAggregate>,
+    candidate: &AggregateCandidate,
+    count_star_arg: &Arc<dyn PhysicalExpr>,
+) -> usize {
+    let physical = aggs.len();
+    let mut op = candidate.op.clone();
+    let mut args = candidate.args.clone();
+    if candidate.kind == AggregateCandidateKind::CountStar {
+        op = Arc::new(CuDFCount::count_all());
+        args = vec![count_star_arg.clone()];
+    }
+    aggs.push(PreparedPhysicalAggregate {
+        op,
+        args,
+        output_type: candidate.output_type.clone(),
+    });
+    physical
+}
+
+fn can_reuse_derived_state(mode: AggregateMode) -> bool {
+    matches!(
+        mode,
+        AggregateMode::Single | AggregateMode::SinglePartitioned
+    )
+}
+
+#[derive(Clone)]
+struct AggregateCandidate {
+    kind: AggregateCandidateKind,
+    expr: Arc<AggregateFunctionExpr>,
+    op: Arc<dyn CuDFAggregationOp>,
+    args: Vec<Arc<dyn PhysicalExpr>>,
+    output_type: DataType,
+}
+
+impl AggregateCandidate {
+    fn reusable_state_keys(
+        &self,
+        input_schema: &SchemaRef,
+    ) -> Result<Vec<(ReusableStateKey, usize)>> {
+        if self.kind == AggregateCandidateKind::CountStar {
+            return Ok(vec![(ReusableStateKey::CountStar, 0)]);
+        }
+
+        self.op.reusable_state_keys(&self.args, input_schema)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AggregateCandidateKind {
+    Regular,
+    CountStar,
+}
+
+impl AggregateCandidateKind {
+    fn from_expr(expr: &AggregateFunctionExpr, mode: AggregateMode) -> Self {
+        if is_raw_input_mode(mode) && is_count_star(expr) {
+            Self::CountStar
+        } else {
+            Self::Regular
+        }
+    }
+}
+
+fn is_raw_input_mode(mode: AggregateMode) -> bool {
+    matches!(
+        mode,
+        AggregateMode::Single | AggregateMode::SinglePartitioned | AggregateMode::Partial
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ExprKey {
+    name: String,
+    index: usize,
+    data_type: DataType,
+}
+
+impl ExprKey {
+    pub(crate) fn try_from_single_arg(
+        args: &[Arc<dyn PhysicalExpr>],
+        input_schema: &SchemaRef,
+    ) -> Result<Option<Self>> {
+        let [arg] = args else {
+            return Ok(None);
+        };
+        Self::try_new(arg, input_schema)
+    }
+
+    fn try_new(expr: &Arc<dyn PhysicalExpr>, input_schema: &SchemaRef) -> Result<Option<Self>> {
+        let column = if let Some(column) = expr.as_any().downcast_ref::<Column>() {
+            column
+        } else if let Some(column) = expr.as_any().downcast_ref::<CuDFColumnExpr>() {
+            column.host_column()
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            name: column.name().to_string(),
+            index: column.index(),
+            data_type: expr.data_type(input_schema)?,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum ReusableStateKey {
+    Sum(ExprKey),
+    Count(ExprKey),
+    CountStar,
+}
+
+#[derive(Default)]
+struct StateRegistry {
+    physical_by_state: HashMap<ReusableStateKey, StateColumnRef>,
+}
+
+impl StateRegistry {
+    fn insert(&mut self, key: ReusableStateKey, state: StateColumnRef) {
+        self.physical_by_state.entry(key).or_insert(state);
+    }
+
+    fn get(&self, key: &ReusableStateKey) -> Option<StateColumnRef> {
+        self.physical_by_state.get(key).copied()
+    }
+}
+
+pub(crate) struct AggregateStatePlanner<'a> {
+    aggs: &'a mut Vec<PreparedPhysicalAggregate>,
+    registry: &'a mut StateRegistry,
+}
+
+impl<'a> AggregateStatePlanner<'a> {
+    fn new(aggs: &'a mut Vec<PreparedPhysicalAggregate>, registry: &'a mut StateRegistry) -> Self {
+        Self { aggs, registry }
+    }
+
+    pub(crate) fn get(&self, key: &ReusableStateKey) -> Option<StateColumnRef> {
+        self.registry.get(key)
+    }
+
+    pub(crate) fn ensure(
+        &mut self,
+        key: ReusableStateKey,
+        build: impl FnOnce() -> Result<PreparedPhysicalAggregate>,
+    ) -> Result<StateColumnRef> {
+        if let Some(state) = self.registry.get(&key) {
+            return Ok(state);
+        }
+
+        // Derived outputs can require hidden physical state that is not one of
+        // DataFusion's requested outputs, for example SUM(a) to finalize AVG(a).
+        let physical = self.aggs.len();
+        self.aggs.push(build()?);
+        let state = StateColumnRef {
+            aggregate: physical,
+            column: 0,
+        };
+        self.registry.insert(key, state);
+        Ok(state)
+    }
+}
+
 fn is_count_star(expr: &AggregateFunctionExpr) -> bool {
-    expr.name().starts_with("count(")
+    expr.fun().name().eq_ignore_ascii_case("count")
         && expr.expressions().iter().all(|arg| {
             arg.as_any()
                 .downcast_ref::<Literal>()
@@ -371,10 +677,10 @@ mod test {
     use crate::physical::{CuDFLoadExec, CuDFUnloadExec};
     use crate::test_utils::sort_batches;
     use crate::CuDFConfig;
-    use arrow::array::{record_batch, Array, Int64Array, StringArray, StringViewArray};
+    use arrow::array::{record_batch, Array, ArrayRef, Int64Array, StringArray, StringViewArray};
     use arrow::record_batch::RecordBatch;
     use arrow::util::pretty::pretty_format_batches;
-    use arrow_schema::SchemaRef;
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
     use datafusion::common::ScalarValue;
     use datafusion::execution::runtime_env::RuntimeEnv;
     use datafusion::execution::TaskContext;
@@ -454,6 +760,51 @@ mod test {
         let batches = result.try_collect::<Vec<_>>().await?;
 
         Ok(batches)
+    }
+
+    fn aggregate_expr(
+        agg_fn: Arc<AggregateUDF>,
+        args: Vec<Arc<dyn PhysicalExpr>>,
+        schema: &SchemaRef,
+        alias: &str,
+    ) -> Result<Arc<datafusion_physical_plan::udaf::AggregateFunctionExpr>, Box<dyn Error>> {
+        Ok(Arc::new(
+            AggregateExprBuilder::new(agg_fn, args)
+                .schema(Arc::clone(schema))
+                .alias(alias)
+                .build()?,
+        ))
+    }
+
+    fn aggregate_for_batch(
+        batch: RecordBatch,
+        aggs: Vec<Arc<datafusion_physical_plan::udaf::AggregateFunctionExpr>>,
+    ) -> Result<CuDFAggregateExec, Box<dyn Error>> {
+        let schema = batch.schema();
+        let root = TestMemoryExec::try_new(&[vec![batch]], Arc::clone(&schema), None)?;
+        let load = CuDFLoadExec::try_new(Arc::new(root))?;
+        let group_by = PhysicalGroupBy::new_single(vec![(col("c", &schema)?, "c".to_string())]);
+
+        Ok(CuDFAggregateExec::try_new(
+            Arc::new(load),
+            AggregateMode::Single,
+            group_by,
+            aggs,
+        )?)
+    }
+
+    fn state_reuse_batch(nullable_a: bool) -> Result<RecordBatch, Box<dyn Error>> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, nullable_a),
+            Field::new("c", DataType::Utf8, false),
+        ]));
+        let a: ArrayRef = if nullable_a {
+            Arc::new(Int64Array::from(vec![Some(1), None, Some(4)]))
+        } else {
+            Arc::new(Int64Array::from(vec![1, 2, 4]))
+        };
+        let c: ArrayRef = Arc::new(StringArray::from(vec!["hello", "hello", "world"]));
+        Ok(RecordBatch::try_new(schema, vec![a, c])?)
     }
 
     #[tokio::test]
@@ -572,6 +923,125 @@ mod test {
         +-------+--------+
         ");
 
+        Ok(())
+    }
+
+    fn cudf_task_context() -> Arc<TaskContext> {
+        Arc::new(TaskContext::default().with_session_config(
+            SessionConfig::default().with_option_extension(CuDFConfig::default()),
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_avg_reuses_sum_and_count_star_for_non_null_input() -> Result<(), Box<dyn Error>> {
+        let batch = state_reuse_batch(false)?;
+        let schema = batch.schema();
+        let lit_one: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int64(Some(1))));
+        let aggregate = aggregate_for_batch(
+            batch,
+            vec![
+                aggregate_expr(sum(), vec![col("a", &schema)?], &schema, "SUM(a)")?,
+                aggregate_expr(count(), vec![lit_one], &schema, "COUNT(*)")?,
+                aggregate_expr(avg(), vec![col("a", &schema)?], &schema, "AVG(a)")?,
+            ],
+        )?;
+
+        assert_eq!(aggregate.prepared.aggs.len(), 2);
+
+        let unload = CuDFUnloadExec::new(Arc::new(aggregate));
+        let result = unload.execute(0, cudf_task_context())?;
+        let batches = result.try_collect::<Vec<_>>().await?;
+        let output = pretty_format_batches(&sort_batches(&batches))?.to_string();
+        assert_snapshot!(output, @r"
+        +-------+--------+----------+--------+
+        | c     | SUM(a) | COUNT(*) | AVG(a) |
+        +-------+--------+----------+--------+
+        | hello | 3      | 2        | 1.5    |
+        | world | 4      | 1        | 4.0    |
+        +-------+--------+----------+--------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nullable_avg_reuses_sum_and_count_column() -> Result<(), Box<dyn Error>> {
+        let batch = state_reuse_batch(true)?;
+        let schema = batch.schema();
+        let aggregate = aggregate_for_batch(
+            batch,
+            vec![
+                aggregate_expr(sum(), vec![col("a", &schema)?], &schema, "SUM(a)")?,
+                aggregate_expr(count(), vec![col("a", &schema)?], &schema, "COUNT(a)")?,
+                aggregate_expr(avg(), vec![col("a", &schema)?], &schema, "AVG(a)")?,
+            ],
+        )?;
+
+        assert_eq!(aggregate.prepared.aggs.len(), 2);
+
+        let unload = CuDFUnloadExec::new(Arc::new(aggregate));
+        let result = unload.execute(0, cudf_task_context())?;
+        let batches = result.try_collect::<Vec<_>>().await?;
+        let output = pretty_format_batches(&sort_batches(&batches))?.to_string();
+        assert_snapshot!(output, @r"
+        +-------+--------+----------+--------+
+        | c     | SUM(a) | COUNT(a) | AVG(a) |
+        +-------+--------+----------+--------+
+        | hello | 1      | 1        | 1.0    |
+        | world | 4      | 1        | 4.0    |
+        +-------+--------+----------+--------+
+        ");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_derived_avg_preserves_output_order() -> Result<(), Box<dyn Error>> {
+        let batch = state_reuse_batch(false)?;
+        let schema = batch.schema();
+        let lit_one: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int64(Some(1))));
+        let aggregate = aggregate_for_batch(
+            batch,
+            vec![
+                aggregate_expr(avg(), vec![col("a", &schema)?], &schema, "AVG(a)")?,
+                aggregate_expr(sum(), vec![col("a", &schema)?], &schema, "SUM(a)")?,
+                aggregate_expr(count(), vec![lit_one], &schema, "COUNT(*)")?,
+            ],
+        )?;
+
+        assert_eq!(aggregate.prepared.aggs.len(), 2);
+
+        let unload = CuDFUnloadExec::new(Arc::new(aggregate));
+        let result = unload.execute(0, cudf_task_context())?;
+        let batches = result.try_collect::<Vec<_>>().await?;
+        let output = pretty_format_batches(&sort_batches(&batches))?.to_string();
+        assert_snapshot!(output, @r"
+        +-------+--------+--------+----------+
+        | c     | AVG(a) | SUM(a) | COUNT(*) |
+        +-------+--------+--------+----------+
+        | hello | 1.5    | 3      | 2        |
+        | world | 4.0    | 4      | 1        |
+        +-------+--------+--------+----------+
+        ");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nullable_avg_does_not_reuse_count_star() -> Result<(), Box<dyn Error>> {
+        let batch = state_reuse_batch(true)?;
+        let schema = batch.schema();
+        let lit_one: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int64(Some(1))));
+        let aggregate = aggregate_for_batch(
+            batch,
+            vec![
+                aggregate_expr(sum(), vec![col("a", &schema)?], &schema, "SUM(a)")?,
+                aggregate_expr(count(), vec![lit_one], &schema, "COUNT(*)")?,
+                aggregate_expr(avg(), vec![col("a", &schema)?], &schema, "AVG(a)")?,
+            ],
+        )?;
+
+        assert_eq!(aggregate.prepared.aggs.len(), 3);
         Ok(())
     }
 

--- a/libcudf-datafusion/src/physical/aggregate/op/avg.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/avg.rs
@@ -1,14 +1,19 @@
 use crate::decimal::{decimal_count_type_for, decimal_div, is_supported_decimal};
 use crate::errors::cudf_to_df;
+use crate::physical::aggregate::op::sum::CuDFSum;
 use crate::physical::aggregate::op::udf::CuDFAggregateUDF;
-use crate::physical::aggregate::CuDFAggregationOp;
+use crate::physical::aggregate::{
+    AggregateStatePlanner, CuDFAggregationOp, DerivedAggregateOutput, ExprKey,
+    PreparedPhysicalAggregate, ReusableStateKey,
+};
 use arrow::array::Array;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, SchemaRef};
 use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::average::Avg;
 use datafusion_expr::AggregateUDF;
 use datafusion_physical_plan::aggregates::AggregateMode;
+use datafusion_physical_plan::PhysicalExpr;
 use libcudf_rs::{
     cudf_binary_op, AggregationOp, AggregationRequest, CuDFBinaryOp, CuDFColumn, CuDFColumnView,
     CuDFColumnViewOrScalar,
@@ -28,6 +33,10 @@ impl CuDFAggregationOp for CuDFAvg {
         2 // [count, sum]
     }
 
+    fn can_derive_from_reusable_state(&self) -> bool {
+        true
+    }
+
     fn supports_input_types(
         &self,
         mode: AggregateMode,
@@ -40,6 +49,43 @@ impl CuDFAggregationOp for CuDFAvg {
             }
             _ => supports_raw_input_types(input_types, output_type),
         }
+    }
+
+    fn try_prepare_derived_output(
+        &self,
+        args: &[Arc<dyn PhysicalExpr>],
+        output_type: &DataType,
+        input_schema: &SchemaRef,
+        state: &mut AggregateStatePlanner<'_>,
+    ) -> Result<Option<DerivedAggregateOutput>> {
+        let Some(key) = ExprKey::try_from_single_arg(args, input_schema)? else {
+            return Ok(None);
+        };
+
+        let count = match state.get(&ReusableStateKey::Count(key.clone())) {
+            Some(count) => count,
+            None if !args[0].nullable(input_schema)? => {
+                let Some(count) = state.get(&ReusableStateKey::CountStar) else {
+                    return Ok(None);
+                };
+                count
+            }
+            None => return Ok(None),
+        };
+
+        let sum_key = ReusableStateKey::Sum(key);
+        let sum = state.ensure(sum_key, || {
+            Ok(PreparedPhysicalAggregate {
+                op: Arc::new(CuDFSum),
+                args: args.to_vec(),
+                output_type: args[0].data_type(input_schema)?,
+            })
+        })?;
+
+        Ok(Some(DerivedAggregateOutput {
+            state: vec![count, sum],
+            output_type: output_type.clone(),
+        }))
     }
 
     fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
@@ -85,30 +131,37 @@ impl CuDFAggregationOp for CuDFAvg {
         state_cols: &[CuDFColumnView],
         output_type: &DataType,
     ) -> Result<CuDFColumnView> {
-        if state_cols.len() != 2 {
-            return exec_err!(
-                "AVG finalize expects 2 state columns, got {}",
-                state_cols.len()
-            );
-        }
+        finalize_avg_state(state_cols, output_type)
+    }
+}
 
-        if is_supported_decimal(output_type) {
-            return finalize_decimal_avg(&state_cols[1], &state_cols[0], output_type);
-        }
+fn finalize_avg_state(
+    state_cols: &[CuDFColumnView],
+    output_type: &DataType,
+) -> Result<CuDFColumnView> {
+    if state_cols.len() != 2 {
+        return exec_err!(
+            "AVG finalize expects 2 state columns, got {}",
+            state_cols.len()
+        );
+    }
 
-        let result = cudf_binary_op(
-            CuDFColumnViewOrScalar::ColumnView(state_cols[1].clone()),
-            CuDFColumnViewOrScalar::ColumnView(state_cols[0].clone()),
-            CuDFBinaryOp::Div,
-            &DataType::Float64,
-        )
-        .map_err(cudf_to_df)?;
+    if is_supported_decimal(output_type) {
+        return finalize_decimal_avg(&state_cols[1], &state_cols[0], output_type);
+    }
 
-        match result {
-            CuDFColumnViewOrScalar::ColumnView(view) => Ok(view),
-            CuDFColumnViewOrScalar::Scalar(_) => {
-                exec_err!("AVG finalize: expected ColumnView from division, got Scalar")
-            }
+    let result = cudf_binary_op(
+        CuDFColumnViewOrScalar::ColumnView(state_cols[1].clone()),
+        CuDFColumnViewOrScalar::ColumnView(state_cols[0].clone()),
+        CuDFBinaryOp::Div,
+        &DataType::Float64,
+    )
+    .map_err(cudf_to_df)?;
+
+    match result {
+        CuDFColumnViewOrScalar::ColumnView(view) => Ok(view),
+        CuDFColumnViewOrScalar::Scalar(_) => {
+            exec_err!("AVG finalize: expected ColumnView from division, got Scalar")
         }
     }
 }

--- a/libcudf-datafusion/src/physical/aggregate/op/count.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/count.rs
@@ -1,11 +1,12 @@
 use crate::errors::cudf_to_df;
 use crate::physical::aggregate::op::udf::CuDFAggregateUDF;
-use crate::physical::aggregate::CuDFAggregationOp;
-use arrow_schema::DataType;
+use crate::physical::aggregate::{CuDFAggregationOp, ExprKey, ReusableStateKey};
+use arrow_schema::{DataType, SchemaRef};
 use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::count::Count;
 use datafusion_expr::AggregateUDF;
+use datafusion_physical_plan::PhysicalExpr;
 use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumn, CuDFColumnView};
 use std::sync::Arc;
 
@@ -28,6 +29,20 @@ impl CuDFCount {
 impl CuDFAggregationOp for CuDFCount {
     fn num_state_columns(&self) -> usize {
         1
+    }
+
+    fn reusable_state_keys(
+        &self,
+        args: &[Arc<dyn PhysicalExpr>],
+        input_schema: &SchemaRef,
+    ) -> Result<Vec<(ReusableStateKey, usize)>> {
+        if self.count_nulls {
+            return Ok(vec![(ReusableStateKey::CountStar, 0)]);
+        }
+
+        Ok(ExprKey::try_from_single_arg(args, input_schema)?
+            .map(|key| vec![(ReusableStateKey::Count(key), 0)])
+            .unwrap_or_default())
     }
 
     fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {

--- a/libcudf-datafusion/src/physical/aggregate/op/mod.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/mod.rs
@@ -1,8 +1,12 @@
+use crate::physical::aggregate::{AggregateStatePlanner, DerivedAggregateOutput, ReusableStateKey};
 use arrow_schema::DataType;
+use arrow_schema::SchemaRef;
 use datafusion::error::Result;
 use datafusion_physical_plan::aggregates::AggregateMode;
+use datafusion_physical_plan::PhysicalExpr;
 use libcudf_rs::{AggregationRequest, CuDFColumn, CuDFColumnView};
 use std::fmt::Debug;
+use std::sync::Arc;
 
 pub mod avg;
 pub mod count;
@@ -36,6 +40,33 @@ pub trait CuDFAggregationOp: Debug + Send + Sync {
         _output_type: &DataType,
     ) -> bool {
         true
+    }
+
+    /// Whether this aggregate can produce its final output from reusable state
+    /// published by other physical aggregates.
+    fn can_derive_from_reusable_state(&self) -> bool {
+        false
+    }
+
+    /// State keys published by this physical aggregate, if its output can be
+    /// reused by another aggregate in the same `AggregateExec`.
+    fn reusable_state_keys(
+        &self,
+        _args: &[Arc<dyn PhysicalExpr>],
+        _input_schema: &SchemaRef,
+    ) -> Result<Vec<(ReusableStateKey, usize)>> {
+        Ok(vec![])
+    }
+
+    /// Build a derived output from reusable state, if the state is available.
+    fn try_prepare_derived_output(
+        &self,
+        _args: &[Arc<dyn PhysicalExpr>],
+        _output_type: &DataType,
+        _input_schema: &SchemaRef,
+        _state: &mut AggregateStatePlanner<'_>,
+    ) -> Result<Option<DerivedAggregateOutput>> {
+        Ok(None)
     }
 
     /// Build cuDF aggregation requests for raw input data.

--- a/libcudf-datafusion/src/physical/aggregate/op/sum.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/sum.rs
@@ -1,9 +1,11 @@
 use crate::physical::aggregate::op::udf::CuDFAggregateUDF;
-use crate::physical::aggregate::CuDFAggregationOp;
+use crate::physical::aggregate::{CuDFAggregationOp, ExprKey, ReusableStateKey};
+use arrow_schema::SchemaRef;
 use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::sum::Sum;
 use datafusion_expr::AggregateUDF;
+use datafusion_physical_plan::PhysicalExpr;
 use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -19,6 +21,16 @@ pub struct CuDFSum;
 impl CuDFAggregationOp for CuDFSum {
     fn num_state_columns(&self) -> usize {
         1
+    }
+
+    fn reusable_state_keys(
+        &self,
+        args: &[Arc<dyn PhysicalExpr>],
+        input_schema: &SchemaRef,
+    ) -> Result<Vec<(ReusableStateKey, usize)>> {
+        Ok(ExprKey::try_from_single_arg(args, input_schema)?
+            .map(|key| vec![(ReusableStateKey::Sum(key), 0)])
+            .unwrap_or_default())
     }
 
     fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {

--- a/libcudf-datafusion/src/physical/aggregate/stream.rs
+++ b/libcudf-datafusion/src/physical/aggregate/stream.rs
@@ -1,6 +1,8 @@
 use crate::errors::cudf_to_df;
 use crate::metrics::CuDFBaselineMetrics;
-use crate::physical::aggregate::PreparedCuDFAggregate;
+use crate::physical::aggregate::{
+    PreparedAggregateOutputKind, PreparedCuDFAggregate, StateColumnRef,
+};
 use arrow::array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::SchemaRef;
 use datafusion::common::{exec_err, internal_err};
@@ -57,11 +59,11 @@ impl GroupByMetrics {
     }
 }
 
-/// Maps each aggregation op to its slice of the flat state_columns array.
+/// Maps each physical aggregation op to its slice of the flat state_columns array.
 ///
 /// Built once at construction from `num_state_columns()`.
 ///
-/// Example for `[SUM, AVG, MAX]`:
+/// Example for physical aggregates `[SUM, AVG, MAX]`:
 /// ```text
 ///   SUM -> (0, 1), AVG -> (1, 2), MAX -> (3, 1)
 /// ```
@@ -90,7 +92,7 @@ pub struct CuDFAggregateStream {
     input: SendableRecordBatchStream,
     output_schema: SchemaRef,
     prepared: PreparedCuDFAggregate,
-    /// cuDF expressions that extract each op's argument columns from a batch.
+    /// cuDF expressions that extract each physical op's argument columns from a batch.
     aggregate_args: Vec<Vec<Arc<dyn PhysicalExpr>>>,
     column_mapping: ColumnMapping,
     state: StreamState,
@@ -311,8 +313,7 @@ impl CuDFAggregateStream {
         let _timer = self.group_by_metrics.emitting_time.timer();
         let num_rows = running.keys.num_rows();
         let key_columns = running.keys.into_columns();
-        let mut arrays: Vec<ArrayRef> =
-            Vec::with_capacity(key_columns.len() + self.prepared.aggs.len());
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.output_schema.fields().len());
 
         for col in key_columns {
             arrays.push(Arc::new(col.into_view()));
@@ -326,26 +327,46 @@ impl CuDFAggregateStream {
 
         let is_partial = matches!(self.prepared.mode, AggregateMode::Partial);
 
-        for (op_idx, agg) in self.prepared.aggs.iter().enumerate() {
-            let (start, count) = self.column_mapping.ranges[op_idx];
-            let state_views: Vec<CuDFColumnView> = state_views[start..start + count].to_vec();
+        for output in &self.prepared.outputs {
+            match &output.kind {
+                PreparedAggregateOutputKind::Direct { physical } => {
+                    let agg = &self.prepared.aggs[*physical];
+                    let state_views = self.state_slice(&state_views, *physical);
 
-            if is_partial {
-                // Partial mode: emit raw state columns, cast to match state_fields schema
-                let state_fields = agg.expr.state_fields()?;
-                for (col_idx, view) in state_views.into_iter().enumerate() {
-                    let target_type = state_fields[col_idx].data_type();
-                    if view.data_type() != target_type {
-                        let casted = libcudf_rs::cast(&view, target_type).map_err(cudf_to_df)?;
-                        arrays.push(Arc::new(casted.into_view()));
+                    if is_partial {
+                        let state_fields = output.expr.state_fields()?;
+                        for (col_idx, view) in state_views.into_iter().enumerate() {
+                            let target_type = state_fields[col_idx].data_type();
+                            if view.data_type() != target_type {
+                                let casted =
+                                    libcudf_rs::cast(&view, target_type).map_err(cudf_to_df)?;
+                                arrays.push(Arc::new(casted.into_view()));
+                            } else {
+                                arrays.push(Arc::new(view));
+                            }
+                        }
                     } else {
-                        arrays.push(Arc::new(view));
+                        let finalized = agg.op.finalize(&state_views, &agg.output_type)?;
+                        arrays.push(Arc::new(finalized));
                     }
                 }
-            } else {
-                // Single/Final/FinalPartitioned/SinglePartitioned: finalize
-                let finalized = agg.op.finalize(&state_views, &agg.output_type)?;
-                arrays.push(Arc::new(finalized));
+                PreparedAggregateOutputKind::Derived {
+                    op,
+                    state,
+                    output_type,
+                } => {
+                    if is_partial {
+                        return internal_err!(
+                            "Derived aggregate output is not valid for Partial mode"
+                        );
+                    }
+                    let state_views = state
+                        .iter()
+                        .map(|state| self.state_column(&state_views, *state))
+                        .collect::<Vec<_>>();
+                    let finalized = op.finalize(&state_views, output_type)?;
+                    arrays.push(Arc::new(finalized));
+                }
             }
         }
 
@@ -354,6 +375,20 @@ impl CuDFAggregateStream {
             &self.output_schema,
             num_rows,
         )?))
+    }
+
+    fn state_slice(&self, state_views: &[CuDFColumnView], aggregate: usize) -> Vec<CuDFColumnView> {
+        let (start, count) = self.column_mapping.ranges[aggregate];
+        state_views[start..start + count].to_vec()
+    }
+
+    fn state_column(
+        &self,
+        state_views: &[CuDFColumnView],
+        state: StateColumnRef,
+    ) -> CuDFColumnView {
+        let (start, _) = self.column_mapping.ranges[state.aggregate];
+        state_views[start + state.column].clone()
     }
 
     /// Evaluate GROUP BY expressions on a batch and wrap the resulting key


### PR DESCRIPTION
## Summary

- Split aggregate planning into physical cuDF aggregate requests and DataFusion output columns so outputs can reuse existing aggregate state while preserving schema order.
- Let `AVG` derive from reusable `SUM` + `COUNT` state in single-pass aggregate modes, including `COUNT(*)` for non-null inputs and `COUNT(col)` for nullable inputs.
- Keep reusable state matching conservative by keying only direct column references, and add focused coverage for nullable AVG, count-star reuse, and output-order preservation.

## Validation

- `cargo fmt --check`
- `cargo check -p libcudf-datafusion`
- `cargo test -p libcudf-datafusion physical::aggregate::test -- --nocapture --test-threads=1`

## TPCH harness results

Both harness runs used `--iterations 3 --warmup --enable-cudf-parquet-scan` on a Tesla T4. The harness reports timing and row counts; it does not compare output correctness.

### SF10

- paired successful queries: `22`
- CPU total avg: `14723.2 ms`
- GPU total avg: `22105.7 ms`
- GPU speedup by total average: `0.67x`
- geometric mean speedup: `0.71x`
- local report: `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf10/1778375961_832ea11/report.md`

### SF1

- paired successful queries: `22`
- CPU total avg: `2058.1 ms`
- GPU total avg: `3045.2 ms`
- GPU speedup by total average: `0.68x`
- geometric mean speedup: `0.76x`
- local report: `libcudf-datafusion-benchmarks/benchmark-results/tpch_sf1/1778376114_832ea11/report.md`
