### PR TITLE
add stream and event parity bindings

### DIFF
--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -186,6 +186,12 @@ pub mod ffi {
         /// Opaque non-owning wrapper for an RMM CUDA stream view.
         type CudaStreamView;
 
+        /// Opaque non-owning wrapper for an upstream CCCL CUDA stream ref.
+        type CudaStreamRef;
+
+        /// Opaque owning wrapper for a CUDA event.
+        type CudaEvent;
+
         /// Return whether this wrapper still owns an underlying CUDA stream.
         ///
         /// In C++, you could do something like
@@ -210,6 +216,27 @@ pub mod ffi {
 
         /// Synchronize the viewed CUDA stream.
         fn synchronize(self: &CudaStreamView) -> Result<()>;
+
+        /// Create and record a CUDA event on this stream.
+        ///
+        /// `flags` is the raw upstream `cuda::event_flags` bitmask; this keeps
+        /// sys mechanical while allowing upstream flag combinations through cxx.
+        fn record_event(self: &CudaStreamRef, flags: u32) -> Result<UniquePtr<CudaEvent>>;
+
+        /// Make this stream wait until the CUDA event has completed.
+        fn wait_event(self: &CudaStreamRef, event: &CudaEvent) -> Result<()>;
+
+        /// Return whether this wrapper owns a live CUDA event.
+        fn is_valid(self: &CudaEvent) -> bool;
+
+        /// Record this CUDA event on the given stream.
+        fn record(self: &CudaEvent, stream: &CudaStreamRef) -> Result<()>;
+
+        /// Block until this CUDA event has completed.
+        fn sync(self: &CudaEvent) -> Result<()>;
+
+        /// Return true if this CUDA event has completed.
+        fn is_done(self: &CudaEvent) -> Result<bool>;
 
         /// Opaque non-owning wrapper for an RMM device async resource reference.
         type DeviceAsyncResourceRef;
@@ -1051,11 +1078,27 @@ pub mod ffi {
         /// Return a non-owning view for an owned CUDA stream.
         fn cuda_stream_view(stream: &CudaStream) -> UniquePtr<CudaStreamView>;
 
+        /// Convert an RMM CUDA stream view into an upstream CCCL CUDA stream ref.
+        ///
+        /// Factory function because cxx cannot expose C++ conversion operators directly.
+        fn cuda_stream_ref_from_view(stream: &CudaStreamView) -> UniquePtr<CudaStreamRef>;
+
+        /// Create a CUDA event on a device with explicit upstream event flags.
+        ///
+        /// Factory function because cxx cannot expose C++ constructors directly.
+        fn cuda_event_create_on_device(device_id: i32, flags: u32) -> Result<UniquePtr<CudaEvent>>;
+
         /// Get cuDF's current default stream.
         fn get_default_stream() -> UniquePtr<CudaStreamView>;
 
         /// Check whether cuDF is using the CUDA per-thread default stream.
         fn is_ptds_enabled() -> bool;
+
+        /// Return the current CUDA device ordinal.
+        fn cuda_get_device() -> Result<i32>;
+
+        /// Set the current CUDA device ordinal.
+        fn cuda_set_device(device_id: i32) -> Result<()>;
 
         /// Return cuDF's current device memory resource reference.
         fn get_current_device_resource_ref() -> UniquePtr<DeviceAsyncResourceRef>;
@@ -1731,6 +1774,18 @@ unsafe impl Send for ffi::CudaStream {}
 /// SAFETY: Shared references to the opaque stream wrapper are safe.
 unsafe impl Sync for ffi::CudaStream {}
 
+/// SAFETY: CUDA stream refs are non-owning handles that can be transferred between threads.
+unsafe impl Send for ffi::CudaStreamRef {}
+
+/// SAFETY: Shared references to the opaque stream ref wrapper are safe.
+unsafe impl Sync for ffi::CudaStreamRef {}
+
+/// SAFETY: CUDA event handles can be transferred between threads.
+unsafe impl Send for ffi::CudaEvent {}
+
+/// SAFETY: Shared references to the opaque event wrapper are safe.
+unsafe impl Sync for ffi::CudaEvent {}
+
 /// SAFETY: The cuda memory resource is a process-global allocator; the wrapper
 /// just owns its `unique_ptr` and is safe to move and share across threads.
 unsafe impl Send for ffi::CudaMemoryResource {}
@@ -1764,6 +1819,7 @@ mod tests {
 
     const CUDA_STREAM_FLAG_SYNC_DEFAULT: u32 = 0;
     const CUDA_STREAM_FLAG_NON_BLOCKING: u32 = 1;
+    const CUDA_EVENT_FLAG_DEFAULT: u32 = 0;
 
     fn expect_stream(stream: &cxx::UniquePtr<ffi::CudaStreamView>) -> &ffi::CudaStreamView {
         stream.as_ref().expect("default stream should not be null")
@@ -2609,6 +2665,63 @@ mod tests {
             assert!(default_view.is_default());
         }
         default_view.synchronize()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cuda_device_bindings() -> Result<(), Box<dyn std::error::Error>> {
+        let current_device = ffi::cuda_get_device()?;
+        ffi::cuda_set_device(current_device)?;
+        assert_eq!(ffi::cuda_get_device()?, current_device);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cuda_event_bindings() -> Result<(), Box<dyn std::error::Error>> {
+        let producer = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING)?;
+        let consumer = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING)?;
+        let producer_view =
+            ffi::cuda_stream_view(producer.as_ref().expect("CudaStream should not be null"));
+        let consumer_view =
+            ffi::cuda_stream_view(consumer.as_ref().expect("CudaStream should not be null"));
+        let producer_ref = ffi::cuda_stream_ref_from_view(
+            producer_view
+                .as_ref()
+                .expect("CudaStreamView should not be null"),
+        );
+        let consumer_ref = ffi::cuda_stream_ref_from_view(
+            consumer_view
+                .as_ref()
+                .expect("CudaStreamView should not be null"),
+        );
+
+        let event =
+            ffi::cuda_event_create_on_device(ffi::cuda_get_device()?, CUDA_EVENT_FLAG_DEFAULT)?;
+        let event_ref = event.as_ref().expect("CudaEvent should not be null");
+        assert!(event_ref.is_valid());
+        event_ref.record(
+            producer_ref
+                .as_ref()
+                .expect("CudaStreamRef should not be null"),
+        )?;
+        event_ref.sync()?;
+        assert!(event_ref.is_done()?);
+
+        let event = producer_ref
+            .as_ref()
+            .expect("CudaStreamRef should not be null")
+            .record_event(CUDA_EVENT_FLAG_DEFAULT)?;
+        consumer_ref
+            .as_ref()
+            .expect("CudaStreamRef should not be null")
+            .wait_event(event.as_ref().expect("CudaEvent should not be null"))?;
+        consumer.synchronize()?;
+        assert!(event
+            .as_ref()
+            .expect("CudaEvent should not be null")
+            .is_done()?);
 
         Ok(())
     }

--- a/libcudf-sys/src/stream.cpp
+++ b/libcudf-sys/src/stream.cpp
@@ -1,6 +1,9 @@
 #include "stream.h"
 
+#include <rmm/detail/error.hpp>
+
 #include <stdexcept>
+#include <utility>
 
 namespace libcudf_bridge {
     namespace {
@@ -13,9 +16,18 @@ namespace libcudf_bridge {
         static_assert(
             static_cast<uint32_t>(rmm::cuda_stream::flags::non_blocking) ==
             kCudaStreamFlagNonBlocking);
+        static_assert(static_cast<uint32_t>(cuda::event_flags::none) == cudaEventDefault);
+        static_assert(
+            static_cast<uint32_t>(cuda::event_flags::blocking_sync) == cudaEventBlockingSync);
+        static_assert(
+            static_cast<uint32_t>(cuda::event_flags::interprocess) == cudaEventInterprocess);
 
         [[nodiscard]] rmm::cuda_stream::flags to_rmm_flags(const uint32_t flags) {
             return static_cast<rmm::cuda_stream::flags>(flags);
+        }
+
+        [[nodiscard]] cuda::event_flags to_event_flags(const uint32_t flags) {
+            return static_cast<cuda::event_flags>(flags);
         }
     } // namespace
 
@@ -33,6 +45,22 @@ namespace libcudf_bridge {
 
     void CudaStreamView::synchronize() const {
         inner.synchronize();
+    }
+
+    CudaStreamRef::CudaStreamRef(cuda::stream_ref stream) : inner(stream) {}
+
+    CudaStreamRef::~CudaStreamRef() = default;
+
+    std::unique_ptr<CudaEvent> CudaStreamRef::record_event(const uint32_t flags) const {
+        auto event = inner.record_event(to_event_flags(flags));
+        return std::make_unique<CudaEvent>(std::move(event));
+    }
+
+    void CudaStreamRef::wait_event(const CudaEvent& event) const {
+        if (!event.is_valid()) {
+            throw std::runtime_error("Cannot wait on null CUDA event");
+        }
+        inner.wait(event.inner);
     }
 
     /// By default, create a stream that synchronizes with the default stream
@@ -64,6 +92,35 @@ namespace libcudf_bridge {
         inner->synchronize();
     }
 
+    CudaEvent::CudaEvent(cuda::event event) : inner(std::move(event)) {}
+
+    CudaEvent::~CudaEvent() = default;
+
+    bool CudaEvent::is_valid() const {
+        return static_cast<bool>(inner);
+    }
+
+    void CudaEvent::record(const CudaStreamRef& stream) const {
+        if (!is_valid()) {
+            throw std::runtime_error("Cannot record null CUDA event");
+        }
+        inner.record(stream.inner);
+    }
+
+    void CudaEvent::sync() const {
+        if (!is_valid()) {
+            throw std::runtime_error("Cannot synchronize null CUDA event");
+        }
+        inner.sync();
+    }
+
+    bool CudaEvent::is_done() const {
+        if (!is_valid()) {
+            throw std::runtime_error("Cannot query null CUDA event");
+        }
+        return inner.is_done();
+    }
+
     std::unique_ptr<CudaStream> cuda_stream_create() {
         return std::make_unique<CudaStream>();
     }
@@ -76,11 +133,32 @@ namespace libcudf_bridge {
         return std::make_unique<CudaStreamView>(stream.view());
     }
 
+    std::unique_ptr<CudaStreamRef> cuda_stream_ref_from_view(const CudaStreamView& stream) {
+        return std::make_unique<CudaStreamRef>(static_cast<cuda::stream_ref>(stream.inner));
+    }
+
+    std::unique_ptr<CudaEvent> cuda_event_create_on_device(
+        const int32_t device_id,
+        const uint32_t flags) {
+        return std::make_unique<CudaEvent>(
+            cuda::event(cuda::device_ref{device_id}, to_event_flags(flags)));
+    }
+
     std::unique_ptr<CudaStreamView> get_default_stream() {
         return std::make_unique<CudaStreamView>(cudf::get_default_stream());
     }
 
     bool is_ptds_enabled() {
         return cudf::is_ptds_enabled();
+    }
+
+    int32_t cuda_get_device() {
+        int device{};
+        RMM_CUDA_TRY(cudaGetDevice(&device));
+        return device;
+    }
+
+    void cuda_set_device(const int32_t device_id) {
+        RMM_CUDA_TRY(cudaSetDevice(device_id));
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/stream.h
+++ b/libcudf-sys/src/stream.h
@@ -3,10 +3,14 @@
 #include <cstdint>
 #include <memory>
 #include <cudf/utilities/default_stream.hpp>
+#include <cuda/stream>
+#include <cuda_runtime_api.h>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 namespace libcudf_bridge {
+    struct CudaEvent;
+
     /// Non-owning wrapper for an RMM CUDA stream view.
     struct CudaStreamView {
         rmm::cuda_stream_view inner;
@@ -23,6 +27,21 @@ namespace libcudf_bridge {
 
         /// Synchronize the viewed CUDA stream.
         void synchronize() const;
+    };
+
+    /// Non-owning wrapper for an upstream CCCL CUDA stream ref.
+    struct CudaStreamRef {
+        cuda::stream_ref inner;
+
+        explicit CudaStreamRef(cuda::stream_ref stream);
+
+        ~CudaStreamRef();
+
+        /// Create and record a CUDA event on this stream.
+        [[nodiscard]] std::unique_ptr<CudaEvent> record_event(uint32_t flags) const;
+
+        /// Make this stream wait until the CUDA event has completed.
+        void wait_event(const CudaEvent& event) const;
     };
 
     /// Owning wrapper for an RMM CUDA stream.
@@ -50,6 +69,28 @@ namespace libcudf_bridge {
         void synchronize() const;
     };
 
+    /// Owning wrapper for a CUDA event.
+    struct CudaEvent {
+        cuda::event inner;
+
+        /// Own an upstream CCCL CUDA event.
+        explicit CudaEvent(cuda::event event);
+
+        ~CudaEvent();
+
+        /// Return whether this wrapper owns a live CUDA event.
+        [[nodiscard]] bool is_valid() const;
+
+        /// Record this CUDA event on the given stream.
+        void record(const CudaStreamRef& stream) const;
+
+        /// Block until this CUDA event has completed.
+        void sync() const;
+
+        /// Return true if this CUDA event has completed.
+        [[nodiscard]] bool is_done() const;
+    };
+
     /// Create a CUDA stream using the default sync-default creation flag.
     std::unique_ptr<CudaStream> cuda_stream_create();
 
@@ -59,9 +100,21 @@ namespace libcudf_bridge {
     /// Return a non-owning view for an owned CUDA stream.
     std::unique_ptr<CudaStreamView> cuda_stream_view(const CudaStream& stream);
 
+    /// Convert an RMM CUDA stream view into an upstream CCCL CUDA stream ref.
+    std::unique_ptr<CudaStreamRef> cuda_stream_ref_from_view(const CudaStreamView& stream);
+
+    /// Create a CUDA event on a device with explicit upstream event flags.
+    std::unique_ptr<CudaEvent> cuda_event_create_on_device(int32_t device_id, uint32_t flags);
+
     /// Get cuDF's current default stream.
     std::unique_ptr<CudaStreamView> get_default_stream();
 
     /// Check whether cuDF is using the CUDA per-thread default stream.
     bool is_ptds_enabled();
+
+    /// Return the current CUDA device ordinal.
+    int32_t cuda_get_device();
+
+    /// Set the current CUDA device ordinal.
+    void cuda_set_device(int32_t device_id);
 } // namespace libcudf_bridge


### PR DESCRIPTION
## Summary

Adds the sys-layer CUDA/RMM plumbing needed for stream-aware root execution.

- `CudaStream` / `CudaStreamView`: continue to own or view RMM streams for cuDF calls.
- `CudaStreamRef`: bridges an RMM stream view to upstream CCCL `cuda::stream_ref` for event waits/records.
- `CudaEvent`: owns upstream `cuda::event` and exposes record, sync, and completion query.
- Device helpers: expose current-device get/set.

## Validation

`cargo test -p libcudf-sys --lib -- --test-threads=1`