### PR TITLE
Align core bindings with cuDF

### DIFF
--- a/libcudf-benchmarks/benches/arrow_conversion.rs
+++ b/libcudf-benchmarks/benches/arrow_conversion.rs
@@ -17,7 +17,7 @@ fn bench_arrow_roundtrip(c: &mut Criterion) {
         group.throughput(Throughput::Bytes((bytes * 2) as u64)); // Both conversions
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &_size| {
             b.iter(|| {
-                let table = CuDFTable::from_arrow_host(black_box(batch.clone())).unwrap();
+                let table = CuDFTable::try_from_arrow_host(black_box(batch.clone())).unwrap();
                 let result = table.into_view().to_arrow_host().unwrap();
                 black_box(result)
             });

--- a/libcudf-datafusion/benches/join.rs
+++ b/libcudf-datafusion/benches/join.rs
@@ -22,7 +22,7 @@ fn make_left(n: usize, right_key_range: usize) -> CuDFTable {
     let keys: Int64Array = (0..n).map(|i| (i % right_key_range) as i64).collect();
     let a: Int32Array = (0..n).map(|i| i as i32).collect();
     let b: Int32Array = (0..n).map(|i| (i * 2) as i32).collect();
-    CuDFTable::from_arrow_host(
+    CuDFTable::try_from_arrow_host(
         RecordBatch::try_new(schema, vec![Arc::new(keys), Arc::new(a), Arc::new(b)]).unwrap(),
     )
     .unwrap()
@@ -37,7 +37,7 @@ fn make_right(m: usize) -> CuDFTable {
     let keys: Int64Array = (0..m).map(|i| i as i64).collect();
     let x: Int32Array = (0..m).map(|i| i as i32).collect();
     let y: Int32Array = (0..m).map(|i| (i * 3) as i32).collect();
-    CuDFTable::from_arrow_host(
+    CuDFTable::try_from_arrow_host(
         RecordBatch::try_new(schema, vec![Arc::new(keys), Arc::new(x), Arc::new(y)]).unwrap(),
     )
     .unwrap()

--- a/libcudf-datafusion/benches/load_unload.rs
+++ b/libcudf-datafusion/benches/load_unload.rs
@@ -55,7 +55,7 @@ fn make_cpu_batches(total_rows: usize) -> Vec<RecordBatch> {
 fn load_plan(batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {
     let schema = batches[0].schema();
     let mem = Arc::new(TestMemoryExec::try_new(&[batches], schema, None).unwrap());
-    Arc::new(CuDFLoadExec::try_new(mem).unwrap())
+    Arc::new(CuDFLoadExec::new(mem))
 }
 
 fn unload_plan(gpu_batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {

--- a/libcudf-datafusion/src/decimal.rs
+++ b/libcudf-datafusion/src/decimal.rs
@@ -73,7 +73,7 @@ fn rescale_decimal(
             let array = scalar.to_arrow_host().map_err(cudf_to_df)?;
             let casted = arrow::compute::cast(array.as_ref(), &target_type)
                 .map_err(|err| DataFusionError::ArrowError(Box::new(err), None))?;
-            Ok(CuDFScalar::from_arrow_host(Scalar::new(casted))
+            Ok(CuDFScalar::try_from_arrow_host(Scalar::new(casted))
                 .map_err(cudf_to_df)?
                 .into())
         }

--- a/libcudf-datafusion/src/errors.rs
+++ b/libcudf-datafusion/src/errors.rs
@@ -5,6 +5,8 @@ pub(crate) fn cudf_to_df(err: CuDFError) -> DataFusionError {
     match err {
         CuDFError::CuDFError(err) => DataFusionError::External(Box::new(err)),
         CuDFError::ArrowError(err) => DataFusionError::ArrowError(Box::new(err), None),
-        err @ CuDFError::NullHandle(_) => DataFusionError::External(Box::new(err)),
+        err @ (CuDFError::NullHandle(_) | CuDFError::Configuration(_) | CuDFError::Cuda { .. }) => {
+            DataFusionError::External(Box::new(err))
+        }
     }
 }

--- a/libcudf-datafusion/src/expr/ast.rs
+++ b/libcudf-datafusion/src/expr/ast.rs
@@ -598,7 +598,7 @@ fn lower_literal_expr(
     ast: &mut CuDFAstExpression,
 ) -> Result<CuDFAstNode, DataFusionError> {
     let value = normalize_scalar_for_cudf(literal.value().clone())?;
-    let scalar = CuDFScalar::from_arrow_host(value.to_scalar()?).map_err(cudf_to_df)?;
+    let scalar = CuDFScalar::try_from_arrow_host(value.to_scalar()?).map_err(cudf_to_df)?;
     ast.literal(scalar).map_err(cudf_to_df)
 }
 
@@ -813,7 +813,7 @@ mod tests {
                 Arc::new(Int32Array::from(values)),
             ],
         )?;
-        Ok(CuDFTable::from_arrow_host(batch)?)
+        Ok(CuDFTable::try_from_arrow_host(batch)?)
     }
 
     fn make_nullable_table(
@@ -830,7 +830,7 @@ mod tests {
                 Arc::new(Int32Array::from(values)),
             ],
         )?;
-        Ok(CuDFTable::from_arrow_host(batch)?)
+        Ok(CuDFTable::try_from_arrow_host(batch)?)
     }
 
     fn filter_schema() -> Arc<Schema> {

--- a/libcudf-datafusion/src/expr/binary.rs
+++ b/libcudf-datafusion/src/expr/binary.rs
@@ -37,7 +37,7 @@ impl Hash for CuDFBinaryExpr {
 }
 
 impl CuDFBinaryExpr {
-    pub fn from_host(expr: BinaryExpr) -> Result<Self, DataFusionError> {
+    pub fn try_from_datafusion(expr: BinaryExpr) -> Result<Self, DataFusionError> {
         let left = expr_to_cudf_expr(expr.left().as_ref())?;
         let right = expr_to_cudf_expr(expr.right().as_ref())?;
         let op = map_op(expr.op()).ok_or_else(|| {
@@ -104,7 +104,7 @@ impl PhysicalExpr for CuDFBinaryExpr {
             *self.inner.op(),
             Arc::clone(&children[1]),
         );
-        Ok(Arc::new(Self::from_host(expr)?))
+        Ok(Arc::new(Self::try_from_datafusion(expr)?))
     }
 
     delegate! {

--- a/libcudf-datafusion/src/expr/column.rs
+++ b/libcudf-datafusion/src/expr/column.rs
@@ -14,11 +14,11 @@ pub struct CuDFColumnExpr {
 }
 
 impl CuDFColumnExpr {
-    pub fn from_host(inner: Column) -> Self {
+    pub fn from_datafusion(inner: Column) -> Self {
         Self { inner }
     }
 
-    pub(crate) fn host_column(&self) -> &Column {
+    pub(crate) fn datafusion_column(&self) -> &Column {
         &self.inner
     }
 }

--- a/libcudf-datafusion/src/expr/literal.rs
+++ b/libcudf-datafusion/src/expr/literal.rs
@@ -33,10 +33,10 @@ impl Hash for CuDFLiteral {
 }
 
 impl CuDFLiteral {
-    pub fn from_host(inner: Literal) -> datafusion::common::Result<Self> {
+    pub fn try_from_datafusion(inner: Literal) -> datafusion::common::Result<Self> {
         let value = normalize_scalar_for_cudf(inner.value().clone())?;
         let host_scalar = value.to_scalar()?;
-        let scalar = CuDFScalar::from_arrow_host(host_scalar).map_err(cudf_to_df)?;
+        let scalar = CuDFScalar::try_from_arrow_host(host_scalar).map_err(cudf_to_df)?;
         Ok(Self {
             inner,
             scalar: Arc::new(scalar),
@@ -97,17 +97,20 @@ mod tests {
 
     #[test]
     fn test_string_view_literals_lower_to_cudf_string() -> Result<(), Box<dyn std::error::Error>> {
-        let literal = CuDFLiteral::from_host(Literal::new(ScalarValue::Utf8View(Some(
+        let literal = CuDFLiteral::try_from_datafusion(Literal::new(ScalarValue::Utf8View(Some(
             "needle".to_string(),
         ))))?;
         assert_eq!(literal.scalar.data_type(), &DataType::Utf8);
 
-        let literal = CuDFLiteral::from_host(Literal::new(ScalarValue::BinaryView(Some(
-            b"needle".to_vec(),
-        ))))?;
+        let literal = CuDFLiteral::try_from_datafusion(Literal::new(ScalarValue::BinaryView(
+            Some(b"needle".to_vec()),
+        )))?;
         assert_eq!(literal.scalar.data_type(), &DataType::Utf8);
 
-        let err = CuDFLiteral::from_host(Literal::new(ScalarValue::BinaryView(Some(vec![0xff]))))
+        let err =
+            CuDFLiteral::try_from_datafusion(Literal::new(ScalarValue::BinaryView(Some(vec![
+                0xff,
+            ]))))
             .expect_err("invalid BinaryView literal should not lower to cuDF");
         assert!(matches!(err, DataFusionError::NotImplemented(_)));
         Ok(())

--- a/libcudf-datafusion/src/expr/mod.rs
+++ b/libcudf-datafusion/src/expr/mod.rs
@@ -48,13 +48,17 @@ pub(crate) fn expr_to_cudf_expr(
 ) -> Result<Arc<dyn PhysicalExpr>, DataFusionError> {
     let any = expr.as_any();
     if let Some(binary_op) = any.downcast_ref::<BinaryExpr>() {
-        return Ok(Arc::new(CuDFBinaryExpr::from_host(binary_op.clone())?));
+        return Ok(Arc::new(CuDFBinaryExpr::try_from_datafusion(
+            binary_op.clone(),
+        )?));
     };
     if let Some(column_expr) = any.downcast_ref::<Column>() {
-        return Ok(Arc::new(CuDFColumnExpr::from_host(column_expr.clone())));
+        return Ok(Arc::new(CuDFColumnExpr::from_datafusion(
+            column_expr.clone(),
+        )));
     };
     if let Some(literal) = any.downcast_ref::<Literal>() {
-        return Ok(Arc::new(CuDFLiteral::from_host(literal.clone())?));
+        return Ok(Arc::new(CuDFLiteral::try_from_datafusion(literal.clone())?));
     }
 
     not_impl_err!("Expression {expr} not supported in CuDF")

--- a/libcudf-datafusion/src/physical/aggregate/mod.rs
+++ b/libcudf-datafusion/src/physical/aggregate/mod.rs
@@ -238,7 +238,7 @@ impl ExecutionPlan for CuDFAggregateExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let cudf_cfg = CuDFConfig::from_config_options(context.session_config().options())?;
+        let cudf_cfg = CuDFConfig::try_get(context.session_config().options())?;
         let aggregate_chunk_target_bytes = cudf_cfg.aggregate_chunk_target_bytes;
         let input = self.input.execute(partition, context)?;
         let stream = stream::CuDFAggregateStream::new(
@@ -543,7 +543,7 @@ impl ExprKey {
         let column = if let Some(column) = expr.as_any().downcast_ref::<Column>() {
             column
         } else if let Some(column) = expr.as_any().downcast_ref::<CuDFColumnExpr>() {
-            column.host_column()
+            column.datafusion_column()
         } else {
             return Ok(None);
         };
@@ -738,7 +738,7 @@ mod test {
             schema.clone(),
             None,
         )?;
-        let load = CuDFLoadExec::try_new(Arc::new(root))?;
+        let load = CuDFLoadExec::new(Arc::new(root));
 
         let group_by = PhysicalGroupBy::new_single(vec![(col("c", &schema)?, "c".to_string())]);
 
@@ -782,7 +782,7 @@ mod test {
     ) -> Result<CuDFAggregateExec, Box<dyn Error>> {
         let schema = batch.schema();
         let root = TestMemoryExec::try_new(&[vec![batch]], Arc::clone(&schema), None)?;
-        let load = CuDFLoadExec::try_new(Arc::new(root))?;
+        let load = CuDFLoadExec::new(Arc::new(root));
         let group_by = PhysicalGroupBy::new_single(vec![(col("c", &schema)?, "c".to_string())]);
 
         Ok(CuDFAggregateExec::try_new(

--- a/libcudf-datafusion/src/physical/aggregate/stream.rs
+++ b/libcudf-datafusion/src/physical/aggregate/stream.rs
@@ -312,7 +312,7 @@ impl CuDFAggregateStream {
 
         let _timer = self.group_by_metrics.emitting_time.timer();
         let num_rows = running.keys.num_rows();
-        let key_columns = running.keys.into_columns();
+        let key_columns = running.keys.into_columns().map_err(cudf_to_df)?;
         let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.output_schema.fields().len());
 
         for col in key_columns {
@@ -412,7 +412,7 @@ impl CuDFAggregateStream {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let table_view = CuDFTableView::from_column_views(column_views).map_err(cudf_to_df)?;
+        let table_view = CuDFTableView::try_from_column_views(column_views).map_err(cudf_to_df)?;
 
         Ok(CuDFGroupBy::from_table_view(table_view))
     }
@@ -434,7 +434,7 @@ impl CuDFAggregateStream {
                         if let Some(view) = arg.as_any().downcast_ref::<CuDFColumnView>() {
                             return Ok(view.clone());
                         }
-                        CuDFColumn::from_arrow_host(arg.as_ref())
+                        CuDFColumn::try_from_arrow_host(arg.as_ref())
                             .map(|col| col.into_view())
                             .map_err(cudf_to_df)
                     })

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -31,18 +31,18 @@ pub struct CuDFLoadExec {
 }
 
 impl CuDFLoadExec {
-    pub fn try_new(input: Arc<dyn ExecutionPlan>) -> Result<Self, DataFusionError> {
+    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(cudf_schema_compatibility_map(input.schema())),
             Partitioning::UnknownPartitioning(1),
             input.properties().emission_type,
             input.properties().boundedness,
         ));
-        Ok(Self {
+        Self {
             input,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
-        })
+        }
     }
 }
 
@@ -80,7 +80,7 @@ impl ExecutionPlan for CuDFLoadExec {
             );
         }
         let input = Arc::clone(&children[0]);
-        Ok(Arc::new(Self::try_new(input)?))
+        Ok(Arc::new(Self::new(input)))
     }
 
     fn execute(
@@ -91,7 +91,7 @@ impl ExecutionPlan for CuDFLoadExec {
         assert_eq_or_internal_err!(partition, 0, "CuDFLoadExec invalid partition {partition}");
 
         let input_partitions = self.input.output_partitioning().partition_count();
-        let cudf_cfg = CuDFConfig::from_config_options(context.session_config().options())?;
+        let cudf_cfg = CuDFConfig::try_get(context.session_config().options())?;
         let coalesce_target_rows = cudf_cfg.batch_size;
 
         // use a stream that allows each sender to put in at
@@ -199,11 +199,11 @@ impl CuDFRecordBatchReceiverStreamBuilder {
                     pin_timer.done();
 
                     let import_timer = ctx.metrics.import_time.timer();
-                    let table = CuDFTable::from_arrow_host(pinned_batch).map_err(cudf_to_df)?;
+                    let table = CuDFTable::try_from_arrow_host(pinned_batch).map_err(cudf_to_df)?;
                     import_timer.done();
 
                     let sync_timer = ctx.metrics.sync_time.timer();
-                    // Beware: `CuDFTable::from_arrow_host` internally uses the default stream.
+                    // Beware: `CuDFTable::try_from_arrow_host` internally uses the default stream.
                     // If we ever migrate that to a different stream, this call should 
                     // be updated to synchronize that stream.
                     synchronize_default_stream().map_err(cudf_to_df)?;
@@ -213,6 +213,7 @@ impl CuDFRecordBatchReceiverStreamBuilder {
                     let num_rows = table.num_rows();
                     let cudf_cols: Vec<Arc<dyn Array>> = table
                         .into_columns()
+                        .map_err(cudf_to_df)?
                         .into_iter()
                         .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
                         .collect();

--- a/libcudf-datafusion/src/physical/cudf_unload.rs
+++ b/libcudf-datafusion/src/physical/cudf_unload.rs
@@ -98,7 +98,7 @@ impl ExecutionPlan for CuDFUnloadExec {
                 Err(err) => return Err(err),
             };
 
-            let view = CuDFTableView::from_record_batch(&batch).map_err(cudf_to_df)?;
+            let view = CuDFTableView::try_from_record_batch(&batch).map_err(cudf_to_df)?;
             let host_batch = view.to_arrow_host().map_err(cudf_to_df)?;
             let num_rows = host_batch.num_rows();
             let columns = host_batch

--- a/libcudf-datafusion/src/physical/filter.rs
+++ b/libcudf-datafusion/src/physical/filter.rs
@@ -188,7 +188,7 @@ fn filter_and_project(
         column_views.push(view.clone());
     }
 
-    let table_view = CuDFTableView::from_column_views(column_views).map_err(cudf_to_df)?;
+    let table_view = CuDFTableView::try_from_column_views(column_views).map_err(cudf_to_df)?;
 
     // Apply boolean mask using CuDF on GPU
     let filtered_table = apply_boolean_mask(&table_view, &bool_mask).map_err(cudf_to_df)?;
@@ -200,7 +200,7 @@ fn filter_and_project(
 
     let mut cudf_columns: Vec<Arc<dyn Array>> = Vec::with_capacity(num_cols);
     for i in 0..num_cols {
-        let col_view = table_view.column(i as i32);
+        let col_view = table_view.column(i as i32).map_err(cudf_to_df)?;
         cudf_columns.push(Arc::new(col_view));
     }
 

--- a/libcudf-datafusion/src/physical/hash_join.rs
+++ b/libcudf-datafusion/src/physical/hash_join.rs
@@ -179,7 +179,7 @@ impl CuDFHashJoinExec {
     }
 
     /// Extract fields from a DataFusion `HashJoinExec` and call `try_new`.
-    pub fn from_hash_join_exec(node: &HashJoinExec) -> Result<Self, DataFusionError> {
+    pub fn try_from_hash_join_exec(node: &HashJoinExec) -> Result<Self, DataFusionError> {
         Self::try_new(
             node.left().clone(),
             node.right().clone(),
@@ -601,9 +601,10 @@ impl StreamingJoinState {
             .as_ref()
             .expect("build side should be initialized before finalizing");
         let left_view = Arc::clone(&build.left).view();
-        let empty_right =
-            CuDFTable::from_arrow_host(RecordBatch::new_empty(Arc::clone(&self.plan.right_schema)))
-                .map_err(cudf_to_df)?;
+        let empty_right = CuDFTable::try_from_arrow_host(RecordBatch::new_empty(Arc::clone(
+            &self.plan.right_schema,
+        )))
+        .map_err(cudf_to_df)?;
         let right_view = empty_right.into_view();
 
         let result = {
@@ -730,7 +731,7 @@ fn split_join_projection(
 fn batches_to_table(batches: &[RecordBatch]) -> Result<CuDFTable, libcudf_rs::CuDFError> {
     let views: Vec<CuDFTableView> = batches
         .iter()
-        .map(CuDFTableView::from_record_batch)
+        .map(CuDFTableView::try_from_record_batch)
         .collect::<Result<_, _>>()?;
     CuDFTable::concat(views)
 }
@@ -769,7 +770,9 @@ pub fn try_as_cudf_hash_join(
         return Ok(None);
     }
 
-    Ok(Some(Arc::new(CuDFHashJoinExec::from_hash_join_exec(node)?)))
+    Ok(Some(Arc::new(CuDFHashJoinExec::try_from_hash_join_exec(
+        node,
+    )?)))
 }
 
 #[cfg(test)]
@@ -898,14 +901,16 @@ mod tests {
                 PartitionMode::CollectLeft => {
                     // CuDFLoadExec intentionally coalesces host input partitions into one GPU
                     // partition. CollectLeft tests use that production upload path.
-                    let left = Arc::new(CuDFLoadExec::try_new(Arc::new(TestMemoryExec::try_new(
+                    let left = Arc::new(CuDFLoadExec::new(Arc::new(TestMemoryExec::try_new(
                         &left_partitions,
                         left_schema,
                         None,
-                    )?))?);
-                    let right = Arc::new(CuDFLoadExec::try_new(Arc::new(
-                        TestMemoryExec::try_new(&right_partitions, right_schema, None)?,
-                    ))?);
+                    )?)));
+                    let right = Arc::new(CuDFLoadExec::new(Arc::new(TestMemoryExec::try_new(
+                        &right_partitions,
+                        right_schema,
+                        None,
+                    )?)));
                     (left, right)
                 }
                 PartitionMode::Partitioned => {
@@ -1032,10 +1037,11 @@ mod tests {
         batch: RecordBatch,
         schema: SchemaRef,
     ) -> datafusion::common::Result<RecordBatch> {
-        let table = CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?;
+        let table = CuDFTable::try_from_arrow_host(batch).map_err(cudf_to_df)?;
         let num_rows = table.num_rows();
         let columns = table
             .into_columns()
+            .map_err(cudf_to_df)?
             .into_iter()
             .map(|column| Arc::new(column.into_view()) as Arc<dyn Array>)
             .collect();
@@ -1592,7 +1598,7 @@ mod tests {
             NullEquality::NullEqualsNothing,
             false,
         )?;
-        let cudf_inner = Arc::new(CuDFHashJoinExec::from_hash_join_exec(&inner_projected)?);
+        let cudf_inner = Arc::new(CuDFHashJoinExec::try_from_hash_join_exec(&inner_projected)?);
 
         // DataFusion validates on-key columns when replacing children, so this
         // fails before the GPU conversion gets another chance to run.

--- a/libcudf-datafusion/src/physical/parquet_scan/mod.rs
+++ b/libcudf-datafusion/src/physical/parquet_scan/mod.rs
@@ -258,7 +258,7 @@ impl ExecutionPlan for CuDFParquetScanExec {
         builder.spawn_blocking(move || {
             for file_batch in scan_partition.batches() {
                 let mut compute_timer = Some(metrics.baseline.elapsed_compute().timer());
-                let result: datafusion::common::Result<_> = (|| {
+                let result: datafusion::common::Result<_> = {
                     metrics.record_file_batch(file_batch);
 
                     let mut read_timer = Some(metrics.read_time.timer());
@@ -286,8 +286,8 @@ impl ExecutionPlan for CuDFParquetScanExec {
                     if let Some(timer) = read_timer.take() {
                         timer.done();
                     }
-                    Ok(continued?)
-                })();
+                    continued
+                };
                 if let Some(timer) = compute_timer.take() {
                     timer.done();
                 }
@@ -590,7 +590,7 @@ mod tests {
     ) -> Result<CuDFAstExpression, Box<dyn std::error::Error>> {
         let mut filter = CuDFAstExpression::new();
         let column = filter.column_name_reference(column)?;
-        let value = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![value])))?;
+        let value = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![value])))?;
         let value = filter.literal(value)?;
         filter.binary_operation(CuDFAstOperator::Greater, column, value)?;
         Ok(filter)

--- a/libcudf-datafusion/src/physical/parquet_scan/reader.rs
+++ b/libcudf-datafusion/src/physical/parquet_scan/reader.rs
@@ -91,19 +91,32 @@ impl ParquetBatchReader {
     }
 }
 
-fn read_parquet_chunks<P>(
-    paths: &[P],
-    row_groups: Option<&[Vec<i32>]>,
-    read_columns: Option<&[String]>,
-    filter: Option<&CuDFAstExpression>,
+struct ParquetChunkReadArgs<'a, P> {
+    paths: &'a [P],
+    row_groups: Option<&'a [Vec<i32>]>,
+    read_columns: Option<&'a [String]>,
+    filter: Option<&'a CuDFAstExpression>,
     chunk_read_limit: usize,
     pass_read_limit: usize,
-    schema: &SchemaRef,
+    schema: &'a SchemaRef,
+}
+
+fn read_parquet_chunks<P>(
+    args: ParquetChunkReadArgs<'_, P>,
     emit: &mut impl FnMut(ReadBatch) -> datafusion::common::Result<bool>,
 ) -> datafusion::common::Result<ChunkReadOutcome>
 where
     P: AsRef<Path>,
 {
+    let ParquetChunkReadArgs {
+        paths,
+        row_groups,
+        read_columns,
+        filter,
+        chunk_read_limit,
+        pass_read_limit,
+        schema,
+    } = args;
     let mut emitted = false;
     let mut continued = true;
     let mut callback_error = None;
@@ -172,13 +185,15 @@ fn read_parquet_sources_together(
     let row_groups = explicit_row_groups_for_batch(batch)?;
 
     match read_parquet_chunks(
-        &files,
-        row_groups.as_deref(),
-        read_columns,
-        filter,
-        chunk_read_limit,
-        pass_read_limit,
-        schema,
+        ParquetChunkReadArgs {
+            paths: &files,
+            row_groups: row_groups.as_deref(),
+            read_columns,
+            filter,
+            chunk_read_limit,
+            pass_read_limit,
+            schema,
+        },
         emit,
     )? {
         ChunkReadOutcome::Finished { emitted, continued } => {
@@ -317,13 +332,15 @@ fn read_parquet_source(
         .indices()
         .map(|indices| vec![indices.to_vec()]);
     match read_parquet_chunks(
-        std::slice::from_ref(&source.path),
-        row_groups.as_deref(),
-        read_columns,
-        filter,
-        chunk_read_limit,
-        pass_read_limit,
-        schema,
+        ParquetChunkReadArgs {
+            paths: std::slice::from_ref(&source.path),
+            row_groups: row_groups.as_deref(),
+            read_columns,
+            filter,
+            chunk_read_limit,
+            pass_read_limit,
+            schema,
+        },
         emit,
     )? {
         ChunkReadOutcome::Finished { emitted, continued } => {
@@ -378,7 +395,7 @@ fn align_parquet_read(
     read: CuDFParquetReadResult,
     schema: &SchemaRef,
 ) -> datafusion::common::Result<ReadBatch> {
-    let columns = read.table.into_columns();
+    let columns = read.table.into_columns().map_err(cudf_to_df)?;
     if read.column_names.len() != columns.len() {
         return plan_err!(
             "cuDF returned {} parquet column names for {} columns",
@@ -414,8 +431,8 @@ fn null_column(
     num_rows: usize,
 ) -> datafusion::common::Result<CuDFColumn> {
     let scalar = normalize_scalar_for_cudf(ScalarValue::try_new_null(data_type)?)?;
-    let scalar = CuDFScalar::from_arrow_host(scalar.to_scalar()?).map_err(cudf_to_df)?;
-    CuDFColumn::from_scalar(&scalar, num_rows).map_err(cudf_to_df)
+    let scalar = CuDFScalar::try_from_arrow_host(scalar.to_scalar()?).map_err(cudf_to_df)?;
+    CuDFColumn::try_from_scalar(&scalar, num_rows).map_err(cudf_to_df)
 }
 
 fn parquet_batch_row_count(batch: &FileBatch) -> datafusion::common::Result<usize> {

--- a/libcudf-datafusion/src/physical/parquet_scan/scan_source.rs
+++ b/libcudf-datafusion/src/physical/parquet_scan/scan_source.rs
@@ -193,9 +193,7 @@ fn parquet_metadata_cached(
 
     let metadata = parquet_metadata(path)?;
     let _ = cache.set(Arc::clone(&metadata));
-    Ok(cache
-        .get()
-        .map_or(metadata, |metadata| Arc::clone(metadata)))
+    Ok(cache.get().map_or(metadata, Arc::clone))
 }
 
 fn parquet_columns_cached(
@@ -209,7 +207,7 @@ fn parquet_columns_cached(
     let metadata = source.metadata()?;
     let columns = Arc::new(parquet_columns(&metadata));
     let _ = cache.set(Arc::clone(&columns));
-    Ok(cache.get().map_or(columns, |columns| Arc::clone(columns)))
+    Ok(cache.get().map_or(columns, Arc::clone))
 }
 
 fn parquet_columns(metadata: &ParquetMetaData) -> HashSet<String> {

--- a/libcudf-datafusion/src/physical/sort.rs
+++ b/libcudf-datafusion/src/physical/sort.rs
@@ -30,8 +30,8 @@ pub struct CuDFSortExec {
 }
 
 impl CuDFSortExec {
-    pub fn try_new(inner: SortExec) -> Result<Self, DataFusionError> {
-        Ok(Self { inner })
+    pub fn new(inner: SortExec) -> Self {
+        Self { inner }
     }
 }
 
@@ -58,7 +58,7 @@ impl ExecutionPlan for CuDFSortExec {
         let inner = SortExec::new(self.inner.expr().clone(), children.swap_remove(0))
             .with_fetch(self.inner.fetch())
             .with_preserve_partitioning(self.inner.preserve_partitioning());
-        Ok(Arc::new(Self::try_new(inner)?))
+        Ok(Arc::new(Self::new(inner)))
     }
 
     fn execute(
@@ -128,7 +128,7 @@ impl Stream for CuDFSortStream {
         }
         match ready!(self.input.poll_next_unpin(cx)) {
             Some(Ok(batch)) => {
-                let view = CuDFTableView::from_record_batch(&batch).map_err(cudf_to_df)?;
+                let view = CuDFTableView::try_from_record_batch(&batch).map_err(cudf_to_df)?;
                 self.views.push(view);
                 cx.waker().wake_by_ref();
                 Poll::Pending
@@ -187,7 +187,7 @@ impl Stream for CuDFTopKStream {
 
         match ready!(self.input.poll_next_unpin(cx)) {
             Some(Ok(batch)) => {
-                let new_table = CuDFTableView::from_record_batch(&batch).map_err(cudf_to_df)?;
+                let new_table = CuDFTableView::try_from_record_batch(&batch).map_err(cudf_to_df)?;
 
                 let merged_table = if let Some(existing) = self.result.take() {
                     let views = vec![existing, new_table];
@@ -202,9 +202,10 @@ impl Stream for CuDFTopKStream {
                     let key_views = key_columns
                         .iter()
                         .map(|&i| merged_table.column(i as i32))
-                        .collect();
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(cudf_to_df)?;
                     let keys_view =
-                        CuDFTableView::from_column_views(key_views).map_err(cudf_to_df)?;
+                        CuDFTableView::try_from_column_views(key_views).map_err(cudf_to_df)?;
 
                     // Get sorted indices
                     let indices =

--- a/libcudf-datafusion/src/planner/config.rs
+++ b/libcudf-datafusion/src/planner/config.rs
@@ -87,7 +87,7 @@ impl CuDFConfig {
     }
 
     /// Gets the [CuDFConfig] from the [ConfigOptions]'s extensions.
-    pub fn from_config_options(cfg: &ConfigOptions) -> Result<&Self, DataFusionError> {
+    pub fn try_get(cfg: &ConfigOptions) -> Result<&Self, DataFusionError> {
         let Some(distributed_cfg) = cfg.extensions.get::<CuDFConfig>() else {
             return plan_err!("CuDFConfig is not in ConfigOptions.extensions");
         };
@@ -95,7 +95,7 @@ impl CuDFConfig {
     }
 
     /// Gets the [CuDFConfig] from the [ConfigOptions]'s extensions.
-    pub fn from_config_options_mut(cfg: &mut ConfigOptions) -> Result<&mut Self, DataFusionError> {
+    pub fn try_get_mut(cfg: &mut ConfigOptions) -> Result<&mut Self, DataFusionError> {
         let Some(distributed_cfg) = cfg.extensions.get_mut::<CuDFConfig>() else {
             return plan_err!("CuDFConfig is not in ConfigOptions.extensions");
         };

--- a/libcudf-datafusion/src/planner/host_to_cudf.rs
+++ b/libcudf-datafusion/src/planner/host_to_cudf.rs
@@ -54,7 +54,7 @@ impl PhysicalOptimizerRule for HostToCuDFRule {
             }
 
             if let Some(node) = plan.as_any().downcast_ref::<SortExec>() {
-                cudf_node = Some(Arc::new(CuDFSortExec::try_new(node.clone())?));
+                cudf_node = Some(Arc::new(CuDFSortExec::new(node.clone())));
             }
 
             if let Some(node) = plan.as_any().downcast_ref::<HashJoinExec>() {
@@ -85,9 +85,9 @@ impl PhysicalOptimizerRule for HostToCuDFRule {
                     }
 
                     if let Some(cp) = child.as_any().downcast_ref::<CoalescePartitionsExec>() {
-                        new_children.push(Arc::new(CuDFLoadExec::try_new(Arc::clone(cp.input()))?));
+                        new_children.push(Arc::new(CuDFLoadExec::new(Arc::clone(cp.input()))));
                     } else {
-                        new_children.push(Arc::new(CuDFLoadExec::try_new(Arc::clone(child))?));
+                        new_children.push(Arc::new(CuDFLoadExec::new(Arc::clone(child))));
                     }
                     changed = true;
                     continue;

--- a/libcudf-sys/src/column.cpp
+++ b/libcudf-sys/src/column.cpp
@@ -1,7 +1,4 @@
 #include "column.h"
-#include "cudf/null_mask.hpp"
-#include "cudf/types.hpp"
-#include <cuda_runtime_api.h>
 #include "data_type.h"
 #include "scalar.h"
 #include "libcudf-sys/src/lib.rs.h"
@@ -9,15 +6,10 @@
 #include <cinttypes>
 #include <cstdint>
 #include <cudf/column/column.hpp>
-#include <cudf/interop.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/unary.hpp>
-#include <cudf/strings/strings_column_view.hpp>
-#include <cudf/utilities/traits.hpp>
 
 #include <memory>
-#include <nanoarrow/nanoarrow.h>
-#include <nanoarrow/nanoarrow_device.h>
 
 
 namespace libcudf_bridge {
@@ -28,58 +20,35 @@ namespace libcudf_bridge {
     ColumnView::~ColumnView() = default;
 
     // Get number of elements
-    size_t ColumnView::size() const {
+    int32_t ColumnView::size() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get size of null column view");
         }
         return inner->size();
     }
 
-    // Get the column's data as an FFI Arrow Array
-    void ColumnView::to_arrow_array(
-        uint8_t *out_array_ptr,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr) const {
-        if (!inner) {
-            throw std::runtime_error("Cannot convert null column view to arrow array");
-        }
-        auto device_array_unique = cudf::to_arrow_host(*this->inner, stream.inner, mr.inner);
-        auto *out_array = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
-        *out_array = *device_array_unique.get();
-        device_array_unique.release();
-    }
-
     // Get the raw device pointer to the column view's data
-    [[nodiscard]] uint64_t ColumnView::data_ptr() const {
+    [[nodiscard]] uintptr_t ColumnView::head() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get data pointer of null column view");
         }
-        return reinterpret_cast<uint64_t>(inner->head());
+        return reinterpret_cast<uintptr_t>(inner->head());
     }
 
     // Get the data type of the column view
-    [[nodiscard]] std::unique_ptr<DataType> ColumnView::data_type() const {
+    [[nodiscard]] std::unique_ptr<DataType> ColumnView::type() const {
         if (!inner) {
             throw std::runtime_error("Cannot get data type of null column view");
         }
-        auto dtype = inner->type();
-        auto type_id = static_cast<int32_t>(dtype.id());
-
-        // Only pass scale for decimal types
-        if (dtype.id() == cudf::type_id::DECIMAL32 ||
-            dtype.id() == cudf::type_id::DECIMAL64 ||
-            dtype.id() == cudf::type_id::DECIMAL128) {
-            return std::make_unique<DataType>(type_id, dtype.scale());
-        }
-        return std::make_unique<DataType>(type_id);
+        return std::make_unique<DataType>(inner->type());
     }
 
-    // Clone this column view
-    [[nodiscard]] std::unique_ptr<ColumnView> ColumnView::clone() const {
-        auto cloned = std::make_unique<ColumnView>();
-        if (inner) {
-            cloned->inner = std::make_unique<cudf::column_view>(*inner);
+    std::unique_ptr<ColumnView> column_view_clone(const ColumnView& view) {
+        if (!view.inner) {
+            throw std::runtime_error("Cannot clone null column view");
         }
+        auto cloned = std::make_unique<ColumnView>();
+        cloned->inner = std::make_unique<cudf::column_view>(*view.inner);
         return cloned;
     }
 
@@ -93,96 +62,40 @@ namespace libcudf_bridge {
 
     // Returns how many nulls this column has
     [[nodiscard]] int32_t ColumnView::null_count() const {
-        if (inner) {
-            return inner->null_count();
-        }
-        return 0;
-    }
-
-    // Helper functions for memory size calculations
-    size_t calculate_buffer_memory_size(const cudf::column_view& view, const CudaStreamView& stream) {
-        size_t data_size = 0;
-        if (cudf::is_fixed_width(view.type())) {
-            data_size = cudf::size_of(view.type()) * view.size();
-        } else if (view.type().id() == cudf::type_id::STRING) {
-            auto const strings = cudf::strings_column_view(view);
-            data_size = ((view.size() + 1) * sizeof(cudf::size_type)) +
-                        static_cast<size_t>(strings.chars_size(stream.inner));
-        } else {
-            // For nested types recursively add child buffer sizes.
-            for (cudf::size_type i = 0; i < view.num_children(); ++i) {
-                data_size += calculate_buffer_memory_size(view.child(i), stream);
-            }
-        }
-
-        return data_size;
-    }
-
-    size_t calculate_null_mask_size(const cudf::column_view& view) {
-        size_t size = 0;
-
-        if (view.nullable()) {
-            size += cudf::bitmask_allocation_size_bytes(view.size());
-        }
-
-        for (cudf::size_type i = 0; i < view.num_children(); ++i) {
-            size += calculate_null_mask_size(view.child(i));
-        }
-
-        return size;
-    }
-
-    size_t calculate_array_memory_size(const cudf::column_view& view, const CudaStreamView& stream) {
-        return calculate_buffer_memory_size(view, stream) + calculate_null_mask_size(view);
-    }
-
-    // Get buffer memory size (data + offsets, no null mask)
-    [[nodiscard]] size_t ColumnView::get_buffer_memory_size(const CudaStreamView &stream) const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get null count of null column view");
         }
-        return calculate_buffer_memory_size(*inner, stream);
+        return inner->null_count();
     }
 
-    // Get total array memory size (data + offsets + null mask + children)
-    [[nodiscard]] size_t ColumnView::get_array_memory_size(const CudaStreamView &stream) const {
+    [[nodiscard]] bool ColumnView::nullable() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot inspect nullability of null column view");
         }
-        return calculate_array_memory_size(*inner, stream);
+        return inner->nullable();
     }
 
-    // Transfer the null buffer
-    [[nodiscard]] rust::Vec<uint8_t> ColumnView::get_null_buffer() const {
-        if (!inner || inner->null_count() == 0) {
-            return rust::Vec<uint8_t>();
+    [[nodiscard]] int32_t ColumnView::num_children() const {
+        if (!inner) {
+            throw std::runtime_error("Cannot inspect children of null column view");
         }
+        return inner->num_children();
+    }
 
-        const auto& view = *inner;
-
-        // Calculate null mask size
-        size_t mask_size = cudf::bitmask_allocation_size_bytes(view.size());
-
-        rust::Vec<uint8_t> host_buffer;
-        host_buffer.reserve(mask_size);
-
-        // Resize to actual size so cudaMemcpy has a valid destination
-        for (size_t i = 0; i < mask_size; ++i) {
-            host_buffer.push_back(0);
+    [[nodiscard]] std::unique_ptr<ColumnView> ColumnView::child(const int32_t index) const {
+        if (!inner) {
+            throw std::runtime_error("Cannot get child of null column view");
         }
+        auto result = std::make_unique<ColumnView>();
+        result->inner = std::make_unique<cudf::column_view>(inner->child(index));
+        return result;
+    }
 
-        cudaError_t err = cudaMemcpy(
-            host_buffer.data(),
-            view.null_mask(),
-            mask_size,
-            cudaMemcpyDeviceToHost
-        );
-
-        if (err != cudaSuccess) {
-            throw std::runtime_error(std::string("cudaMemcpy failed: ") + cudaGetErrorString(err));
+    [[nodiscard]] uintptr_t ColumnView::null_mask() const {
+        if (!inner) {
+            throw std::runtime_error("Cannot get null mask of null column view");
         }
-
-        return host_buffer;
+        return reinterpret_cast<uintptr_t>(inner->null_mask());
     }
 
     // Column implementation
@@ -192,9 +105,9 @@ namespace libcudf_bridge {
     Column::~Column() = default;
 
     // Get number of elements
-    size_t Column::size() const {
+    int32_t Column::size() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get size of null column");
         }
         return inner->size();
     }
@@ -210,20 +123,18 @@ namespace libcudf_bridge {
     }
 
     // Get the data type of the column
-    [[nodiscard]] std::unique_ptr<DataType> Column::data_type() const {
+    [[nodiscard]] std::unique_ptr<DataType> Column::type() const {
         if (!inner) {
             throw std::runtime_error("Cannot get data type of null column");
         }
-        auto dtype = inner->type();
-        auto type_id = static_cast<int32_t>(dtype.id());
+        return std::make_unique<DataType>(inner->type());
+    }
 
-        // Only pass scale for decimal types
-        if (dtype.id() == cudf::type_id::DECIMAL32 ||
-            dtype.id() == cudf::type_id::DECIMAL64 ||
-            dtype.id() == cudf::type_id::DECIMAL128) {
-            return std::make_unique<DataType>(type_id, dtype.scale());
+    size_t Column::alloc_size() const {
+        if (!inner) {
+            throw std::runtime_error("Cannot get allocation size of null column");
         }
-        return std::make_unique<DataType>(type_id);
+        return inner->alloc_size();
     }
 
     // Helper function to create Column from unique_ptr<cudf::column>
@@ -233,8 +144,37 @@ namespace libcudf_bridge {
         return c;
     }
 
+    std::unique_ptr<ColumnView> column_view_create(
+        const DataType& type,
+        int32_t size,
+        uintptr_t data,
+        uintptr_t null_mask,
+        int32_t null_count,
+        int32_t offset,
+        rust::Slice<const ColumnView *const> children) {
+        std::vector<cudf::column_view> child_views;
+        child_views.reserve(children.size());
+        for (const auto* child : children) {
+            if (child == nullptr || !child->inner) {
+                throw std::invalid_argument("Cannot construct a column view with a null child");
+            }
+            child_views.push_back(*child->inner);
+        }
+
+        auto result = std::make_unique<ColumnView>();
+        result->inner = std::make_unique<cudf::column_view>(
+            type.inner,
+            size,
+            reinterpret_cast<void const*>(data),
+            reinterpret_cast<cudf::bitmask_type const*>(null_mask),
+            null_count,
+            offset,
+            child_views);
+        return result;
+    }
+
     // Cast a column to a different data type
-    std::unique_ptr<Column> cast_column(
+    std::unique_ptr<Column> cast(
         const ColumnView &input,
         const DataType &target_type,
         const CudaStreamView &stream,
@@ -250,19 +190,16 @@ namespace libcudf_bridge {
     // Extract a scalar from a column at the specified index
     std::unique_ptr<Scalar> get_element(
         const ColumnView &column,
-        size_t index,
+        int32_t index,
         const CudaStreamView &stream,
         const DeviceAsyncResourceRef &mr) {
         if (!column.inner) {
             throw std::runtime_error("Cannot get element from null column view");
         }
-        if (index >= static_cast<size_t>(column.inner->size())) {
-            throw std::out_of_range("Index out of bounds for get_element");
-        }
         auto result = std::make_unique<Scalar>();
         result->inner = cudf::get_element(
             *column.inner,
-            static_cast<cudf::size_type>(index),
+            index,
             stream.inner,
             mr.inner);
         return result;

--- a/libcudf-sys/src/column.h
+++ b/libcudf-sys/src/column.h
@@ -13,11 +13,6 @@
 namespace libcudf_bridge {
     struct DataType;
 
-    // Helper functions for memory size calculations
-    size_t calculate_buffer_memory_size(const cudf::column_view& view, const CudaStreamView& stream);
-    size_t calculate_null_mask_size(const cudf::column_view& view);
-    size_t calculate_array_memory_size(const cudf::column_view& view, const CudaStreamView& stream);
-
     // Opaque wrapper for cuDF column_view
     struct ColumnView {
         std::unique_ptr<cudf::column_view> inner;
@@ -27,22 +22,13 @@ namespace libcudf_bridge {
         ~ColumnView();
 
         // Get number of elements
-        [[nodiscard]] size_t size() const;
-
-        // Get the column's data as an FFI Arrow Array
-        void to_arrow_array(
-            uint8_t *out_array_ptr,
-            const CudaStreamView &stream,
-            const DeviceAsyncResourceRef &mr) const;
+        [[nodiscard]] int32_t size() const;
 
         // Get the raw device pointer to the column view's data
-        [[nodiscard]] uint64_t data_ptr() const;
+        [[nodiscard]] uintptr_t head() const;
 
         // Get the data type of the column view
-        [[nodiscard]] std::unique_ptr<DataType> data_type() const;
-
-        // Clone this column view
-        [[nodiscard]] std::unique_ptr<ColumnView> clone() const;
+        [[nodiscard]] std::unique_ptr<DataType> type() const;
 
         // Get the offset of the current ColumnView in case it was a slice of another one
         [[nodiscard]] int32_t offset() const;
@@ -50,14 +36,17 @@ namespace libcudf_bridge {
         // Returns how many nulls this column has
         [[nodiscard]] int32_t null_count() const;
 
-        // Get buffer memory size (data + offsets, no null mask)
-        [[nodiscard]] size_t get_buffer_memory_size(const CudaStreamView &stream) const;
+        // Returns whether this view has a null mask
+        [[nodiscard]] bool nullable() const;
 
-        // Get total array memory size (data + offsets + null mask + children)
-        [[nodiscard]] size_t get_array_memory_size(const CudaStreamView &stream) const;
+        // Returns the number of child views
+        [[nodiscard]] int32_t num_children() const;
 
-        // Transfer the null buffer
-        [[nodiscard]] rust::Vec<uint8_t> get_null_buffer() const;
+        // Returns a child view by index
+        [[nodiscard]] std::unique_ptr<ColumnView> child(int32_t index) const;
+
+        // Return the null-mask device pointer encoded for cxx.
+        [[nodiscard]] uintptr_t null_mask() const;
     };
 
     // Opaque wrapper for cuDF column
@@ -78,13 +67,16 @@ namespace libcudf_bridge {
         Column &operator=(Column &&) = default;
 
         // Get number of elements
-        [[nodiscard]] size_t size() const;
+        [[nodiscard]] int32_t size() const;
 
         // Get the column as a read-only view
         [[nodiscard]] std::unique_ptr<ColumnView> view() const;
 
         // Get the data type of the column
-        [[nodiscard]] std::unique_ptr<DataType> data_type() const;
+        [[nodiscard]] std::unique_ptr<DataType> type() const;
+
+        // Get the total device allocation size of the column
+        [[nodiscard]] size_t alloc_size() const;
     };
 
     // Forward declaration
@@ -93,15 +85,27 @@ namespace libcudf_bridge {
     // Helper function to create Column from unique_ptr<cudf::column>
     Column column_from_unique_ptr(std::unique_ptr<cudf::column> col);
 
+    // Mechanical factory for cudf::column_view's copy constructor.
+    std::unique_ptr<ColumnView> column_view_clone(const ColumnView& view);
+
+    std::unique_ptr<ColumnView> column_view_create(
+        const DataType& type,
+        int32_t size,
+        uintptr_t data,
+        uintptr_t null_mask,
+        int32_t null_count,
+        int32_t offset,
+        rust::Slice<const ColumnView *const> children);
+
     // Extract a scalar from a column at the specified index
     std::unique_ptr<Scalar> get_element(
         const ColumnView &column,
-        size_t index,
+        int32_t index,
         const CudaStreamView &stream,
         const DeviceAsyncResourceRef &mr);
 
     // Cast a column to a different data type
-    std::unique_ptr<Column> cast_column(
+    std::unique_ptr<Column> cast(
         const ColumnView &input,
         const DataType &target_type,
         const CudaStreamView &stream,

--- a/libcudf-sys/src/data_type.cpp
+++ b/libcudf-sys/src/data_type.cpp
@@ -1,7 +1,9 @@
 #include "data_type.h"
 #include "libcudf-sys/src/lib.rs.h"
 
+#include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/traits.hpp>
 
 namespace libcudf_bridge {
 
@@ -10,6 +12,8 @@ namespace libcudf_bridge {
 
     DataType::DataType(int32_t type_id, int32_t scale)
         : inner(static_cast<cudf::type_id>(type_id), scale) {}
+
+    DataType::DataType(cudf::data_type type) : inner(type) {}
 
     int32_t DataType::id() const {
         return static_cast<int32_t>(inner.id());
@@ -25,6 +29,20 @@ namespace libcudf_bridge {
 
     std::unique_ptr<DataType> new_data_type_with_scale(int32_t type_id, int32_t scale) {
         return std::make_unique<DataType>(type_id, scale);
+    }
+
+    bool is_fixed_width(const DataType& type) {
+        return cudf::is_fixed_width(type.inner);
+    }
+
+    std::size_t size_of(const DataType& type) {
+        return cudf::size_of(type.inner);
+    }
+
+    std::size_t bitmask_allocation_size_bytes(
+        const std::int32_t number_of_bits,
+        const std::size_t padding_boundary) {
+        return cudf::bitmask_allocation_size_bytes(number_of_bits, padding_boundary);
     }
 
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/data_type.h
+++ b/libcudf-sys/src/data_type.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <cudf/types.hpp>
@@ -14,6 +15,9 @@ namespace libcudf_bridge {
 
         /// Construct from a type_id and scale (for fixed_point types)
         DataType(int32_t type_id, int32_t scale);
+
+        /// Wrap an upstream data_type value.
+        explicit DataType(cudf::data_type type);
 
         /// Get the type_id
         int32_t id() const;
@@ -30,5 +34,16 @@ namespace libcudf_bridge {
 
     /// Create a DataType from a type_id and scale (for decimals)
     std::unique_ptr<DataType> new_data_type_with_scale(int32_t type_id, int32_t scale);
+
+    /// Return whether `type` has a fixed-width representation.
+    bool is_fixed_width(const DataType& type);
+
+    /// Return the byte width of a fixed-width `type`.
+    std::size_t size_of(const DataType& type);
+
+    /// Return the padded allocation size for a null mask.
+    std::size_t bitmask_allocation_size_bytes(
+        std::int32_t number_of_bits,
+        std::size_t padding_boundary);
 
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/device_memory.cpp
+++ b/libcudf-sys/src/device_memory.cpp
@@ -15,11 +15,28 @@ namespace libcudf_bridge {
         return std::make_unique<CudaMemoryResource>();
     }
 
+    AvailableDeviceMemory::AvailableDeviceMemory(
+        const std::size_t free_bytes,
+        const std::size_t total_bytes) : free(free_bytes), total(total_bytes) {}
+
+    std::size_t AvailableDeviceMemory::free_bytes() const {
+        return free;
+    }
+
+    std::size_t AvailableDeviceMemory::total_bytes() const {
+        return total;
+    }
+
+    PoolMemoryResource::PoolMemoryResource(rmm::mr::cuda_memory_resource* upstream,
+                                           const std::size_t initial_size)
+        : inner(std::make_unique<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(
+              upstream, initial_size)) {}
+
     PoolMemoryResource::PoolMemoryResource(rmm::mr::cuda_memory_resource* upstream,
                                            const std::size_t initial_size,
-                                           const std::size_t max_size)
+                                           const std::size_t maximum_size)
         : inner(std::make_unique<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(
-              upstream, initial_size, max_size)) {}
+              upstream, initial_size, maximum_size)) {}
 
     rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>* PoolMemoryResource::get() const {
         return inner.get();
@@ -27,16 +44,25 @@ namespace libcudf_bridge {
 
     std::unique_ptr<PoolMemoryResource> make_pool_memory_resource(
         const CudaMemoryResource& upstream,
+        const std::size_t initial_size) {
+        return std::make_unique<PoolMemoryResource>(upstream.get(), initial_size);
+    }
+
+    std::unique_ptr<PoolMemoryResource> make_pool_memory_resource_with_maximum(
+        const CudaMemoryResource& upstream,
         const std::size_t initial_size,
-        const std::size_t max_size) {
-        return std::make_unique<PoolMemoryResource>(upstream.get(), initial_size, max_size);
+        const std::size_t maximum_size) {
+        return std::make_unique<PoolMemoryResource>(upstream.get(), initial_size, maximum_size);
     }
 
-    void set_current_device_resource(const PoolMemoryResource& resource) {
-        rmm::mr::set_current_device_resource(resource.get());
+    std::unique_ptr<DeviceAsyncResourceRef> make_device_async_resource_ref(
+        const PoolMemoryResource& resource) {
+        return std::make_unique<DeviceAsyncResourceRef>(
+            rmm::device_async_resource_ref{*resource.get()});
     }
 
-    std::size_t total_device_memory() {
-        return rmm::available_device_memory().second;
+    std::unique_ptr<AvailableDeviceMemory> available_device_memory() {
+        const auto [free, total] = rmm::available_device_memory();
+        return std::make_unique<AvailableDeviceMemory>(free, total);
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/device_memory.h
+++ b/libcudf-sys/src/device_memory.h
@@ -5,6 +5,7 @@
 
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include "memory_resource.h"
 
 namespace libcudf_bridge {
     /// Owning wrapper around `rmm::mr::cuda_memory_resource`. Allocates GPU memory
@@ -21,6 +22,17 @@ namespace libcudf_bridge {
     /// Construct an RMM CUDA memory resource.
     std::unique_ptr<CudaMemoryResource> make_cuda_memory_resource();
 
+    /// Mechanical wrapper around the pair returned by rmm::available_device_memory.
+    struct AvailableDeviceMemory {
+        std::size_t free;
+        std::size_t total;
+
+        AvailableDeviceMemory(std::size_t free_bytes, std::size_t total_bytes);
+
+        [[nodiscard]] std::size_t free_bytes() const;
+        [[nodiscard]] std::size_t total_bytes() const;
+    };
+
     /// Owning wrapper around `rmm::mr::pool_memory_resource` backed by
     /// `rmm::mr::cuda_memory_resource`. Sub-allocates from a single up-front
     /// `cudaMalloc` slab.
@@ -28,22 +40,31 @@ namespace libcudf_bridge {
         std::unique_ptr<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>> inner;
 
         PoolMemoryResource(rmm::mr::cuda_memory_resource* upstream,
+                           std::size_t initial_size);
+
+        PoolMemoryResource(rmm::mr::cuda_memory_resource* upstream,
                            std::size_t initial_size,
-                           std::size_t max_size);
+                           std::size_t maximum_size);
 
         [[nodiscard]] rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>* get() const;
+
     };
 
     /// Construct an RMM pool memory resource. Borrows the upstream resource for
     /// the pool's lifetime.
     std::unique_ptr<PoolMemoryResource> make_pool_memory_resource(
         const CudaMemoryResource& upstream,
+        std::size_t initial_size);
+
+    /// Construct an RMM pool memory resource with an explicit maximum size.
+    std::unique_ptr<PoolMemoryResource> make_pool_memory_resource_with_maximum(
+        const CudaMemoryResource& upstream,
         std::size_t initial_size,
-        std::size_t max_size);
+        std::size_t maximum_size);
 
-    /// Install the pool as RMM's current device resource.
-    void set_current_device_resource(const PoolMemoryResource& resource);
+    std::unique_ptr<DeviceAsyncResourceRef> make_device_async_resource_ref(
+        const PoolMemoryResource& resource);
 
-    /// Return total VRAM bytes on the current CUDA device.
-    std::size_t total_device_memory();
+    /// Direct wrapper for rmm::available_device_memory.
+    std::unique_ptr<AvailableDeviceMemory> available_device_memory();
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/interop.cpp
+++ b/libcudf-sys/src/interop.cpp
@@ -1,0 +1,196 @@
+#include "interop.h"
+#include "libcudf-sys/src/lib.rs.h"
+
+#include <nanoarrow/nanoarrow.h>
+#include <nanoarrow/nanoarrow_device.h>
+#include <stdexcept>
+
+namespace libcudf_bridge {
+    static_assert(ARROW_DEVICE_CPU == 1);
+    static_assert(ARROW_DEVICE_CUDA == 2);
+    static_assert(ARROW_DEVICE_CUDA_HOST == 3);
+    static_assert(ARROW_DEVICE_OPENCL == 4);
+    static_assert(ARROW_DEVICE_VULKAN == 7);
+    static_assert(ARROW_DEVICE_METAL == 8);
+    static_assert(ARROW_DEVICE_VPI == 9);
+    static_assert(ARROW_DEVICE_ROCM == 10);
+    static_assert(ARROW_DEVICE_ROCM_HOST == 11);
+    static_assert(ARROW_DEVICE_EXT_DEV == 12);
+    static_assert(ARROW_DEVICE_CUDA_MANAGED == 13);
+    static_assert(ARROW_DEVICE_ONEAPI == 14);
+    static_assert(ARROW_DEVICE_WEBGPU == 15);
+    static_assert(ARROW_DEVICE_HEXAGON == 16);
+
+    std::unique_ptr<Table> from_arrow_host(
+        std::uint8_t const* schema_ptr,
+        std::uint8_t const* device_array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr) {
+        auto const* schema = reinterpret_cast<ArrowSchema const*>(schema_ptr);
+        auto const* device_array = reinterpret_cast<ArrowDeviceArray const*>(device_array_ptr);
+
+        auto result = std::make_unique<Table>();
+        result->inner = cudf::from_arrow_host(schema, device_array, stream.inner, mr.inner);
+        return result;
+    }
+
+    std::unique_ptr<Column> from_arrow_column(
+        std::uint8_t const* schema_ptr,
+        std::uint8_t const* array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr) {
+        auto const* schema = reinterpret_cast<ArrowSchema const*>(schema_ptr);
+        auto const* array = reinterpret_cast<ArrowArray const*>(array_ptr);
+
+        auto result = std::make_unique<Column>();
+        result->inner = cudf::from_arrow_column(schema, array, stream.inner, mr.inner);
+        return result;
+    }
+
+    ColumnMetadata::ColumnMetadata(cudf::column_metadata metadata)
+        : inner(std::move(metadata)) {}
+
+    rust::String ColumnMetadata::name() const { return inner.name; }
+
+    void ColumnMetadata::set_name(const rust::Str value) {
+        inner.name.assign(value.data(), value.size());
+    }
+
+    rust::String ColumnMetadata::timezone() const { return inner.timezone; }
+
+    void ColumnMetadata::set_timezone(const rust::Str value) {
+        inner.timezone.assign(value.data(), value.size());
+    }
+
+    bool ColumnMetadata::has_precision() const { return inner.precision.has_value(); }
+
+    std::int32_t ColumnMetadata::precision() const {
+        if (!inner.precision.has_value()) {
+            throw std::runtime_error("Column metadata precision is not set");
+        }
+        return *inner.precision;
+    }
+
+    void ColumnMetadata::set_precision(const std::int32_t value) { inner.precision = value; }
+
+    void ColumnMetadata::clear_precision() { inner.precision.reset(); }
+
+    std::size_t ColumnMetadata::children_len() const { return inner.children_meta.size(); }
+
+    std::unique_ptr<ColumnMetadata> ColumnMetadata::child(const std::size_t index) const {
+        if (index >= inner.children_meta.size()) {
+            throw std::out_of_range("Column metadata child index is out of range");
+        }
+        return std::make_unique<ColumnMetadata>(inner.children_meta[index]);
+    }
+
+    void ColumnMetadata::set_child(
+        const std::size_t index,
+        const ColumnMetadata& child) {
+        if (index >= inner.children_meta.size()) {
+            throw std::out_of_range("Column metadata child index is out of range");
+        }
+        inner.children_meta[index] = child.inner;
+    }
+
+    void ColumnMetadata::push_child(const ColumnMetadata& child) {
+        inner.children_meta.push_back(child.inner);
+    }
+
+    ColumnMetadataVector::ColumnMetadataVector(
+        std::vector<cudf::column_metadata> metadata)
+        : inner(std::move(metadata)) {}
+
+    std::size_t ColumnMetadataVector::len() const { return inner.size(); }
+
+    bool ColumnMetadataVector::is_empty() const { return inner.empty(); }
+
+    std::unique_ptr<ColumnMetadata> ColumnMetadataVector::get(const std::size_t index) const {
+        if (index >= inner.size()) {
+            throw std::out_of_range("Column metadata index is out of range");
+        }
+        return std::make_unique<ColumnMetadata>(inner[index]);
+    }
+
+    void ColumnMetadataVector::set(
+        const std::size_t index,
+        const ColumnMetadata& metadata) {
+        if (index >= inner.size()) {
+            throw std::out_of_range("Column metadata index is out of range");
+        }
+        inner[index] = metadata.inner;
+    }
+
+    void ColumnMetadataVector::push(const ColumnMetadata& metadata) {
+        inner.push_back(metadata.inner);
+    }
+
+    std::unique_ptr<ColumnMetadata> make_column_metadata() {
+        return std::make_unique<ColumnMetadata>(cudf::column_metadata{});
+    }
+
+    std::unique_ptr<ColumnMetadata> make_column_metadata_with_name(const rust::Str name) {
+        return std::make_unique<ColumnMetadata>(
+            cudf::column_metadata{std::string{name.data(), name.size()}});
+    }
+
+    std::unique_ptr<ColumnMetadataVector> make_column_metadata_vector() {
+        return std::make_unique<ColumnMetadataVector>(std::vector<cudf::column_metadata>{});
+    }
+
+    std::unique_ptr<ColumnMetadata> get_column_metadata(const ColumnView& input) {
+        if (!input.inner) {
+            throw std::runtime_error("Cannot get metadata for null column view");
+        }
+        return std::make_unique<ColumnMetadata>(cudf::interop::get_column_metadata(*input.inner));
+    }
+
+    std::unique_ptr<ColumnMetadataVector> get_table_metadata(const TableView& input) {
+        if (!input.inner) {
+            throw std::runtime_error("Cannot get metadata for null table view");
+        }
+        return std::make_unique<ColumnMetadataVector>(
+            cudf::interop::get_table_metadata(*input.inner));
+    }
+
+    void to_arrow_schema(
+        const TableView& input,
+        const ColumnMetadataVector& metadata,
+        std::uint8_t* out_schema_ptr) {
+        if (!input.inner) {
+            throw std::runtime_error("Cannot convert null table view to Arrow schema");
+        }
+        auto schema = cudf::to_arrow_schema(*input.inner, metadata.inner);
+        auto* out = reinterpret_cast<ArrowSchema*>(out_schema_ptr);
+        *out = *schema;
+        schema->release = nullptr;
+    }
+
+    void to_arrow_host(
+        const TableView& input,
+        std::uint8_t* out_array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr) {
+        if (!input.inner) {
+            throw std::runtime_error("Cannot convert null table view to Arrow");
+        }
+        auto array = cudf::to_arrow_host(*input.inner, stream.inner, mr.inner);
+        auto* out = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
+        *out = *array;
+        array->array.release = nullptr;
+    }
+
+    void to_arrow_host(
+        const ColumnView& input,
+        std::uint8_t* out_array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr) {
+        if (!input.inner) {
+            throw std::runtime_error("Cannot convert null column view to Arrow");
+        }
+        auto array = cudf::to_arrow_host(*input.inner, stream.inner, mr.inner);
+        auto* out = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
+        *out = *array;
+        array->array.release = nullptr;
+    }
+}  // namespace libcudf_bridge

--- a/libcudf-sys/src/interop.h
+++ b/libcudf-sys/src/interop.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "column.h"
+#include "memory_resource.h"
+#include "stream.h"
+#include "table.h"
+
+#include <cudf/interop.hpp>
+
+namespace libcudf_bridge {
+    std::unique_ptr<Table> from_arrow_host(
+        std::uint8_t const* schema_ptr,
+        std::uint8_t const* device_array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+
+    std::unique_ptr<Column> from_arrow_column(
+        std::uint8_t const* schema_ptr,
+        std::uint8_t const* array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+
+    struct ColumnMetadata {
+        cudf::column_metadata inner;
+
+        explicit ColumnMetadata(cudf::column_metadata metadata);
+
+        [[nodiscard]] rust::String name() const;
+        void set_name(rust::Str value);
+        [[nodiscard]] rust::String timezone() const;
+        void set_timezone(rust::Str value);
+        [[nodiscard]] bool has_precision() const;
+        [[nodiscard]] std::int32_t precision() const;
+        void set_precision(std::int32_t value);
+        void clear_precision();
+        [[nodiscard]] std::size_t children_len() const;
+        [[nodiscard]] std::unique_ptr<ColumnMetadata> child(std::size_t index) const;
+        void set_child(std::size_t index, const ColumnMetadata& child);
+        void push_child(const ColumnMetadata& child);
+    };
+
+    struct ColumnMetadataVector {
+        std::vector<cudf::column_metadata> inner;
+
+        explicit ColumnMetadataVector(std::vector<cudf::column_metadata> metadata);
+
+        [[nodiscard]] std::size_t len() const;
+        [[nodiscard]] bool is_empty() const;
+        [[nodiscard]] std::unique_ptr<ColumnMetadata> get(std::size_t index) const;
+        void set(std::size_t index, const ColumnMetadata& metadata);
+        void push(const ColumnMetadata& metadata);
+    };
+
+    // cxx cannot represent recursive column_metadata values or optional fields
+    // directly, so these factories and accessors mechanically bridge them.
+    std::unique_ptr<ColumnMetadata> make_column_metadata();
+    std::unique_ptr<ColumnMetadata> make_column_metadata_with_name(rust::Str name);
+    std::unique_ptr<ColumnMetadataVector> make_column_metadata_vector();
+
+    std::unique_ptr<ColumnMetadata> get_column_metadata(const ColumnView& input);
+
+    std::unique_ptr<ColumnMetadataVector> get_table_metadata(const TableView& input);
+
+    void to_arrow_schema(
+        const TableView& input,
+        const ColumnMetadataVector& metadata,
+        std::uint8_t* out_schema_ptr);
+
+    void to_arrow_host(
+        const TableView& input,
+        std::uint8_t* out_array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+
+    void to_arrow_host(
+        const ColumnView& input,
+        std::uint8_t* out_array_ptr,
+        const CudaStreamView& stream,
+        const DeviceAsyncResourceRef& mr);
+}  // namespace libcudf_bridge

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -25,6 +25,8 @@ pub mod ffi {
         include!("libcudf-sys/src/scalar.h");
         include!("libcudf-sys/src/ast.h");
         include!("libcudf-sys/src/table.h");
+        include!("libcudf-sys/src/interop.h");
+        include!("libcudf-sys/src/pinned_memory.h");
         include!("libcudf-sys/src/aggregation.h");
         include!("libcudf-sys/src/groupby.h");
         include!("libcudf-sys/src/io.h");
@@ -55,6 +57,12 @@ pub mod ffi {
         /// contain null values and have an associated data type.
         type Column;
 
+        /// Non-owning reference to a column owned by a table.
+        ///
+        /// This is the minimal cxx wrapper for `cudf::column const&` and must
+        /// not outlive its owning [`Table`].
+        type ColumnRef;
+
         /// Non-owning view of a column
         ///
         /// A column_view is a non-owning, immutable view of device data as a column of elements,
@@ -71,6 +79,80 @@ pub mod ffi {
         /// A scalar is a singular value of any of the supported data types in cuDF.
         /// Scalars can be valid or null.
         type Scalar;
+
+        /// Direct wrapper for `cudf::column_metadata`.
+        type ColumnMetadata;
+
+        /// Direct wrapper for `std::vector<cudf::column_metadata>`.
+        type ColumnMetadataVector;
+
+        /// Return the number of metadata entries.
+        fn len(self: &ColumnMetadataVector) -> usize;
+
+        /// Return whether there are no metadata entries.
+        fn is_empty(self: &ColumnMetadataVector) -> bool;
+
+        /// Return the metadata entry at `index` by value.
+        fn get(self: &ColumnMetadataVector, index: usize) -> Result<UniquePtr<ColumnMetadata>>;
+
+        /// Replace the metadata entry at `index`.
+        fn set(
+            self: Pin<&mut ColumnMetadataVector>,
+            index: usize,
+            metadata: &ColumnMetadata,
+        ) -> Result<()>;
+
+        /// Append one metadata entry.
+        fn push(self: Pin<&mut ColumnMetadataVector>, metadata: &ColumnMetadata);
+
+        /// Return the column name.
+        fn name(self: &ColumnMetadata) -> String;
+
+        /// Replace the column name.
+        fn set_name(self: Pin<&mut ColumnMetadata>, value: &str);
+
+        /// Return the column timezone.
+        fn timezone(self: &ColumnMetadata) -> String;
+
+        /// Replace the column timezone.
+        fn set_timezone(self: Pin<&mut ColumnMetadata>, value: &str);
+
+        /// Return whether decimal precision is present.
+        fn has_precision(self: &ColumnMetadata) -> bool;
+
+        /// Return decimal precision, or an error if it is absent.
+        fn precision(self: &ColumnMetadata) -> Result<i32>;
+
+        /// Set decimal precision.
+        fn set_precision(self: Pin<&mut ColumnMetadata>, value: i32);
+
+        /// Clear decimal precision.
+        fn clear_precision(self: Pin<&mut ColumnMetadata>);
+
+        /// Return the number of recursive child metadata entries.
+        fn children_len(self: &ColumnMetadata) -> usize;
+
+        /// Return a recursive child metadata entry by value.
+        fn child(self: &ColumnMetadata, index: usize) -> Result<UniquePtr<ColumnMetadata>>;
+
+        /// Replace a recursive child metadata entry.
+        fn set_child(
+            self: Pin<&mut ColumnMetadata>,
+            index: usize,
+            child: &ColumnMetadata,
+        ) -> Result<()>;
+
+        /// Append a recursive child metadata entry.
+        fn push_child(self: Pin<&mut ColumnMetadata>, child: &ColumnMetadata);
+
+        /// Construct `cudf::column_metadata()`.
+        fn make_column_metadata() -> UniquePtr<ColumnMetadata>;
+
+        /// Construct `cudf::column_metadata(name)`.
+        fn make_column_metadata_with_name(name: &str) -> UniquePtr<ColumnMetadata>;
+
+        /// Construct an empty `std::vector<cudf::column_metadata>`.
+        fn make_column_metadata_vector() -> UniquePtr<ColumnMetadataVector>;
 
         /// Owning cuDF AST expression tree.
         type AstExpressionTree;
@@ -123,7 +205,11 @@ pub mod ffi {
         fn size(self: &DeviceIndexVector) -> usize;
 
         /// View the row indices as a non-owning cuDF column view.
-        fn view(self: &DeviceIndexVector) -> UniquePtr<ColumnView>;
+        ///
+        /// # Safety
+        ///
+        /// The returned view must not outlive this vector.
+        unsafe fn view(self: &DeviceIndexVector) -> UniquePtr<ColumnView>;
 
         /// Pair of cuDF join index maps.
         type JoinIndices;
@@ -311,109 +397,111 @@ pub mod ffi {
 
         // Table methods
         /// Get the number of columns in the table
-        fn num_columns(self: &Table) -> usize;
+        fn num_columns(self: &Table) -> Result<i32>;
 
         /// Get the number of rows in the table
-        fn num_rows(self: &Table) -> usize;
+        fn num_rows(self: &Table) -> Result<i32>;
 
         /// Get a view of this table
-        fn view(self: &Table) -> UniquePtr<TableView>;
+        ///
+        /// # Safety
+        ///
+        /// The returned view must not outlive this table.
+        unsafe fn view(self: &Table) -> Result<UniquePtr<TableView>>;
+
+        /// Get a const column reference at index.
+        ///
+        /// # Safety
+        ///
+        /// The returned reference wrapper must not outlive this table.
+        unsafe fn get_column(self: &Table, index: i32) -> Result<UniquePtr<ColumnRef>>;
 
         /// Release and take ownership of the table's columns
-        fn release(self: &Table) -> UniquePtr<ColumnVectorHelper>;
+        fn release(self: Pin<&mut Table>) -> Result<UniquePtr<ColumnVectorHelper>>;
 
         // TableView methods
         /// Get the number of columns in the table view
-        fn num_columns(self: &TableView) -> usize;
+        fn num_columns(self: &TableView) -> Result<i32>;
 
         /// Get the number of rows in the table view
-        fn num_rows(self: &TableView) -> usize;
+        fn num_rows(self: &TableView) -> Result<i32>;
 
         /// Select specific columns by indices
-        fn select(self: &TableView, column_indices: &[i32]) -> UniquePtr<TableView>;
+        fn select(self: &TableView, column_indices: &[i32]) -> Result<UniquePtr<TableView>>;
 
         /// Get column view at index
-        fn column(self: &TableView, index: i32) -> UniquePtr<ColumnView>;
+        fn column(self: &TableView, index: i32) -> Result<UniquePtr<ColumnView>>;
 
-        /// Get the table view schema as an FFI ArrowSchema
-        ///
-        /// # Safety
-        ///
-        /// `out_schema_ptr` must point to a valid `ArrowSchema`. Caller must release it.
-        unsafe fn to_arrow_schema(self: &TableView, out_schema_ptr: *mut u8);
-
-        /// Get the table view data as an FFI ArrowArray
-        ///
-        /// # Safety
-        ///
-        /// `out_array_ptr` must point to a valid `ArrowArray`. Caller must release it.
-        unsafe fn to_arrow_array(
-            self: &TableView,
-            out_array_ptr: *mut u8,
-            stream: &CudaStreamView,
-            mr: &DeviceAsyncResourceRef,
-        );
-
-        /// Clone this table view
-        ///
-        /// Note: Cannot implement `Clone` trait due to cxx FFI limitations.
-        /// This creates a deep copy of the view structure (not the underlying data).
-        #[allow(clippy::should_implement_trait)]
-        fn clone(self: &TableView) -> UniquePtr<TableView>;
+        /// Mechanical factory for `cudf::table_view`'s copy constructor.
+        fn table_view_clone(view: &TableView) -> Result<UniquePtr<TableView>>;
 
         // Column methods
         /// Get the number of elements in the column
-        fn size(self: &Column) -> usize;
+        fn size(self: &Column) -> Result<i32>;
 
         /// Get the data type of the column
-        fn data_type(self: &Column) -> UniquePtr<DataType>;
+        #[cxx_name = "type"]
+        fn data_type(self: &Column) -> Result<UniquePtr<DataType>>;
+
+        /// Get the total device allocation size of the column.
+        fn alloc_size(self: &Column) -> Result<usize>;
+
+        /// Get the total device allocation size of a referenced column.
+        fn alloc_size(self: &ColumnRef) -> Result<usize>;
 
         // ColumnView methods
         /// Get the number of elements in the column view
-        fn size(self: &ColumnView) -> usize;
+        fn size(self: &ColumnView) -> Result<i32>;
 
         /// Get a view of this column
-        fn view(self: &Column) -> UniquePtr<ColumnView>;
-
-        /// Get the column view data as an FFI ArrowDeviceArray
         ///
         /// # Safety
         ///
-        /// `out_array_ptr` must point to a valid `ArrowDeviceArray`. Caller must release it.
-        unsafe fn to_arrow_array(
-            self: &ColumnView,
-            out_array_ptr: *mut u8,
-            stream: &CudaStreamView,
-            mr: &DeviceAsyncResourceRef,
-        );
+        /// The returned view must not outlive this column.
+        unsafe fn view(self: &Column) -> Result<UniquePtr<ColumnView>>;
 
         /// Get the raw device pointer to the column view's data
-        fn data_ptr(self: &ColumnView) -> u64;
+        fn head(self: &ColumnView) -> Result<usize>;
 
         /// Get the data type of the column view
-        fn data_type(self: &ColumnView) -> UniquePtr<DataType>;
+        #[cxx_name = "type"]
+        fn data_type(self: &ColumnView) -> Result<UniquePtr<DataType>>;
 
-        /// Clone this column view
-        ///
-        /// Note: Cannot implement `Clone` trait due to cxx FFI limitations.
-        /// This creates a deep copy of the view structure (not the underlying data).
-        #[allow(clippy::should_implement_trait)]
-        fn clone(self: &ColumnView) -> UniquePtr<ColumnView>;
+        /// Mechanical factory for `cudf::column_view`'s copy constructor.
+        fn column_view_clone(view: &ColumnView) -> Result<UniquePtr<ColumnView>>;
 
         /// Get the offset of the current ColumnView in case it was a slice of another one
-        fn offset(self: &ColumnView) -> i32;
+        fn offset(self: &ColumnView) -> Result<i32>;
 
         /// Get the number of null values in the column
-        fn null_count(self: &ColumnView) -> i32;
+        fn null_count(self: &ColumnView) -> Result<i32>;
 
-        /// Get buffer memory size (data + offsets, no null mask)
-        fn get_buffer_memory_size(self: &ColumnView, stream: &CudaStreamView) -> usize;
+        /// Return whether the column view has a null mask.
+        fn nullable(self: &ColumnView) -> Result<bool>;
 
-        /// Get total array memory size (data + offsets + null mask + children)
-        fn get_array_memory_size(self: &ColumnView, stream: &CudaStreamView) -> usize;
+        /// Return the number of child column views.
+        fn num_children(self: &ColumnView) -> Result<i32>;
 
-        /// Transfer the null buffer
-        fn get_null_buffer(self: &ColumnView) -> Vec<u8>;
+        /// Return a child column view by index.
+        ///
+        /// The index must be less than `num_children`, matching cuDF's
+        /// unchecked `column_view::child` contract.
+        unsafe fn child(self: &ColumnView, index: i32) -> Result<UniquePtr<ColumnView>>;
+
+        /// Return `column_view::null_mask()` encoded as an integer because cxx
+        /// cannot return `bitmask_type const*` directly.
+        fn null_mask(self: &ColumnView) -> Result<usize>;
+
+        /// Construct the full pointer-based `cudf::column_view` overload.
+        unsafe fn column_view_create(
+            dtype: &DataType,
+            size: i32,
+            data: usize,
+            null_mask: usize,
+            null_count: i32,
+            offset: i32,
+            children: &[*const ColumnView],
+        ) -> Result<UniquePtr<ColumnView>>;
 
         // DataType methods
         /// Get the type_id
@@ -422,31 +510,53 @@ pub mod ffi {
         /// Get the scale (for fixed_point types)
         fn scale(self: &DataType) -> i32;
 
-        // Scalar methods
-        /// Get the scalar data as an FFI ArrowDeviceArray
-        ///
-        /// # Safety
-        ///
-        /// `out_array_ptr` must point to a valid `ArrowDeviceArray`. Caller must release it.
-        unsafe fn to_arrow_array(
-            self: &Scalar,
+        /// Return whether `type` has a fixed-width representation.
+        fn is_fixed_width(dtype: &DataType) -> bool;
+
+        /// Return the byte width of a fixed-width `type`.
+        fn size_of(dtype: &DataType) -> Result<usize>;
+
+        /// Return the padded allocation size for a null mask.
+        fn bitmask_allocation_size_bytes(number_of_bits: i32, padding_boundary: usize) -> usize;
+
+        /// Direct wrapper for `cudf::get_column_metadata`.
+        fn get_column_metadata(input: &ColumnView) -> Result<UniquePtr<ColumnMetadata>>;
+
+        /// Direct wrapper for `cudf::get_table_metadata`.
+        fn get_table_metadata(input: &TableView) -> Result<UniquePtr<ColumnMetadataVector>>;
+
+        /// Direct wrapper for `cudf::to_arrow_schema`.
+        unsafe fn to_arrow_schema(
+            input: &TableView,
+            metadata: &ColumnMetadataVector,
+            out_schema_ptr: *mut u8,
+        ) -> Result<()>;
+
+        /// Direct wrapper for the table-view overload of `cudf::to_arrow_host`.
+        #[rust_name = "to_arrow_host_table"]
+        unsafe fn to_arrow_host(
+            input: &TableView,
             out_array_ptr: *mut u8,
             stream: &CudaStreamView,
             mr: &DeviceAsyncResourceRef,
-        );
+        ) -> Result<()>;
 
+        /// Direct wrapper for the column-view overload of `cudf::to_arrow_host`.
+        #[rust_name = "to_arrow_host_column"]
+        unsafe fn to_arrow_host(
+            input: &ColumnView,
+            out_array_ptr: *mut u8,
+            stream: &CudaStreamView,
+            mr: &DeviceAsyncResourceRef,
+        ) -> Result<()>;
+
+        // Scalar methods
         /// Check if the scalar is valid (not null)
-        fn is_valid(self: &Scalar) -> bool;
+        fn is_valid(self: &Scalar, stream: &CudaStreamView) -> Result<bool>;
 
         /// Get the data type of the scalar
-        fn data_type(self: &Scalar) -> UniquePtr<DataType>;
-
-        /// Clone this scalar (deep copy)
-        ///
-        /// Note: Cannot implement `Clone` trait due to cxx FFI limitations.
-        /// This creates a deep copy of the scalar and its data.
-        #[allow(clippy::should_implement_trait)]
-        fn clone(self: &Scalar) -> UniquePtr<Scalar>;
+        #[cxx_name = "type"]
+        fn data_type(self: &Scalar) -> Result<UniquePtr<DataType>>;
 
         // Factory functions
 
@@ -457,11 +567,13 @@ pub mod ffi {
         fn new_data_type_with_scale(type_id: i32, scale: i32) -> UniquePtr<DataType>;
 
         /// Create an empty table with no columns and no rows
-        fn create_empty_table() -> UniquePtr<Table>;
+        fn create_empty_table() -> Result<UniquePtr<Table>>;
 
         /// Create a table from a set of column pointers (takes ownership)
         /// The columns are consumed and should not be used after this call
-        fn create_table_from_columns_move(columns: &[*mut Column]) -> UniquePtr<Table>;
+        unsafe fn create_table_from_columns_move(
+            columns: &[*mut Column],
+        ) -> Result<UniquePtr<Table>>;
 
         /// Create a table from vertically concatenating TableView together
         fn concat_table_views(
@@ -495,9 +607,9 @@ pub mod ffi {
         ) -> Result<UniquePtr<Column>>;
 
         /// Create a TableView from a set of ColumnView pointers (non-owning)
-        fn create_table_view_from_column_views(
+        unsafe fn create_table_view_from_column_views(
             column_views: &[*const ColumnView],
-        ) -> UniquePtr<TableView>;
+        ) -> Result<UniquePtr<TableView>>;
 
         // Parquet I/O
 
@@ -1025,7 +1137,7 @@ pub mod ffi {
         /// # Safety
         ///
         /// Pointers must be valid Arrow C Data Interface structures.
-        unsafe fn table_from_arrow_host(
+        unsafe fn from_arrow_host(
             schema_ptr: *const u8,
             device_array_ptr: *const u8,
             stream: &CudaStreamView,
@@ -1037,7 +1149,7 @@ pub mod ffi {
         /// # Safety
         ///
         /// Pointers must be valid Arrow C Data Interface structures.
-        unsafe fn column_from_arrow(
+        unsafe fn from_arrow_column(
             schema_ptr: *const u8,
             array_ptr: *const u8,
             stream: &CudaStreamView,
@@ -1045,7 +1157,7 @@ pub mod ffi {
         ) -> Result<UniquePtr<Column>>;
 
         /// Cast a column to a different data type using GPU-native cudf::cast
-        fn cast_column(
+        fn cast(
             input: &ColumnView,
             target_type: &DataType,
             stream: &CudaStreamView,
@@ -1055,16 +1167,27 @@ pub mod ffi {
         /// Extract a scalar from a column at the specified index
         fn get_element(
             column: &ColumnView,
-            index: usize,
+            index: i32,
             stream: &CudaStreamView,
             mr: &DeviceAsyncResourceRef,
-        ) -> UniquePtr<Scalar>;
+        ) -> Result<UniquePtr<Scalar>>;
 
         /// Get the version of the cuDF library
         fn get_cudf_version() -> String;
 
-        /// Configure cuDF's default pinned-memory resource pool.
-        fn config_default_pinned_memory_resource(pool_size_bytes: usize) -> bool;
+        /// Opaque wrapper around `cudf::pinned_mr_options`.
+        type PinnedMrOptions;
+
+        /// Construct options with upstream's default `pool_size = nullopt`.
+        fn make_pinned_mr_options() -> UniquePtr<PinnedMrOptions>;
+
+        /// Construct options with an explicit pool size.
+        fn make_pinned_mr_options_with_pool_size(
+            pool_size_bytes: usize,
+        ) -> UniquePtr<PinnedMrOptions>;
+
+        /// Direct wrapper for `cudf::config_default_pinned_memory_resource`.
+        fn config_default_pinned_memory_resource(options: &PinnedMrOptions) -> bool;
 
         /// Set cuDF's host allocation threshold for pinned memory.
         fn set_allocate_host_as_pinned_threshold(threshold_bytes: usize);
@@ -1076,7 +1199,11 @@ pub mod ffi {
         fn cuda_stream_create_with_flags(flags: u32) -> Result<UniquePtr<CudaStream>>;
 
         /// Return a non-owning view for an owned CUDA stream.
-        fn cuda_stream_view(stream: &CudaStream) -> UniquePtr<CudaStreamView>;
+        ///
+        /// # Safety
+        ///
+        /// The returned view must not outlive `stream`.
+        unsafe fn cuda_stream_view(stream: &CudaStream) -> UniquePtr<CudaStreamView>;
 
         /// Convert an RMM CUDA stream view into an upstream CCCL CUDA stream ref.
         ///
@@ -1100,11 +1227,23 @@ pub mod ffi {
         /// Set the current CUDA device ordinal.
         fn cuda_set_device(device_id: i32) -> Result<()>;
 
+        /// Direct wrapper for `cudaMemcpy`. Pointer values are integer-encoded
+        /// because cxx cannot expose untyped CUDA pointers directly.
+        unsafe fn cuda_memcpy(destination: usize, source: usize, count: usize, kind: i32) -> i32;
+
+        /// Direct wrapper for `cudaGetErrorString`.
+        fn cuda_get_error_string(error: i32) -> String;
+
         /// Return cuDF's current device memory resource reference.
         fn get_current_device_resource_ref() -> UniquePtr<DeviceAsyncResourceRef>;
 
         /// Set cuDF's current device memory resource reference.
-        fn set_current_device_resource_ref(
+        ///
+        /// # Safety
+        ///
+        /// The referenced resource must remain alive until it is replaced or
+        /// reset and all work using it has completed.
+        unsafe fn set_current_device_resource_ref(
             resource: &DeviceAsyncResourceRef,
         ) -> UniquePtr<DeviceAsyncResourceRef>;
 
@@ -1141,19 +1280,62 @@ pub mod ffi {
         type PoolMemoryResource;
 
         /// Construct an RMM pool memory resource.
-        fn make_pool_memory_resource(
+        ///
+        /// # Safety
+        ///
+        /// `upstream` must outlive the returned pool.
+        unsafe fn make_pool_memory_resource(
             upstream: &CudaMemoryResource,
             initial_size: usize,
-            max_size: usize,
-        ) -> UniquePtr<PoolMemoryResource>;
+        ) -> Result<UniquePtr<PoolMemoryResource>>;
 
-        /// Install the pool as RMM's current device resource.
-        fn set_current_device_resource(resource: &PoolMemoryResource);
+        /// Construct an RMM pool memory resource with an explicit maximum size.
+        ///
+        /// # Safety
+        ///
+        /// `upstream` must outlive the returned pool.
+        unsafe fn make_pool_memory_resource_with_maximum(
+            upstream: &CudaMemoryResource,
+            initial_size: usize,
+            maximum_size: usize,
+        ) -> Result<UniquePtr<PoolMemoryResource>>;
 
-        /// Return total VRAM bytes on the current CUDA device.
-        fn total_device_memory() -> usize;
+        /// Construct RMM's non-owning resource-reference type from a pool.
+        ///
+        /// # Safety
+        ///
+        /// `resource` must outlive the returned reference and every operation
+        /// to which that reference is passed.
+        unsafe fn make_device_async_resource_ref(
+            resource: &PoolMemoryResource,
+        ) -> UniquePtr<DeviceAsyncResourceRef>;
+
+        /// Opaque wrapper for the pair returned by `rmm::available_device_memory`.
+        type AvailableDeviceMemory;
+
+        /// Return the pair's available-memory component.
+        fn free_bytes(self: &AvailableDeviceMemory) -> usize;
+
+        /// Return the pair's total-memory component.
+        fn total_bytes(self: &AvailableDeviceMemory) -> usize;
+
+        /// Direct wrapper for `rmm::available_device_memory`.
+        fn available_device_memory() -> Result<UniquePtr<AvailableDeviceMemory>>;
     }
 }
+
+/// `cudaMemcpyHostToHost` from `cudaMemcpyKind`.
+pub const CUDA_MEMCPY_HOST_TO_HOST: i32 = 0;
+/// `cudaMemcpyHostToDevice` from `cudaMemcpyKind`.
+pub const CUDA_MEMCPY_HOST_TO_DEVICE: i32 = 1;
+/// `cudaMemcpyDeviceToHost` from `cudaMemcpyKind`.
+pub const CUDA_MEMCPY_DEVICE_TO_HOST: i32 = 2;
+/// `cudaMemcpyDeviceToDevice` from `cudaMemcpyKind`.
+pub const CUDA_MEMCPY_DEVICE_TO_DEVICE: i32 = 3;
+/// `cudaMemcpyDefault` from `cudaMemcpyKind`.
+pub const CUDA_MEMCPY_DEFAULT: i32 = 4;
+/// `cudaSuccess` from `cudaError_t`.
+pub const CUDA_SUCCESS: i32 = 0;
 
 /// Return cuDF's current default stream as an explicit stream-view handle.
 pub fn get_default_stream() -> cxx::UniquePtr<ffi::CudaStreamView> {
@@ -1576,18 +1758,34 @@ pub struct ArrowDeviceArray {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ArrowDeviceType {
+    /// CPU memory.
     Cpu = 1,
+    /// CUDA device memory.
     Cuda = 2,
+    /// CUDA-pinned host memory.
     CudaHost = 3,
+    /// OpenCL device memory.
     OpenCL = 4,
-    Vulkan = 5,
-    Metal = 6,
-    VulkanHost = 7,
-    OpenCLHost = 8,
-    CudaManaged = 9,
-    OneAPI = 10,
-    WebGPU = 11,
-    Hexagon = 12,
+    /// Vulkan device memory.
+    Vulkan = 7,
+    /// Metal device memory.
+    Metal = 8,
+    /// NVIDIA VPI device memory.
+    Vpi = 9,
+    /// ROCm device memory.
+    Rocm = 10,
+    /// ROCm-pinned host memory.
+    RocmHost = 11,
+    /// Extension-defined device memory.
+    ExtDev = 12,
+    /// CUDA managed memory.
+    CudaManaged = 13,
+    /// oneAPI device memory.
+    OneAPI = 14,
+    /// WebGPU device memory.
+    WebGPU = 15,
+    /// Hexagon device memory.
+    Hexagon = 16,
 }
 
 impl ArrowDeviceType {
@@ -1792,7 +1990,7 @@ unsafe impl Send for ffi::CudaMemoryResource {}
 unsafe impl Sync for ffi::CudaMemoryResource {}
 
 /// SAFETY: Same as `CudaMemoryResource`. Once installed via
-/// `set_current_device_resource`, RMM serializes its own concurrent allocate /
+/// `set_current_device_resource_ref`, RMM serializes its own concurrent allocate /
 /// deallocate, so shared references to the handle are safe.
 unsafe impl Send for ffi::PoolMemoryResource {}
 unsafe impl Sync for ffi::PoolMemoryResource {}
@@ -1812,7 +2010,7 @@ mod tests {
     use arrow::ffi::{from_ffi, from_ffi_and_data_type, FFI_ArrowArray};
     use arrow::util::pretty::{pretty_format_batches, pretty_format_columns};
     use arrow_schema::ffi::FFI_ArrowSchema;
-    use arrow_schema::{ArrowError, DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Schema};
     use insta::assert_snapshot;
     use std::fmt::Display;
     use std::sync::Arc;
@@ -1900,7 +2098,7 @@ mod tests {
         assert!(result.num_input_row_groups() > 0);
 
         let table = result.pin_mut().release_table();
-        assert!(table.num_rows() > 0);
+        assert!(table.num_rows()? > 0);
 
         Ok(())
     }
@@ -1915,9 +2113,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let num_cols = table.num_columns();
+        let num_cols = usize::try_from(table.num_columns()?)?;
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
@@ -1929,9 +2127,9 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(sorted_table.num_rows(), table.num_rows());
-        assert_eq!(sorted_table.num_columns(), table.num_columns());
-        assert_snapshot!(pretty_table(&sorted_table.view())?);
+        assert_eq!(sorted_table.num_rows()?, table.num_rows()?);
+        assert_eq!(sorted_table.num_columns()?, table.num_columns()?);
+        assert_snapshot!(pretty_table(&*unsafe { sorted_table.view() }?)?);
 
         Ok(())
     }
@@ -1945,9 +2143,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let num_cols = table.num_columns();
+        let num_cols = usize::try_from(table.num_columns()?)?;
         let column_order: Vec<i32> = vec![Order::Descending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::After as i32; num_cols];
 
@@ -1959,9 +2157,9 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(sorted_table.num_rows(), table.num_rows());
-        assert_eq!(sorted_table.num_columns(), table.num_columns());
-        assert_snapshot!(pretty_table(&sorted_table.view())?);
+        assert_eq!(sorted_table.num_rows()?, table.num_rows()?);
+        assert_eq!(sorted_table.num_columns()?, table.num_columns()?);
+        assert_snapshot!(pretty_table(&*unsafe { sorted_table.view() }?)?);
 
         Ok(())
     }
@@ -1975,9 +2173,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let num_cols = table.num_columns();
+        let num_cols = usize::try_from(table.num_columns()?)?;
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
@@ -1989,9 +2187,9 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(sorted_table.num_rows(), table.num_rows());
-        assert_eq!(sorted_table.num_columns(), table.num_columns());
-        assert_snapshot!(pretty_table(&sorted_table.view())?);
+        assert_eq!(sorted_table.num_rows()?, table.num_rows()?);
+        assert_eq!(sorted_table.num_columns()?, table.num_columns()?);
+        assert_snapshot!(pretty_table(&*unsafe { sorted_table.view() }?)?);
 
         Ok(())
     }
@@ -2005,9 +2203,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let num_cols = table.num_columns();
+        let num_cols = usize::try_from(table.num_columns()?)?;
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
@@ -2019,8 +2217,11 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(indices.size(), table.num_rows());
-        assert_snapshot!(pretty_column(&indices.view(), DataType::Int32)?);
+        assert_eq!(indices.size()?, table.num_rows()?);
+        assert_snapshot!(pretty_column(
+            &*unsafe { indices.view() }?,
+            DataType::Int32
+        )?);
 
         Ok(())
     }
@@ -2034,9 +2235,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let num_cols = table.num_columns();
+        let num_cols = usize::try_from(table.num_columns()?)?;
         let column_order: Vec<i32> = vec![Order::Ascending as i32; num_cols];
         let null_precedence: Vec<i32> = vec![NullOrder::Before as i32; num_cols];
 
@@ -2047,7 +2248,7 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let sorted_view = sorted_table.view();
+        let sorted_view = unsafe { sorted_table.view() }?;
 
         let is_sorted = ffi::is_sorted(&sorted_view, &column_order, &null_precedence, stream_view)?;
         assert!(is_sorted, "Table should be sorted after calling sort_table");
@@ -2064,9 +2265,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let keys_view = table_view.select(&[0]);
+        let keys_view = table_view.select(&[0])?;
 
         let column_order = vec![Order::Ascending as i32];
         let null_precedence = vec![NullOrder::Before as i32];
@@ -2080,9 +2281,9 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(sorted_table.num_rows(), table.num_rows());
-        assert_eq!(sorted_table.num_columns(), table.num_columns());
-        assert_snapshot!(pretty_table(&sorted_table.view())?);
+        assert_eq!(sorted_table.num_rows()?, table.num_rows()?);
+        assert_eq!(sorted_table.num_columns()?, table.num_columns()?);
+        assert_snapshot!(pretty_table(&*unsafe { sorted_table.view() }?)?);
 
         Ok(())
     }
@@ -2096,9 +2297,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let keys_view = table_view.select(&[0, 1]);
+        let keys_view = table_view.select(&[0, 1])?;
 
         let column_order = vec![Order::Ascending as i32, Order::Descending as i32];
         let null_precedence = vec![NullOrder::Before as i32, NullOrder::After as i32];
@@ -2112,9 +2313,9 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(sorted_table.num_rows(), table.num_rows());
-        assert_eq!(sorted_table.num_columns(), table.num_columns());
-        assert_snapshot!(pretty_table(&sorted_table.view())?);
+        assert_eq!(sorted_table.num_rows()?, table.num_rows()?);
+        assert_eq!(sorted_table.num_columns()?, table.num_columns()?);
+        assert_snapshot!(pretty_table(&*unsafe { sorted_table.view() }?)?);
 
         Ok(())
     }
@@ -2129,10 +2330,10 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let col1 = table_view.column(1);
-        let col2 = table_view.column(2);
+        let col1 = table_view.column(1)?;
+        let col2 = table_view.column(2)?;
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
         let result = ffi::binary_operation_col_col(
@@ -2144,9 +2345,12 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(result.size(), col1.size());
-        assert_eq!(result.size(), col2.size());
-        assert_snapshot!(pretty_column(&result.view(), DataType::Float64)?);
+        assert_eq!(result.size()?, col1.size()?);
+        assert_eq!(result.size()?, col2.size()?);
+        assert_snapshot!(pretty_column(
+            &*unsafe { result.view() }?,
+            DataType::Float64
+        )?);
 
         Ok(())
     }
@@ -2160,10 +2364,10 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let col1 = table_view.column(1);
-        let col2 = table_view.column(2);
+        let col1 = table_view.column(1)?;
+        let col2 = table_view.column(2)?;
 
         let output_type = ffi::new_data_type(TypeId::Float64 as i32);
         let result = ffi::binary_operation_col_col(
@@ -2175,8 +2379,11 @@ mod tests {
             resource_ref,
         )?;
 
-        assert_eq!(result.size(), col1.size());
-        assert_snapshot!(pretty_column(&result.view(), DataType::Float64)?);
+        assert_eq!(result.size()?, col1.size()?);
+        assert_snapshot!(pretty_column(
+            &*unsafe { result.view() }?,
+            DataType::Float64
+        )?);
 
         Ok(())
     }
@@ -2239,9 +2446,33 @@ mod tests {
     }
 
     #[test]
+    fn arrow_device_type_matches_c_device_interface() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(
+            [
+                ArrowDeviceType::Cpu as i32,
+                ArrowDeviceType::Cuda as i32,
+                ArrowDeviceType::CudaHost as i32,
+                ArrowDeviceType::OpenCL as i32,
+                ArrowDeviceType::Vulkan as i32,
+                ArrowDeviceType::Metal as i32,
+                ArrowDeviceType::Vpi as i32,
+                ArrowDeviceType::Rocm as i32,
+                ArrowDeviceType::RocmHost as i32,
+                ArrowDeviceType::ExtDev as i32,
+                ArrowDeviceType::CudaManaged as i32,
+                ArrowDeviceType::OneAPI as i32,
+                ArrowDeviceType::WebGPU as i32,
+                ArrowDeviceType::Hexagon as i32,
+            ],
+            [1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_reduce_uses_full_output_data_type() -> Result<(), Box<dyn std::error::Error>> {
         let table = table_from_decimal128_column("amount", vec![12345, 67890], 2)?;
-        let column = table.view().column(0);
+        let column = unsafe { table.view() }?.column(0)?;
         let output_type = ffi::new_data_type_with_scale(TypeId::Decimal128 as i32, -2);
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
@@ -2254,9 +2485,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let result_type = result.data_type();
+        let result_type = result.data_type()?;
 
-        assert!(result.is_valid());
+        assert!(result.is_valid(stream_view)?);
         assert_eq!(result_type.id(), TypeId::Decimal128 as i32);
         assert_eq!(result_type.scale(), -2);
 
@@ -2266,11 +2497,16 @@ mod tests {
     #[test]
     fn test_reduce_with_init() -> Result<(), Box<dyn std::error::Error>> {
         let table = table_from_i32_columns(&[("values", vec![1, 2, 3])])?;
-        let values = table.view().column(0);
+        let values = unsafe { table.view() }?.column(0)?;
         let init_table = table_from_i32_columns(&[("init", vec![10])])?;
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
-        let init = ffi::get_element(&init_table.view().column(0), 0, stream_view, resource_ref);
+        let init = ffi::get_element(
+            &*unsafe { init_table.view() }?.column(0)?,
+            0,
+            stream_view,
+            resource_ref,
+        )?;
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
 
         let result = ffi::reduce_with_init(
@@ -2283,7 +2519,7 @@ mod tests {
         )?;
         let result_column = ffi::make_column_from_scalar(&result, 1, stream_view, resource_ref)?;
 
-        assert_snapshot!(pretty_column(&result_column.view(), DataType::Int32)?, @r"
+        assert_snapshot!(pretty_column(&*unsafe { result_column.view() }?, DataType::Int32)?, @r"
         +------+
         | test |
         +------+
@@ -2297,7 +2533,7 @@ mod tests {
     #[test]
     fn test_count_aggregation_respects_null_policy() -> Result<(), Box<dyn std::error::Error>> {
         let table = table_from_nullable_i32_column("values", vec![Some(1), None, Some(3), None])?;
-        let values = table.view().column(0);
+        let values = unsafe { table.view() }?.column(0)?;
         let output_type = ffi::new_data_type(TypeId::Int32 as i32);
         let (stream, resource) = default_stream_and_resource();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
@@ -2320,14 +2556,14 @@ mod tests {
         let exclude_column = ffi::make_column_from_scalar(&exclude, 1, stream_view, resource_ref)?;
         let include_column = ffi::make_column_from_scalar(&include, 1, stream_view, resource_ref)?;
 
-        assert_snapshot!(pretty_column(&exclude_column.view(), DataType::Int32)?, @r"
+        assert_snapshot!(pretty_column(&*unsafe { exclude_column.view() }?, DataType::Int32)?, @r"
         +------+
         | test |
         +------+
         | 2    |
         +------+
         ");
-        assert_snapshot!(pretty_column(&include_column.view(), DataType::Int32)?, @r"
+        assert_snapshot!(pretty_column(&*unsafe { include_column.view() }?, DataType::Int32)?, @r"
         +------+
         | test |
         +------+
@@ -2358,10 +2594,10 @@ mod tests {
         let left =
             table_from_i32_columns(&[("key", vec![1, 2, 2, 3]), ("val", vec![10, 20, 25, 30])])?;
         let right = table_from_i32_columns(&[("key", vec![2, 2, 3]), ("val", vec![15, 30, 35])])?;
-        let left_view = left.view();
-        let right_view = right.view();
-        let left_keys = left_view.select(&[0]);
-        let right_keys = right_view.select(&[0]);
+        let left_view = unsafe { left.view() }?;
+        let right_view = unsafe { right.view() }?;
+        let left_keys = left_view.select(&[0])?;
+        let right_keys = right_view.select(&[0])?;
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
@@ -2374,7 +2610,7 @@ mod tests {
         )?;
         let left_indices = indices.pin_mut().release_left();
         let right_indices = indices.pin_mut().release_right();
-        let left_indices_view = left_indices.view();
+        let left_indices_view = unsafe { left_indices.view() };
 
         let mut predicate = ffi::ast_expression_tree_create();
         let left_val = ffi::ast_expression_tree_add_column_reference(
@@ -2394,8 +2630,8 @@ mod tests {
             right_val,
         )?;
 
-        let left_values = left_view.select(&[1]);
-        let right_values = right_view.select(&[1]);
+        let left_values = left_view.select(&[1])?;
+        let right_values = right_view.select(&[1])?;
         let mut filtered = ffi::filter_join_indices(
             &left_values,
             &right_values,
@@ -2414,7 +2650,7 @@ mod tests {
         let filtered_right = filtered.pin_mut().release_right();
 
         assert_eq!(left_indices.size(), 5);
-        assert_eq!(left_indices_view.size(), 5);
+        assert_eq!(left_indices_view.size()?, 5);
         assert_eq!(right_indices.size(), 5);
         assert_eq!(filtered_left.size(), 3);
         assert_eq!(filtered_right.size(), 3);
@@ -2431,10 +2667,10 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let min_temp = table_view.column(1);
-        let max_temp = table_view.column(2);
+        let min_temp = table_view.column(1)?;
+        let max_temp = table_view.column(2)?;
 
         let output_type = ffi::new_data_type(TypeId::Bool8 as i32);
         let boolean_mask = ffi::binary_operation_col_col(
@@ -2446,15 +2682,15 @@ mod tests {
             resource_ref,
         )?;
 
-        let boolean_mask_view = boolean_mask.view();
+        let boolean_mask_view = unsafe { boolean_mask.view() }?;
         let filtered_table =
             ffi::apply_boolean_mask(&table_view, &boolean_mask_view, stream_view, resource_ref)?;
 
-        assert!(filtered_table.num_rows() < table.num_rows());
-        assert_eq!(filtered_table.num_columns(), table.num_columns());
+        assert!(filtered_table.num_rows()? < table.num_rows()?);
+        assert_eq!(filtered_table.num_columns()?, table.num_columns()?);
 
-        let filtered_view = filtered_table.view();
-        let filtered_col = filtered_view.column(1);
+        let filtered_view = unsafe { filtered_table.view() }?;
+        let filtered_col = filtered_view.column(1)?;
         assert_snapshot!(pretty_column(&filtered_col, DataType::Float64)?);
 
         Ok(())
@@ -2470,19 +2706,19 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
         let column_order: &[i32] = &[];
         let null_precedence: &[i32] = &[];
         let groupby = ffi::groupby_create(
-            &table_view.select(&[21]),
+            &*table_view.select(&[21])?,
             NullPolicy::Exclude as i32,
             Sorted::No as i32,
             column_order,
             null_precedence,
         );
 
-        let value_column = table_view.column(1);
+        let value_column = table_view.column(1)?;
         let mut request = ffi::aggregation_request_create(&value_column);
         request.pin_mut().add(ffi::make_max_aggregation_groupby());
 
@@ -2495,8 +2731,8 @@ mod tests {
 
         assert_eq!(aggregation_result.len(), 1);
         assert_eq!(
-            aggregation_result.pin_mut().release(0).size(),
-            keys.num_rows()
+            aggregation_result.pin_mut().release(0).size()?,
+            keys.num_rows()?
         );
 
         Ok(())
@@ -2511,9 +2747,9 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
+        let table_view = unsafe { table.view() }?;
 
-        let keys_view = table_view.select(&[0]);
+        let keys_view = table_view.select(&[0])?;
         let column_order: &[i32] = &[];
         let null_precedence: &[i32] = &[];
         let groupby = ffi::groupby_create(
@@ -2524,7 +2760,7 @@ mod tests {
             null_precedence,
         );
 
-        let value_column = table_view.column(1);
+        let value_column = table_view.column(1)?;
         let mut agg_request = ffi::aggregation_request_create(&value_column);
         agg_request
             .pin_mut()
@@ -2549,11 +2785,11 @@ mod tests {
         let max_column = agg_result.pin_mut().release(2);
 
         let keys = groupby_result.pin_mut().release_keys();
-        assert!(keys.num_rows() > 0);
+        assert!(keys.num_rows()? > 0);
 
-        assert_eq!(sum_column.size(), keys.num_rows());
-        assert_eq!(min_column.size(), keys.num_rows());
-        assert_eq!(max_column.size(), keys.num_rows());
+        assert_eq!(sum_column.size()?, keys.num_rows()?);
+        assert_eq!(min_column.size()?, keys.num_rows()?);
+        assert_eq!(max_column.size()?, keys.num_rows()?);
 
         Ok(())
     }
@@ -2568,18 +2804,18 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
-        let original_col = table_view.column(1);
+        let table_view = unsafe { table.view() }?;
+        let original_col = table_view.column(1)?;
 
-        let original_size = original_col.size();
+        let original_size = original_col.size()?;
         assert!(original_size > 10, "Need at least 10 rows for testing");
 
         let sliced_col = ffi::slice_column(&original_col, 5, 5, stream_view)?;
 
-        assert_eq!(sliced_col.size(), 5);
+        assert_eq!(sliced_col.size()?, 5);
 
-        let original_dtype = original_col.data_type();
-        let sliced_dtype = sliced_col.data_type();
+        let original_dtype = original_col.data_type()?;
+        let sliced_dtype = sliced_col.data_type()?;
         assert_eq!(original_dtype.id(), sliced_dtype.id());
 
         assert_snapshot!(pretty_column(&sliced_col, DataType::Float64)?, @r"
@@ -2606,12 +2842,12 @@ mod tests {
             stream_view,
             resource_ref,
         )?;
-        let table_view = table.view();
-        let original_col = table_view.column(2);
+        let table_view = unsafe { table.view() }?;
+        let original_col = table_view.column(2)?;
 
         let sliced_col = ffi::slice_column(&original_col, 0, 10, stream_view)?;
 
-        assert_eq!(sliced_col.size(), 10);
+        assert_eq!(sliced_col.size()?, 10);
         assert_snapshot!(pretty_column(&sliced_col, DataType::Float64)?, @r"
         +------+
         | test |
@@ -2655,7 +2891,9 @@ mod tests {
     #[test]
     fn test_cuda_stream_view_bindings() -> Result<(), Box<dyn std::error::Error>> {
         let stream = ffi::cuda_stream_create()?;
-        let view = ffi::cuda_stream_view(stream.as_ref().expect("CudaStream should not be null"));
+        let view = unsafe {
+            ffi::cuda_stream_view(stream.as_ref().expect("CudaStream should not be null"))
+        };
         view.synchronize()?;
 
         let default_view = ffi::get_default_stream();
@@ -2682,10 +2920,12 @@ mod tests {
     fn test_cuda_event_bindings() -> Result<(), Box<dyn std::error::Error>> {
         let producer = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING)?;
         let consumer = ffi::cuda_stream_create_with_flags(CUDA_STREAM_FLAG_NON_BLOCKING)?;
-        let producer_view =
-            ffi::cuda_stream_view(producer.as_ref().expect("CudaStream should not be null"));
-        let consumer_view =
-            ffi::cuda_stream_view(consumer.as_ref().expect("CudaStream should not be null"));
+        let producer_view = unsafe {
+            ffi::cuda_stream_view(producer.as_ref().expect("CudaStream should not be null"))
+        };
+        let consumer_view = unsafe {
+            ffi::cuda_stream_view(consumer.as_ref().expect("CudaStream should not be null"))
+        };
         let producer_ref = ffi::cuda_stream_ref_from_view(
             producer_view
                 .as_ref()
@@ -2737,8 +2977,90 @@ mod tests {
             resource_ref,
         )?;
 
-        assert!(table.num_rows() > 0);
-        assert!(table.num_columns() > 0);
+        assert!(table.num_rows()? > 0);
+        assert!(table.num_columns()? > 0);
+        Ok(())
+    }
+
+    #[test]
+    fn column_view_metadata_matches_cudf() -> Result<(), Box<dyn std::error::Error>> {
+        let table = table_from_nullable_i32_column("a", vec![Some(1), None, Some(3)])?;
+        let table_view = unsafe { table.view() }?;
+        let column = table_view.column(0)?;
+        let dtype = column.data_type()?;
+
+        assert!(column.nullable()?);
+        assert_eq!(column.num_children()?, 0);
+        assert_ne!(column.null_mask()?, 0);
+        assert!(ffi::is_fixed_width(&dtype));
+        assert_eq!(ffi::size_of(&dtype)?, std::mem::size_of::<i32>());
+        let string_type = ffi::new_data_type(TypeId::String as i32);
+        assert!(!ffi::is_fixed_width(&string_type));
+        assert!(ffi::size_of(&string_type).is_err());
+        assert_eq!(ffi::bitmask_allocation_size_bytes(3, 64), 64);
+        assert!(
+            unsafe { table.get_column(0) }?.alloc_size()? >= 3 * std::mem::size_of::<i32>() + 64
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn arrow_metadata_preserves_all_upstream_fields() -> Result<(), Box<dyn std::error::Error>> {
+        let mut metadata = ffi::make_column_metadata_with_name("amount");
+        metadata.pin_mut().set_timezone("UTC");
+        metadata.pin_mut().set_precision(12);
+        let child = ffi::make_column_metadata_with_name("element");
+        metadata.pin_mut().push_child(&child);
+
+        assert_eq!(metadata.name(), "amount");
+        assert_eq!(metadata.timezone(), "UTC");
+        assert!(metadata.has_precision());
+        assert_eq!(metadata.precision()?, 12);
+        assert_eq!(metadata.children_len(), 1);
+        assert_eq!(metadata.child(0)?.name(), "element");
+        metadata.pin_mut().clear_precision();
+        assert!(!metadata.has_precision());
+        assert!(metadata.precision().is_err());
+
+        let mut vector = ffi::make_column_metadata_vector();
+        vector.pin_mut().push(&metadata);
+        assert_eq!(vector.len(), 1);
+        assert_eq!(vector.get(0)?.name(), "amount");
+
+        let table = table_from_i32_columns(&[("ignored", vec![1, 2, 3])])?;
+        let table_view = unsafe { table.view() }?;
+        let mut table_metadata = ffi::get_table_metadata(&table_view)?;
+        let schema_metadata = ffi::make_column_metadata_with_name("renamed");
+        table_metadata.pin_mut().set(0, &schema_metadata)?;
+        let mut ffi_schema = FFI_ArrowSchema::empty();
+        unsafe {
+            ffi::to_arrow_schema(
+                &table_view,
+                &table_metadata,
+                &mut ffi_schema as *mut FFI_ArrowSchema as *mut u8,
+            )?;
+        }
+        let schema = Schema::try_from(&ffi_schema)?;
+        assert_eq!(schema.field(0).name(), "renamed");
+        Ok(())
+    }
+
+    #[test]
+    fn memory_configuration_bindings_preserve_upstream_shapes(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let memory = ffi::available_device_memory()?;
+        assert!(memory.total_bytes() > 0);
+        assert!(memory.free_bytes() <= memory.total_bytes());
+
+        assert!(!ffi::make_pinned_mr_options().is_null());
+        assert!(!ffi::make_pinned_mr_options_with_pool_size(1 << 20).is_null());
+
+        let upstream = ffi::make_cuda_memory_resource();
+        let default_maximum = unsafe { ffi::make_pool_memory_resource(&upstream, 256) }?;
+        assert!(!unsafe { ffi::make_device_async_resource_ref(&default_maximum) }.is_null());
+        let explicit_maximum =
+            unsafe { ffi::make_pool_memory_resource_with_maximum(&upstream, 256, 256) }?;
+        assert!(!unsafe { ffi::make_device_async_resource_ref(&explicit_maximum) }.is_null());
         Ok(())
     }
 
@@ -2784,7 +3106,7 @@ mod tests {
         let mr = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &mr);
         Ok(unsafe {
-            ffi::table_from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
+            ffi::from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
         }?)
     }
 
@@ -2807,7 +3129,7 @@ mod tests {
         let mr = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &mr);
         Ok(unsafe {
-            ffi::table_from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
+            ffi::from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
         }?)
     }
 
@@ -2832,7 +3154,7 @@ mod tests {
         let mr = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &mr);
         Ok(unsafe {
-            ffi::table_from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
+            ffi::from_arrow_host(schema_ptr, device_array_ptr, stream_view, resource_ref)
         }?)
     }
 
@@ -2855,46 +3177,52 @@ mod tests {
         Ok(result.pin_mut().release_table())
     }
 
-    fn pretty_table(table_view: &ffi::TableView) -> Result<impl Display + use<>, ArrowError> {
-        let mut array = FFI_ArrowArray::empty();
+    fn pretty_table(
+        table_view: &ffi::TableView,
+    ) -> Result<impl Display + use<>, Box<dyn std::error::Error>> {
+        let mut device_array = ArrowDeviceArray::new_cpu();
         let mut schema = FFI_ArrowSchema::empty();
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
-        let data = unsafe {
-            table_view.to_arrow_array(
-                &mut array as *mut FFI_ArrowArray as *mut u8,
+        let metadata = ffi::get_table_metadata(table_view)?;
+        unsafe {
+            ffi::to_arrow_host_table(
+                table_view,
+                &mut device_array as *mut ArrowDeviceArray as *mut u8,
                 stream_view,
                 resource_ref,
-            );
-            table_view.to_arrow_schema(&mut schema as *mut FFI_ArrowSchema as *mut u8);
-
-            from_ffi(array, &schema).expect("ffi data should be valid")
-        };
+            )?;
+            ffi::to_arrow_schema(
+                table_view,
+                &metadata,
+                &mut schema as *mut FFI_ArrowSchema as *mut u8,
+            )?;
+        }
+        let data = unsafe { from_ffi(device_array.array, &schema)? };
 
         let record = RecordBatch::from(StructArray::from(data));
 
-        pretty_format_batches(&[record])
+        Ok(pretty_format_batches(&[record])?)
     }
 
     fn pretty_column(
         column_view: &ColumnView,
         data_type: DataType,
-    ) -> Result<impl Display + use<>, ArrowError> {
+    ) -> Result<impl Display + use<>, Box<dyn std::error::Error>> {
         let mut device_array = ArrowDeviceArray::new_cpu();
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
         let (stream_view, resource_ref) = expect_stream_and_resource(&stream, &resource);
 
-        let data = unsafe {
+        unsafe {
             let device_array_ptr = &mut device_array as *mut ArrowDeviceArray as *mut u8;
-            column_view.to_arrow_array(device_array_ptr, stream_view, resource_ref);
-
-            from_ffi_and_data_type(device_array.array, data_type).expect("ffi data should be valid")
-        };
+            ffi::to_arrow_host_column(column_view, device_array_ptr, stream_view, resource_ref)?;
+        }
+        let data = unsafe { from_ffi_and_data_type(device_array.array, data_type)? };
 
         let array = make_array(data);
-        pretty_format_columns("test", &[array])
+        Ok(pretty_format_columns("test", &[array])?)
     }
 }

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -7,13 +7,9 @@
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
-#include <cudf/interop.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/stream_compaction.hpp>
-#include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/version_config.hpp>
-
-#include <nanoarrow/nanoarrow.h>
 
 #include <functional>
 #include <limits>
@@ -22,28 +18,6 @@
 #include <unordered_map>
 
 namespace libcudf_bridge {
-    // Factory functions
-    std::unique_ptr<Table> create_empty_table() {
-        auto table = std::make_unique<Table>();
-        std::vector<std::unique_ptr<cudf::column> > columns;
-        table->inner = std::make_unique<cudf::table>(std::move(columns));
-        return table;
-    }
-
-    std::unique_ptr<Table> create_table_from_columns_move(rust::Slice<Column *const> columns) {
-        std::vector<std::unique_ptr<cudf::column> > cudf_columns;
-        cudf_columns.reserve(columns.size());
-
-        // Take ownership of columns by moving from each pointer
-        for (auto *col: columns) {
-            cudf_columns.push_back(std::move(col->inner));
-        }
-
-        auto table = std::make_unique<Table>();
-        table->inner = std::make_unique<cudf::table>(std::move(cudf_columns));
-        return table;
-    }
-
     std::unique_ptr<Table> concat_table_views(
         rust::Slice<const std::unique_ptr<TableView>> views,
         const CudaStreamView &stream,
@@ -234,39 +208,4 @@ namespace libcudf_bridge {
         return {version.str()};
     }
 
-    bool config_default_pinned_memory_resource(size_t pool_size_bytes) {
-        return cudf::config_default_pinned_memory_resource({.pool_size = pool_size_bytes});
-    }
-
-    void set_allocate_host_as_pinned_threshold(size_t threshold_bytes) {
-        cudf::set_allocate_host_as_pinned_threshold(threshold_bytes);
-    }
-
-    // Arrow interop - convert Arrow data to cuDF table
-    std::unique_ptr<Table> table_from_arrow_host(
-        uint8_t const *schema_ptr,
-        uint8_t const *device_array_ptr,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr) {
-        auto *schema = reinterpret_cast<const ArrowSchema *>(schema_ptr);
-        auto *device_array = reinterpret_cast<const ArrowDeviceArray *>(device_array_ptr);
-
-        auto result = std::make_unique<Table>();
-        result->inner = cudf::from_arrow_host(schema, device_array, stream.inner, mr.inner);
-        return result;
-    }
-
-    // Arrow interop - convert Arrow array to cuDF column
-    std::unique_ptr<Column> column_from_arrow(
-        uint8_t const *schema_ptr,
-        uint8_t const *array_ptr,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr) {
-        auto *schema = reinterpret_cast<const ArrowSchema *>(schema_ptr);
-        auto *array = reinterpret_cast<const ArrowArray *>(array_ptr);
-
-        auto result = std::make_unique<Column>();
-        result->inner = cudf::from_arrow_column(schema, array, stream.inner, mr.inner);
-        return result;
-    }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -9,29 +9,11 @@
 #include "stream.h"
 #include "memory_resource.h"
 
-// Forward declarations of Arrow C ABI types
-struct ArrowSchema;
-struct ArrowDeviceArray;
-struct ArrowArray;
-
 namespace libcudf_bridge {
     // Direct cuDF operations exposed through bridge-owned return types.
     std::unique_ptr<Table> apply_boolean_mask(
         const TableView &table,
         const ColumnView &boolean_mask,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr);
-
-    // Arrow interop - direct cuDF calls
-    std::unique_ptr<Table> table_from_arrow_host(
-        uint8_t const *schema_ptr,
-        uint8_t const *device_array_ptr,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr);
-
-    std::unique_ptr<Column> column_from_arrow(
-        uint8_t const *schema_ptr,
-        uint8_t const *array_ptr,
         const CudaStreamView &stream,
         const DeviceAsyncResourceRef &mr);
 
@@ -98,9 +80,4 @@ namespace libcudf_bridge {
     // Utility functions
     rust::String get_cudf_version();
 
-    // Configure cuDF's default pinned-memory resource pool.
-    bool config_default_pinned_memory_resource(size_t pool_size_bytes);
-
-    // Set cuDF's host allocation threshold for pinned memory.
-    void set_allocate_host_as_pinned_threshold(size_t threshold_bytes);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/pinned_memory.cpp
+++ b/libcudf-sys/src/pinned_memory.cpp
@@ -1,0 +1,26 @@
+#include "pinned_memory.h"
+#include "libcudf-sys/src/lib.rs.h"
+
+namespace libcudf_bridge {
+    PinnedMrOptions::PinnedMrOptions() = default;
+
+    PinnedMrOptions::PinnedMrOptions(const std::size_t pool_size)
+        : inner{.pool_size = pool_size} {}
+
+    std::unique_ptr<PinnedMrOptions> make_pinned_mr_options() {
+        return std::make_unique<PinnedMrOptions>();
+    }
+
+    std::unique_ptr<PinnedMrOptions> make_pinned_mr_options_with_pool_size(
+        const std::size_t pool_size) {
+        return std::make_unique<PinnedMrOptions>(pool_size);
+    }
+
+    bool config_default_pinned_memory_resource(const PinnedMrOptions& options) {
+        return cudf::config_default_pinned_memory_resource(options.inner);
+    }
+
+    void set_allocate_host_as_pinned_threshold(const std::size_t threshold_bytes) {
+        cudf::set_allocate_host_as_pinned_threshold(threshold_bytes);
+    }
+}  // namespace libcudf_bridge

--- a/libcudf-sys/src/pinned_memory.h
+++ b/libcudf-sys/src/pinned_memory.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include <cudf/utilities/pinned_memory.hpp>
+
+namespace libcudf_bridge {
+    // cxx cannot represent std::optional<size_t>, so this wrapper preserves
+    // cudf::pinned_mr_options without introducing defaults in the bridge.
+    struct PinnedMrOptions {
+        cudf::pinned_mr_options inner;
+
+        PinnedMrOptions();
+        explicit PinnedMrOptions(std::size_t pool_size);
+    };
+
+    std::unique_ptr<PinnedMrOptions> make_pinned_mr_options();
+
+    std::unique_ptr<PinnedMrOptions> make_pinned_mr_options_with_pool_size(
+        std::size_t pool_size);
+
+    bool config_default_pinned_memory_resource(const PinnedMrOptions& options);
+
+    void set_allocate_host_as_pinned_threshold(std::size_t threshold_bytes);
+}  // namespace libcudf_bridge

--- a/libcudf-sys/src/scalar.cpp
+++ b/libcudf-sys/src/scalar.cpp
@@ -2,12 +2,7 @@
 #include "data_type.h"
 #include "libcudf-sys/src/lib.rs.h"
 
-#include <cudf/interop.hpp>
 #include <cudf/scalar/scalar.hpp>
-#include <cudf/column/column_factories.hpp>
-#include <cudf/types.hpp>
-#include <nanoarrow/nanoarrow.h>
-#include <nanoarrow/nanoarrow_device.h>
 #include <stdexcept>
 
 namespace libcudf_bridge {
@@ -17,144 +12,20 @@ namespace libcudf_bridge {
 
     Scalar::~Scalar() = default;
 
-    // Get the scalar's data as an FFI Arrow Array
-    void Scalar::to_arrow_array(
-        uint8_t *out_array_ptr,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr) const {
-        if (!inner) {
-            throw std::runtime_error("Cannot convert null column view to arrow array");
-        }
-        std::unique_ptr<cudf::column> single_element_col =
-            cudf::make_column_from_scalar(*inner, 1, stream.inner, mr.inner);
-        auto device_array_unique = cudf::to_arrow_host(single_element_col->view(), stream.inner, mr.inner);
-        auto *out_array = reinterpret_cast<ArrowDeviceArray*>(out_array_ptr);
-        *out_array = *device_array_unique.get();
-        device_array_unique.release();
-    }
-
     // Check if the scalar is valid (not null)
-    bool Scalar::is_valid() const {
+    bool Scalar::is_valid(const CudaStreamView& stream) const {
         if (!inner) {
-            return false;
+            throw std::runtime_error("Cannot inspect validity of null scalar");
         }
-        return inner->is_valid();
+        return inner->is_valid(stream.inner);
     }
 
     // Get the data type of the scalar
-    [[nodiscard]] std::unique_ptr<DataType> Scalar::data_type() const {
-        auto dtype = inner->type();
-        auto type_id = static_cast<int32_t>(dtype.id());
-
-        // Only pass scale for decimal types
-        if (dtype.id() == cudf::type_id::DECIMAL32 ||
-            dtype.id() == cudf::type_id::DECIMAL64 ||
-            dtype.id() == cudf::type_id::DECIMAL128) {
-            return std::make_unique<DataType>(type_id, dtype.scale());
-        } else {
-            return std::make_unique<DataType>(type_id);
-        }
-    }
-
-    // Clone this scalar (deep copy)
-    [[nodiscard]] std::unique_ptr<Scalar> Scalar::clone() const {
-        auto cloned = std::make_unique<Scalar>();
-
+    [[nodiscard]] std::unique_ptr<DataType> Scalar::type() const {
         if (!inner) {
-            return cloned;
+            throw std::runtime_error("Cannot get data type of null scalar");
         }
-
-        // Get the scalar's type to determine which derived class to instantiate
-        auto dtype = inner->type();
-
-        // Create a new scalar of the same type using the polymorphic copy constructor
-        // We use a switch to dispatch to the correct derived type's copy constructor
-        switch (dtype.id()) {
-            case cudf::type_id::INT8:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<int8_t>>(
-                    static_cast<cudf::numeric_scalar<int8_t> const&>(*inner));
-                break;
-            case cudf::type_id::INT16:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<int16_t>>(
-                    static_cast<cudf::numeric_scalar<int16_t> const&>(*inner));
-                break;
-            case cudf::type_id::INT32:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<int32_t>>(
-                    static_cast<cudf::numeric_scalar<int32_t> const&>(*inner));
-                break;
-            case cudf::type_id::INT64:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<int64_t>>(
-                    static_cast<cudf::numeric_scalar<int64_t> const&>(*inner));
-                break;
-            case cudf::type_id::UINT8:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<uint8_t>>(
-                    static_cast<cudf::numeric_scalar<uint8_t> const&>(*inner));
-                break;
-            case cudf::type_id::UINT16:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<uint16_t>>(
-                    static_cast<cudf::numeric_scalar<uint16_t> const&>(*inner));
-                break;
-            case cudf::type_id::UINT32:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<uint32_t>>(
-                    static_cast<cudf::numeric_scalar<uint32_t> const&>(*inner));
-                break;
-            case cudf::type_id::UINT64:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<uint64_t>>(
-                    static_cast<cudf::numeric_scalar<uint64_t> const&>(*inner));
-                break;
-            case cudf::type_id::FLOAT32:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<float>>(
-                    static_cast<cudf::numeric_scalar<float> const&>(*inner));
-                break;
-            case cudf::type_id::FLOAT64:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<double>>(
-                    static_cast<cudf::numeric_scalar<double> const&>(*inner));
-                break;
-            case cudf::type_id::BOOL8:
-                cloned->inner = std::make_unique<cudf::numeric_scalar<bool>>(
-                    static_cast<cudf::numeric_scalar<bool> const&>(*inner));
-                break;
-            case cudf::type_id::STRING:
-                cloned->inner = std::make_unique<cudf::string_scalar>(
-                    static_cast<cudf::string_scalar const&>(*inner));
-                break;
-            case cudf::type_id::DECIMAL32:
-                cloned->inner = std::make_unique<cudf::fixed_point_scalar<numeric::decimal32>>(
-                    static_cast<cudf::fixed_point_scalar<numeric::decimal32> const&>(*inner));
-                break;
-            case cudf::type_id::DECIMAL64:
-                cloned->inner = std::make_unique<cudf::fixed_point_scalar<numeric::decimal64>>(
-                    static_cast<cudf::fixed_point_scalar<numeric::decimal64> const&>(*inner));
-                break;
-            case cudf::type_id::DECIMAL128:
-                cloned->inner = std::make_unique<cudf::fixed_point_scalar<numeric::decimal128>>(
-                    static_cast<cudf::fixed_point_scalar<numeric::decimal128> const&>(*inner));
-                break;
-            case cudf::type_id::TIMESTAMP_DAYS:
-                cloned->inner = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
-                    static_cast<cudf::timestamp_scalar<cudf::timestamp_D> const&>(*inner));
-                break;
-            case cudf::type_id::TIMESTAMP_SECONDS:
-                cloned->inner = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_s>>(
-                    static_cast<cudf::timestamp_scalar<cudf::timestamp_s> const&>(*inner));
-                break;
-            case cudf::type_id::TIMESTAMP_MILLISECONDS:
-                cloned->inner = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ms>>(
-                    static_cast<cudf::timestamp_scalar<cudf::timestamp_ms> const&>(*inner));
-                break;
-            case cudf::type_id::TIMESTAMP_MICROSECONDS:
-                cloned->inner = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_us>>(
-                    static_cast<cudf::timestamp_scalar<cudf::timestamp_us> const&>(*inner));
-                break;
-            case cudf::type_id::TIMESTAMP_NANOSECONDS:
-                cloned->inner = std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ns>>(
-                    static_cast<cudf::timestamp_scalar<cudf::timestamp_ns> const&>(*inner));
-                break;
-            // Add more types as needed
-            default:
-                throw std::runtime_error("Unsupported scalar type for cloning");
-        }
-
-        return cloned;
+        return std::make_unique<DataType>(inner->type());
     }
+
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/scalar.h
+++ b/libcudf-sys/src/scalar.h
@@ -23,19 +23,11 @@ namespace libcudf_bridge {
 
         ~Scalar();
 
-        // Get the scalar's data as an FFI Arrow Array
-        void to_arrow_array(
-            uint8_t *out_array_ptr,
-            const CudaStreamView &stream,
-            const DeviceAsyncResourceRef &mr) const;
-
         // Check if the scalar is valid (not null)
-        [[nodiscard]] bool is_valid() const;
+        [[nodiscard]] bool is_valid(const CudaStreamView& stream) const;
 
         // Get the data type of the scalar
-        [[nodiscard]] std::unique_ptr<DataType> data_type() const;
+        [[nodiscard]] std::unique_ptr<DataType> type() const;
 
-        // Clone this scalar (deep copy)
-        [[nodiscard]] std::unique_ptr<Scalar> clone() const;
     };
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/stream.cpp
+++ b/libcudf-sys/src/stream.cpp
@@ -21,6 +21,12 @@ namespace libcudf_bridge {
             static_cast<uint32_t>(cuda::event_flags::blocking_sync) == cudaEventBlockingSync);
         static_assert(
             static_cast<uint32_t>(cuda::event_flags::interprocess) == cudaEventInterprocess);
+        static_assert(static_cast<int32_t>(cudaMemcpyHostToHost) == 0);
+        static_assert(static_cast<int32_t>(cudaMemcpyHostToDevice) == 1);
+        static_assert(static_cast<int32_t>(cudaMemcpyDeviceToHost) == 2);
+        static_assert(static_cast<int32_t>(cudaMemcpyDeviceToDevice) == 3);
+        static_assert(static_cast<int32_t>(cudaMemcpyDefault) == 4);
+        static_assert(static_cast<int32_t>(cudaSuccess) == 0);
 
         [[nodiscard]] rmm::cuda_stream::flags to_rmm_flags(const uint32_t flags) {
             return static_cast<rmm::cuda_stream::flags>(flags);
@@ -160,5 +166,21 @@ namespace libcudf_bridge {
 
     void cuda_set_device(const int32_t device_id) {
         RMM_CUDA_TRY(cudaSetDevice(device_id));
+    }
+
+    int32_t cuda_memcpy(
+        const uintptr_t destination,
+        const uintptr_t source,
+        const size_t count,
+        const int32_t kind) {
+        return static_cast<int32_t>(cudaMemcpy(
+            reinterpret_cast<void*>(destination),
+            reinterpret_cast<void const*>(source),
+            count,
+            static_cast<cudaMemcpyKind>(kind)));
+    }
+
+    rust::String cuda_get_error_string(const int32_t error) {
+        return rust::String(cudaGetErrorString(static_cast<cudaError_t>(error)));
     }
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/stream.h
+++ b/libcudf-sys/src/stream.h
@@ -7,6 +7,7 @@
 #include <cuda_runtime_api.h>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include "rust/cxx.h"
 
 namespace libcudf_bridge {
     struct CudaEvent;
@@ -117,4 +118,13 @@ namespace libcudf_bridge {
 
     /// Set the current CUDA device ordinal.
     void cuda_set_device(int32_t device_id);
+
+    /// Direct wrapper for cudaMemcpy. Pointer values are integer-encoded for cxx.
+    int32_t cuda_memcpy(uintptr_t destination,
+                        uintptr_t source,
+                        size_t count,
+                        int32_t kind);
+
+    /// Direct wrapper for cudaGetErrorString.
+    rust::String cuda_get_error_string(int32_t error);
 } // namespace libcudf_bridge

--- a/libcudf-sys/src/table.cpp
+++ b/libcudf-sys/src/table.cpp
@@ -5,28 +5,56 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <nanoarrow/nanoarrow.h>
-#include <nanoarrow/nanoarrow_device.h>
-
-#include "cudf/interop.hpp"
 
 namespace libcudf_bridge {
+    std::unique_ptr<Table> create_empty_table() {
+        auto table = std::make_unique<Table>();
+        table->inner = std::make_unique<cudf::table>(
+            std::vector<std::unique_ptr<cudf::column>>{});
+        return table;
+    }
+
+    std::unique_ptr<Table> create_table_from_columns_move(
+        const rust::Slice<Column *const> columns) {
+        std::vector<std::unique_ptr<cudf::column>> cudf_columns;
+        cudf_columns.reserve(columns.size());
+        for (auto* column : columns) {
+            if (column == nullptr || !column->inner) {
+                throw std::invalid_argument("Cannot move a null column into a table");
+            }
+            cudf_columns.push_back(std::move(column->inner));
+        }
+
+        auto table = std::make_unique<Table>();
+        table->inner = std::make_unique<cudf::table>(std::move(cudf_columns));
+        return table;
+    }
+
+    ColumnRef::ColumnRef(const cudf::column& column) : inner(&column) {}
+
+    size_t ColumnRef::alloc_size() const {
+        if (!inner) {
+            throw std::runtime_error("Cannot get allocation size of null column reference");
+        }
+        return inner->alloc_size();
+    }
+
     // Table implementation
     Table::Table() : inner(nullptr) {
     }
 
     Table::~Table() = default;
 
-    size_t Table::num_columns() const {
+    int32_t Table::num_columns() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get column count of null table");
         }
         return inner->num_columns();
     }
 
-    size_t Table::num_rows() const {
+    int32_t Table::num_rows() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get row count of null table");
         }
         return inner->num_rows();
     }
@@ -40,7 +68,14 @@ namespace libcudf_bridge {
         return result;
     }
 
-    std::unique_ptr<ColumnVectorHelper> Table::release() const {
+    std::unique_ptr<ColumnRef> Table::get_column(const int32_t index) const {
+        if (!inner) {
+            throw std::runtime_error("Cannot get column from null table");
+        }
+        return std::make_unique<ColumnRef>(inner->get_column(index));
+    }
+
+    std::unique_ptr<ColumnVectorHelper> Table::release() {
         if (!inner) {
             throw std::runtime_error("Cannot release columns from null table");
         }
@@ -60,16 +95,16 @@ namespace libcudf_bridge {
 
     TableView::~TableView() = default;
 
-    size_t TableView::num_columns() const {
+    int32_t TableView::num_columns() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get column count of null table view");
         }
         return inner->num_columns();
     }
 
-    size_t TableView::num_rows() const {
+    int32_t TableView::num_rows() const {
         if (!inner) {
-            return 0;
+            throw std::runtime_error("Cannot get row count of null table view");
         }
         return inner->num_rows();
     }
@@ -81,9 +116,6 @@ namespace libcudf_bridge {
         std::vector<cudf::size_type> indices;
         indices.reserve(column_indices.size());
         for (const auto idx: column_indices) {
-            if (idx < 0 || idx >= inner->num_columns()) {
-                throw std::out_of_range("Column index out of bounds in select");
-            }
             indices.emplace_back(idx);
         }
 
@@ -96,45 +128,17 @@ namespace libcudf_bridge {
         if (!inner) {
             throw std::runtime_error("Cannot get column from null table view");
         }
-        if (index < 0 || index >= inner->num_columns()) {
-            throw std::out_of_range("Column index out of bounds");
-        }
         auto result = std::make_unique<ColumnView>();
         result->inner = std::make_unique<cudf::column_view>(inner->column(index));
         return result;
     }
 
-    void TableView::to_arrow_schema(uint8_t *out_schema_ptr) const {
-        if (!inner) {
-            throw std::runtime_error("Cannot convert null table view to arrow schema");
+    std::unique_ptr<TableView> table_view_clone(const TableView& view) {
+        if (!view.inner) {
+            throw std::runtime_error("Cannot clone null table view");
         }
-        std::vector<cudf::column_metadata> metadata(this->inner->num_columns());
-        auto schema_unique =
-                cudf::to_arrow_schema(*this->inner, cudf::host_span<cudf::column_metadata const>(metadata));
-        auto *out_schema = reinterpret_cast<ArrowSchema *>(out_schema_ptr);
-        *out_schema = *schema_unique.get();
-        schema_unique.release();
-    }
-
-    void TableView::to_arrow_array(
-        uint8_t *out_array_ptr,
-        const CudaStreamView &stream,
-        const DeviceAsyncResourceRef &mr) const {
-        if (!inner) {
-            throw std::runtime_error("Cannot convert null table view to arrow array");
-        }
-        auto device_array_unique = cudf::to_arrow_host(*this->inner, stream.inner, mr.inner);
-        auto *out_array = reinterpret_cast<ArrowArray *>(out_array_ptr);
-        // Extract just the ArrowArray from the ArrowDeviceArray
-        *out_array = device_array_unique->array;
-        device_array_unique.release();
-    }
-
-    [[nodiscard]] std::unique_ptr<TableView> TableView::clone() const {
         auto cloned = std::make_unique<TableView>();
-        if (inner) {
-            cloned->inner = std::make_unique<cudf::table_view>(*inner);
-        }
+        cloned->inner = std::make_unique<cudf::table_view>(*view.inner);
         return cloned;
     }
 
@@ -144,6 +148,9 @@ namespace libcudf_bridge {
         views.reserve(column_views.size());
 
         for (const auto *col_view_ptr: column_views) {
+            if (col_view_ptr == nullptr || !col_view_ptr->inner) {
+                throw std::invalid_argument("Cannot create a table view from a null column view");
+            }
             views.push_back(*col_view_ptr->inner);
         }
 

--- a/libcudf-sys/src/table.h
+++ b/libcudf-sys/src/table.h
@@ -13,6 +13,16 @@ namespace libcudf_bridge {
     // Forward declaration
     struct ColumnVectorHelper;
 
+    // cxx cannot return `cudf::column const&` directly. This mechanical wrapper
+    // must not outlive the Table that owns the referenced column.
+    struct ColumnRef {
+        const cudf::column* inner;
+
+        explicit ColumnRef(const cudf::column& column);
+
+        [[nodiscard]] size_t alloc_size() const;
+    };
+
     // Opaque wrapper for cuDF table_view
     struct TableView {
         std::unique_ptr<cudf::table_view> inner;
@@ -22,10 +32,10 @@ namespace libcudf_bridge {
         ~TableView();
 
         // Get number of columns
-        [[nodiscard]] size_t num_columns() const;
+        [[nodiscard]] int32_t num_columns() const;
 
         // Get number of rows
-        [[nodiscard]] size_t num_rows() const;
+        [[nodiscard]] int32_t num_rows() const;
 
         // Select specific columns by indices
         [[nodiscard]] std::unique_ptr<TableView> select(rust::Slice<const int32_t> column_indices) const;
@@ -33,17 +43,6 @@ namespace libcudf_bridge {
         // Get column view at index
         [[nodiscard]] std::unique_ptr<ColumnView> column(int32_t index) const;
 
-        // Get the columns' data types as an FFI Arrow Schema
-        void to_arrow_schema(uint8_t *out_schema_ptr) const;
-
-        // Get the columns' data as an FFI Arrow Array
-        void to_arrow_array(
-            uint8_t *out_array_ptr,
-            const CudaStreamView &stream,
-            const DeviceAsyncResourceRef &mr) const;
-
-        // Clone this table view
-        [[nodiscard]] std::unique_ptr<TableView> clone() const;
     };
 
     // Opaque wrapper for cuDF table
@@ -55,15 +54,18 @@ namespace libcudf_bridge {
         ~Table();
 
         // Get number of columns
-        [[nodiscard]] size_t num_columns() const;
+        [[nodiscard]] int32_t num_columns() const;
 
         // Get number of rows
-        [[nodiscard]] size_t num_rows() const;
+        [[nodiscard]] int32_t num_rows() const;
 
         // Get a view of this table
         [[nodiscard]] std::unique_ptr<TableView> view() const;
 
-        [[nodiscard]] std::unique_ptr<ColumnVectorHelper> release() const;
+        // Get a const column reference at index
+        [[nodiscard]] std::unique_ptr<ColumnRef> get_column(int32_t index) const;
+
+        [[nodiscard]] std::unique_ptr<ColumnVectorHelper> release();
     };
 
     // Table factory functions
@@ -72,5 +74,7 @@ namespace libcudf_bridge {
     std::unique_ptr<Table> create_table_from_columns_move(rust::Slice<Column *const> columns);
 
     // TableView factory functions
+    std::unique_ptr<TableView> table_view_clone(const TableView& view);
+
     std::unique_ptr<TableView> create_table_view_from_column_views(rust::Slice<const ColumnView *const> column_views);
 } // namespace libcudf_bridge

--- a/src/binary_op.rs
+++ b/src/binary_op.rs
@@ -140,7 +140,7 @@ pub fn cudf_binary_op(
         }
     }?;
     Ok(CuDFColumnViewOrScalar::ColumnView(
-        CuDFColumn::new(result).into_view(),
+        CuDFColumn::try_from_inner(result)?.into_view(),
     ))
 }
 
@@ -159,8 +159,8 @@ mod tests {
         let array1 = Decimal128Array::from(values1).with_precision_and_scale(38, 2)?;
         let array2 = Decimal128Array::from(values2).with_precision_and_scale(38, 2)?;
 
-        let col1 = CuDFColumn::from_arrow_host(&array1)?;
-        let col2 = CuDFColumn::from_arrow_host(&array2)?;
+        let col1 = CuDFColumn::try_from_arrow_host(&array1)?;
+        let col2 = CuDFColumn::try_from_arrow_host(&array2)?;
 
         // Add the two decimal columns
         let result = cudf_binary_op(
@@ -200,8 +200,8 @@ mod tests {
         let price_array = Decimal128Array::from(prices).with_precision_and_scale(38, 2)?;
         let qty_array = Decimal128Array::from(quantities).with_precision_and_scale(38, 0)?;
 
-        let col_price = CuDFColumn::from_arrow_host(&price_array)?;
-        let col_qty = CuDFColumn::from_arrow_host(&qty_array)?;
+        let col_price = CuDFColumn::try_from_arrow_host(&price_array)?;
+        let col_qty = CuDFColumn::try_from_arrow_host(&qty_array)?;
 
         // Multiply: result should have scale = 2 + 0 = 2
         let result = cudf_binary_op(

--- a/src/column.rs
+++ b/src/column.rs
@@ -14,16 +14,36 @@ use std::sync::Arc;
 ///
 /// This is a safe wrapper around cuDF's column type.
 pub struct CuDFColumn {
+    view: Arc<UniquePtr<ffi::ColumnView>>,
     pub(crate) inner: UniquePtr<libcudf_sys::ffi::Column>,
+    metadata: crate::column_view::ColumnViewMetadata,
 }
 
 impl CuDFColumn {
-    pub fn new(inner: UniquePtr<libcudf_sys::ffi::Column>) -> Self {
-        Self { inner }
+    pub(crate) fn try_from_inner(
+        inner: UniquePtr<libcudf_sys::ffi::Column>,
+    ) -> Result<Self, CuDFError> {
+        if inner.is_null() {
+            return Err(CuDFError::NullHandle("column"));
+        }
+        let device_memory_size = inner.alloc_size()?;
+        // `inner` is stored alongside the view and therefore outlives it.
+        let view = unsafe { inner.view() }?;
+        let metadata = crate::column_view::column_view_metadata(&view, Some(device_memory_size))?;
+        Ok(Self {
+            inner,
+            view: Arc::new(view),
+            metadata,
+        })
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.inner.size()
+        self.metadata.len()
+    }
+
+    /// Return the bytes allocated for this column in device memory.
+    pub fn device_memory_size(&self) -> usize {
+        self.metadata.device_memory_size()
     }
 
     /// Convert an Arrow array to a cuDF column
@@ -43,11 +63,11 @@ impl CuDFColumn {
     /// use libcudf_rs::CuDFColumn;
     ///
     /// let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-    /// let column = CuDFColumn::from_arrow_host(&array)?;
+    /// let column = CuDFColumn::try_from_arrow_host(&array)?;
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
-    pub fn from_arrow_host(array: &dyn Array) -> Result<Self, CuDFError> {
-        crate::config::ensure_pools_configured();
+    pub fn try_from_arrow_host(array: &dyn Array) -> Result<Self, CuDFError> {
+        crate::config::ensure_pools_configured()?;
         if arrow_type_to_cudf(array.data_type()).is_none() {
             return Err(CuDFError::ArrowError(ArrowError::NotYetImplemented(
                 format!("Arrow type {} not supported in CuDF", array.data_type()),
@@ -64,14 +84,14 @@ impl CuDFColumn {
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
         let inner = unsafe {
-            ffi::column_from_arrow(
+            ffi::from_arrow_column(
                 schema_ptr,
                 array_ptr,
                 stream_ref(&stream)?,
                 resource_ref(&mr)?,
             )
         }?;
-        Ok(Self { inner })
+        Self::try_from_inner(inner)
     }
 
     /// Create a column by repeating a scalar value.
@@ -79,23 +99,24 @@ impl CuDFColumn {
     /// # Errors
     ///
     /// Returns an error if the column cannot be allocated on the GPU.
-    pub fn from_scalar(scalar: &CuDFScalar, len: usize) -> Result<Self, CuDFError> {
-        crate::config::ensure_pools_configured();
+    pub fn try_from_scalar(scalar: &CuDFScalar, len: usize) -> Result<Self, CuDFError> {
+        crate::config::ensure_pools_configured()?;
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        Ok(Self::new(ffi::make_column_from_scalar(
+        Self::try_from_inner(ffi::make_column_from_scalar(
             scalar.inner(),
             len,
             stream_ref(&stream)?,
             resource_ref(&mr)?,
-        )?))
+        )?)
     }
 
     /// Return a [CuDFColumnView] pointing to this [CuDFColumn]. The current [CuDFColumn] will
     /// be kept alive at least until the [CuDFColumnView] is dropped.
     pub fn view(self: Arc<Self>) -> CuDFColumnView {
-        let view = self.inner.view();
-        CuDFColumnView::new_with_ref(view, Some(self))
+        let view = Arc::clone(&self.view);
+        let metadata = self.metadata.clone();
+        CuDFColumnView::from_shared_view(view, Some(self), metadata)
     }
 
     /// Consumes the current [CuDFColumn], returning a [CuDFColumnView] pointing to it.
@@ -105,22 +126,17 @@ impl CuDFColumn {
 
     /// Concatenate multiple [CuDFColumnView]s into a single [CuDFColumn].
     pub fn concat(views: Vec<CuDFColumnView>) -> Result<Self, CuDFError> {
-        // Keep the references alive until the concat_column_views operation has completed.
-        let mut _refs = Vec::with_capacity(views.len());
-        let views = views
-            .into_iter()
-            .map(|x| {
-                _refs.push(x._ref.clone());
-                x.into_inner()
-            })
-            .collect::<Vec<_>>();
+        let inner_views = views
+            .iter()
+            .map(CuDFColumnView::clone_inner)
+            .collect::<Result<Vec<_>, _>>()?;
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
-        Ok(Self::new(libcudf_sys::ffi::concat_column_views(
-            &views,
+        Self::try_from_inner(libcudf_sys::ffi::concat_column_views(
+            &inner_views,
             stream_ref(&stream)?,
             resource_ref(&mr)?,
-        )?))
+        )?)
     }
 }
 
@@ -132,7 +148,7 @@ mod tests {
     #[test]
     fn test_column_from_arrow_int32() {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -143,7 +159,7 @@ mod tests {
     #[test]
     fn test_column_from_arrow_string() {
         let array = StringArray::from(vec!["hello", "world", "test"]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -154,7 +170,7 @@ mod tests {
     #[test]
     fn test_column_from_arrow_with_nulls() {
         let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -165,7 +181,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_int64() {
         let original = Int64Array::from(vec![100, 200, 300, 400, 500]);
-        let column = CuDFColumn::from_arrow_host(&original)
+        let column = CuDFColumn::try_from_arrow_host(&original)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -187,7 +203,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_float64() {
         let original = Float64Array::from(vec![1.5, 2.5, 3.5, 4.5, 5.5]);
-        let column = CuDFColumn::from_arrow_host(&original)
+        let column = CuDFColumn::try_from_arrow_host(&original)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -209,7 +225,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_string() {
         let original = StringArray::from(vec!["hello", "world", "test", "cudf", "rust"]);
-        let column = CuDFColumn::from_arrow_host(&original)
+        let column = CuDFColumn::try_from_arrow_host(&original)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -231,7 +247,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_with_nulls() {
         let original = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let column = CuDFColumn::from_arrow_host(&original)
+        let column = CuDFColumn::try_from_arrow_host(&original)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -262,7 +278,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_empty() {
         let original = Int32Array::from(Vec::<i32>::new());
-        let column = CuDFColumn::from_arrow_host(&original)
+        let column = CuDFColumn::try_from_arrow_host(&original)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -277,7 +293,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_roundtrip_preserves_data() {
         let original = Int32Array::from(vec![10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
-        let column = CuDFColumn::from_arrow_host(&original)
+        let column = CuDFColumn::try_from_arrow_host(&original)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -13,6 +13,30 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, OnceLock};
 
+const CUDF_NULL_MASK_PADDING: usize = 64;
+
+#[derive(Clone)]
+pub(crate) struct ColumnViewMetadata {
+    dt: DataType,
+    len: usize,
+    offset: usize,
+    null_count: usize,
+    nullable: bool,
+    buffer_memory_size: usize,
+    array_memory_size: usize,
+    device_memory_size: usize,
+}
+
+impl ColumnViewMetadata {
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn device_memory_size(&self) -> usize {
+        self.device_memory_size
+    }
+}
+
 /// A view into a cuDF column stored in GPU memory
 ///
 /// This type wraps a cuDF column_view and implements Arrow's Array trait,
@@ -22,10 +46,10 @@ use std::sync::{Arc, OnceLock};
 /// column alive. It can be created from Arrow arrays (copying to GPU) or from
 /// existing cuDF columns.
 pub struct CuDFColumnView {
-    // Keep a ref to CuDF structs so that they live as long as this view exists
-    pub(crate) _ref: Option<Arc<dyn CuDFRef>>,
-    inner: UniquePtr<ffi::ColumnView>,
-    dt: DataType,
+    inner: Arc<UniquePtr<ffi::ColumnView>>,
+    // Keep cuDF owners alive until after the non-owning view is dropped.
+    pub(crate) keepalive: Option<Arc<dyn CuDFRef>>,
+    metadata: ColumnViewMetadata,
     null_buf: OnceLock<Option<NullBuffer>>,
 }
 
@@ -33,17 +57,36 @@ impl CuDFColumnView {
     /// Create a [CuDFColumnView] from a column view and optional table reference
     ///
     /// This is used internally to create column views that keep the source table or column alive
-    pub(crate) fn new_with_ref(
+    pub(crate) fn try_from_inner(
         inner: UniquePtr<ffi::ColumnView>,
-        _ref: Option<Arc<dyn CuDFRef>>,
+        keepalive: Option<Arc<dyn CuDFRef>>,
+    ) -> Result<Self, CuDFError> {
+        Self::try_from_inner_with_device_size(inner, keepalive, None)
+    }
+
+    pub(crate) fn try_from_inner_with_device_size(
+        inner: UniquePtr<ffi::ColumnView>,
+        keepalive: Option<Arc<dyn CuDFRef>>,
+        device_memory_size: Option<usize>,
+    ) -> Result<Self, CuDFError> {
+        let metadata = column_view_metadata(&inner, device_memory_size)?;
+        Ok(Self {
+            inner: Arc::new(inner),
+            keepalive,
+            metadata,
+            null_buf: OnceLock::new(),
+        })
+    }
+
+    pub(crate) fn from_shared_view(
+        inner: Arc<UniquePtr<ffi::ColumnView>>,
+        keepalive: Option<Arc<dyn CuDFRef>>,
+        metadata: ColumnViewMetadata,
     ) -> Self {
-        let cudf_dtype = inner.data_type();
-        let dt = cudf_type_to_arrow(&cudf_dtype);
-        let dt = dt.unwrap_or(DataType::Null);
         Self {
-            _ref,
             inner,
-            dt,
+            keepalive,
+            metadata,
             null_buf: OnceLock::new(),
         }
     }
@@ -52,19 +95,25 @@ impl CuDFColumnView {
         &self.inner
     }
 
-    /// Consume this wrapper and return the underlying cuDF column view
-    pub(crate) fn into_inner(self) -> UniquePtr<ffi::ColumnView> {
-        self.inner
+    pub(crate) fn clone_inner(&self) -> Result<UniquePtr<ffi::ColumnView>, CuDFError> {
+        let inner = self
+            .inner
+            .as_ref()
+            .as_ref()
+            .ok_or(CuDFError::NullHandle("column view"))?;
+        Ok(ffi::column_view_clone(inner)?)
     }
 
     /// Relabel this view's Arrow `DataType` without touching GPU memory.
     /// Used by [`record_batch_with_schema`](crate::record_batch_with_schema) to
     /// reconcile cuDF's max-precision decimals with declared schema types.
     pub fn with_data_type(self, dt: DataType) -> Self {
+        let mut metadata = self.metadata;
+        metadata.dt = dt;
         Self {
-            _ref: self._ref,
             inner: self.inner,
-            dt,
+            keepalive: self.keepalive,
+            metadata,
             null_buf: self.null_buf,
         }
     }
@@ -86,7 +135,7 @@ impl CuDFColumnView {
     /// use libcudf_rs::CuDFColumn;
     ///
     /// let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-    /// let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+    /// let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
     /// // Do some GPU processing...
     /// let result = column.to_arrow_host()?;
     /// # Ok::<(), libcudf_rs::CuDFError>(())
@@ -104,8 +153,13 @@ impl CuDFColumnView {
                 &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
             let stream = ffi::get_default_stream();
             let mr = ffi::get_current_device_resource_ref();
-            self.inner
-                .to_arrow_array(device_array_ptr, stream_ref(&stream)?, resource_ref(&mr)?);
+            ffi::to_arrow_host_column(
+                self.inner(),
+                device_array_ptr,
+                stream_ref(&stream)?,
+                resource_ref(&mr)?,
+            )?;
+            stream_ref(&stream)?.synchronize()?;
         }
 
         // Convert from FFI structures to Arrow ArrayData
@@ -118,25 +172,81 @@ impl CuDFColumnView {
 
     /// Return the device buffer memory used by this column view.
     pub fn get_buffer_memory_size(&self) -> Result<usize, CuDFError> {
-        let stream = ffi::get_default_stream();
-        Ok(self.inner().get_buffer_memory_size(stream_ref(&stream)?))
+        Ok(self.metadata.buffer_memory_size)
     }
 
     /// Return the total device memory used by this column view, including child buffers.
     pub fn get_array_memory_size(&self) -> Result<usize, CuDFError> {
+        Ok(self.metadata.array_memory_size)
+    }
+
+    /// Return the allocation retained by this view.
+    pub fn device_memory_size(&self) -> usize {
+        self.metadata.device_memory_size
+    }
+
+    /// Copy this view's physical null mask to host memory and cache it.
+    pub fn materialize_null_mask(&self) -> Result<(), CuDFError> {
+        if self.null_buf.get().is_some() {
+            return Ok(());
+        }
+        if self.metadata.null_count == 0 {
+            let _ = self.null_buf.set(None);
+            return Ok(());
+        }
         let stream = ffi::get_default_stream();
-        Ok(self.inner().get_array_memory_size(stream_ref(&stream)?))
+        stream_ref(&stream)?.synchronize()?;
+        let mask_bits = self
+            .metadata
+            .offset
+            .checked_add(self.metadata.len)
+            .ok_or_else(|| {
+                arrow_schema::ArrowError::ComputeError(
+                    "cuDF null-mask size overflowed usize".into(),
+                )
+            })?;
+        let mask_bits = i32::try_from(mask_bits).map_err(|_| {
+            arrow_schema::ArrowError::ComputeError(
+                "cuDF null-mask size exceeds cudf::size_type".into(),
+            )
+        })?;
+        let mask_size = ffi::bitmask_allocation_size_bytes(mask_bits, CUDF_NULL_MASK_PADDING);
+        let source = self.inner().null_mask()?;
+        if source == 0 {
+            return Err(CuDFError::NullHandle("column null mask"));
+        }
+        let mut null_bytes = vec![0; mask_size];
+        let status = unsafe {
+            ffi::cuda_memcpy(
+                null_bytes.as_mut_ptr() as usize,
+                source,
+                mask_size,
+                libcudf_sys::CUDA_MEMCPY_DEVICE_TO_HOST,
+            )
+        };
+        if status != libcudf_sys::CUDA_SUCCESS {
+            return Err(CuDFError::Cuda {
+                code: status,
+                message: ffi::cuda_get_error_string(status),
+            });
+        }
+        let buffer = Buffer::from_vec(null_bytes);
+        let nulls = NullBuffer::new(BooleanBuffer::new(
+            buffer,
+            self.metadata.offset,
+            self.metadata.len,
+        ));
+        let _ = self.null_buf.set(Some(nulls));
+        Ok(())
     }
 }
 
 impl Clone for CuDFColumnView {
     fn clone(&self) -> Self {
-        // Clone the view using the FFI clone method
-        let cloned_inner = self.inner.clone();
         Self {
-            _ref: self._ref.clone(),
-            inner: cloned_inner,
-            dt: self.dt.clone(),
+            inner: Arc::clone(&self.inner),
+            keepalive: self.keepalive.clone(),
+            metadata: self.metadata.clone(),
             null_buf: self.null_buf.clone(),
         }
     }
@@ -179,7 +289,7 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn data_type(&self) -> &DataType {
-        &self.dt
+        &self.metadata.dt
     }
 
     fn slice(&self, offset: usize, length: usize) -> ArrayRef {
@@ -187,42 +297,38 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn len(&self) -> usize {
-        self.inner.size()
+        self.metadata.len
     }
 
     fn is_empty(&self) -> bool {
-        self.inner.size() == 0
+        self.metadata.len == 0
     }
 
     fn offset(&self) -> usize {
-        self.inner.offset() as usize
+        self.metadata.offset
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
-        self.null_buf
-            .get_or_init(|| {
-                if self.null_count() == 0 {
-                    return None;
-                }
-                let null_bytes = self.inner().get_null_buffer();
-                let offset = self.inner().offset() as usize;
-                let length = self.inner().size();
-
-                let buffer = Buffer::from_vec(null_bytes);
-                let boolean_buffer = BooleanBuffer::new(buffer, offset, length);
-                Some(NullBuffer::new(boolean_buffer))
-            })
-            .as_ref()
+        if self.metadata.null_count == 0 {
+            return None;
+        }
+        if self.null_buf.get().is_none() {
+            debug_assert!(
+                false,
+                "CuDFColumnView::nulls(), implicit GPU->CPU copy detected. Call materialize_null_mask() explicitly."
+            );
+            self.materialize_null_mask()
+                .expect("failed to materialize cuDF null mask");
+        }
+        self.null_buf.get().and_then(Option::as_ref)
     }
 
     fn get_buffer_memory_size(&self) -> usize {
-        CuDFColumnView::get_buffer_memory_size(self)
-            .expect("failed to get cuDF column buffer memory size")
+        self.metadata.buffer_memory_size
     }
 
     fn get_array_memory_size(&self) -> usize {
-        CuDFColumnView::get_array_memory_size(self)
-            .expect("failed to get cuDF column array memory size")
+        self.metadata.array_memory_size
     }
 
     fn logical_nulls(&self) -> Option<NullBuffer> {
@@ -243,7 +349,7 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn null_count(&self) -> usize {
-        self.inner.null_count() as usize
+        self.metadata.null_count
     }
 
     fn logical_null_count(&self) -> usize {
@@ -253,9 +359,78 @@ unsafe impl Array for CuDFColumnView {
     }
 
     fn is_nullable(&self) -> bool {
-        // All cuDF columns can potentially have nulls
-        true
+        self.metadata.nullable
     }
+}
+
+pub(crate) fn column_view_metadata(
+    inner: &UniquePtr<ffi::ColumnView>,
+    device_memory_size: Option<usize>,
+) -> Result<ColumnViewMetadata, CuDFError> {
+    if inner.is_null() {
+        return Err(CuDFError::NullHandle("column view"));
+    }
+    let cudf_dtype = inner.data_type()?;
+    let dt = cudf_type_to_arrow(&cudf_dtype).unwrap_or(DataType::Null);
+    let len = crate::errors::cudf_size_to_usize(inner.size()?, "column-view size")?;
+    let offset = usize::try_from(inner.offset()?).map_err(|_| {
+        arrow_schema::ArrowError::ComputeError("cuDF column view has a negative offset".into())
+    })?;
+    let null_count = usize::try_from(inner.null_count()?).map_err(|_| {
+        arrow_schema::ArrowError::ComputeError("cuDF column view has a negative null count".into())
+    })?;
+    let nullable = inner.nullable()?;
+    let (mut buffer_memory_size, mut array_memory_size) = column_view_memory_sizes(inner)?;
+    let device_memory_size = device_memory_size.unwrap_or(array_memory_size);
+    if !ffi::is_fixed_width(&cudf_dtype) && device_memory_size > array_memory_size {
+        let null_mask_size = array_memory_size.saturating_sub(buffer_memory_size);
+        buffer_memory_size = device_memory_size.saturating_sub(null_mask_size);
+        array_memory_size = device_memory_size;
+    }
+    Ok(ColumnViewMetadata {
+        dt,
+        len,
+        offset,
+        null_count,
+        nullable,
+        buffer_memory_size,
+        array_memory_size,
+        device_memory_size,
+    })
+}
+
+pub(crate) fn column_view_memory_sizes(
+    inner: &UniquePtr<ffi::ColumnView>,
+) -> Result<(usize, usize), CuDFError> {
+    let Some(view) = inner.as_ref() else {
+        return Err(CuDFError::NullHandle("column view"));
+    };
+    let data_type = view.data_type()?;
+    let len = crate::errors::cudf_size_to_usize(view.size()?, "column-view size")?;
+    let mut buffer_size = if ffi::is_fixed_width(&data_type) {
+        ffi::size_of(&data_type)?.saturating_mul(len)
+    } else {
+        0
+    };
+    let mut array_size = buffer_size;
+    for index in 0..view.num_children()? {
+        let child = unsafe { view.child(index) }?;
+        let (child_buffer_size, child_array_size) = column_view_memory_sizes(&child)?;
+        buffer_size = buffer_size.saturating_add(child_buffer_size);
+        array_size = array_size.saturating_add(child_array_size);
+    }
+    if view.nullable()? {
+        let len = i32::try_from(len).map_err(|_| {
+            arrow_schema::ArrowError::ComputeError(
+                "cuDF column size exceeds cudf::size_type".to_string(),
+            )
+        })?;
+        array_size = array_size.saturating_add(ffi::bitmask_allocation_size_bytes(
+            len,
+            CUDF_NULL_MASK_PADDING,
+        ));
+    }
+    Ok((buffer_size, array_size))
 }
 
 #[cfg(test)]
@@ -267,7 +442,7 @@ mod tests {
     #[test]
     fn test_column_view_clone() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -276,8 +451,8 @@ mod tests {
         assert_eq!(column.len(), 5);
         assert_eq!(cloned.len(), 5);
 
-        let original_ptr = column.inner.data_ptr();
-        let cloned_ptr = cloned.inner.data_ptr();
+        let original_ptr = column.inner.head()?;
+        let cloned_ptr = cloned.inner.head()?;
         assert_eq!(
             original_ptr, cloned_ptr,
             "Cloned view should point to the same GPU memory"
@@ -289,7 +464,7 @@ mod tests {
     #[test]
     fn test_string_column_view_memory_size() -> Result<(), Box<dyn std::error::Error>> {
         let array = StringArray::from(vec!["hello", "world", ""]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let size = column.get_array_memory_size()?;
         let min_offsets_and_chars =
@@ -302,7 +477,7 @@ mod tests {
     #[test]
     fn test_multiple_clones() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![10, 20, 30]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -310,10 +485,10 @@ mod tests {
         let clone2 = column.clone();
         let clone3 = clone1.clone();
 
-        let ptr = column.inner.data_ptr();
-        assert_eq!(clone1.inner.data_ptr(), ptr);
-        assert_eq!(clone2.inner.data_ptr(), ptr);
-        assert_eq!(clone3.inner.data_ptr(), ptr);
+        let ptr = column.inner.head()?;
+        assert_eq!(clone1.inner.head()?, ptr);
+        assert_eq!(clone2.inner.head()?, ptr);
+        assert_eq!(clone3.inner.head()?, ptr);
 
         assert_eq!(column.len(), 3);
         assert_eq!(clone1.len(), 3);
@@ -321,7 +496,7 @@ mod tests {
         assert_eq!(clone3.len(), 3);
 
         drop(column);
-        assert_eq!(clone1.inner.data_ptr(), ptr);
+        assert_eq!(clone1.inner.head()?, ptr);
         assert_eq!(clone1.len(), 3);
 
         Ok(())
@@ -330,11 +505,11 @@ mod tests {
     #[test]
     fn test_column_data_is_on_gpu() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
-        let ptr = column.inner.data_ptr();
+        let ptr = column.inner.head()?;
 
         assert_ne!(ptr, 0, "Column data pointer should not be null");
 
@@ -372,7 +547,7 @@ mod tests {
     #[test]
     fn test_get_buffer_memory_size_int32() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -386,7 +561,7 @@ mod tests {
     fn test_get_buffer_memory_size_large() -> Result<(), Box<dyn std::error::Error>> {
         let data: Vec<i32> = (0..1_000_000).collect();
         let array = Int32Array::from(data);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -399,7 +574,7 @@ mod tests {
     #[test]
     fn test_get_array_memory_size_no_nulls() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -418,7 +593,7 @@ mod tests {
     #[test]
     fn test_get_array_memory_size_with_nulls() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -444,7 +619,7 @@ mod tests {
     #[test]
     fn test_nulls_no_nulls_returns_none() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
@@ -457,10 +632,11 @@ mod tests {
     #[test]
     fn test_nulls_with_nulls_returns_buffer() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         let nulls = column.nulls();
         assert!(
             nulls.is_some(),
@@ -473,10 +649,11 @@ mod tests {
     #[test]
     fn test_nulls_correct_bit_pattern() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(10), None, Some(30), None, Some(50)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         let nulls = column.nulls().expect("Should have null buffer");
         assert!(nulls.is_valid(0), "Element 0 should be valid (Some(10))");
         assert!(nulls.is_null(1), "Element 1 should be null");
@@ -490,10 +667,11 @@ mod tests {
     #[test]
     fn test_nulls_cached_same_reference() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         let nulls1 = column.nulls();
         let nulls2 = column.nulls();
 
@@ -514,10 +692,11 @@ mod tests {
     #[test]
     fn test_is_null_uses_null_buffer() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         assert!(!column.is_null(0), "Index 0 should not be null");
         assert!(column.is_null(1), "Index 1 should be null");
         assert!(!column.is_null(2), "Index 2 should not be null");
@@ -530,10 +709,11 @@ mod tests {
     #[test]
     fn test_is_valid_inverse_of_is_null() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         for i in 0..3 {
             assert_eq!(
                 column.is_valid(i),
@@ -549,10 +729,11 @@ mod tests {
     #[test]
     fn test_null_count_matches_null_buffer() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5), None]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         let null_count = column.null_count();
 
         // Should have 3 nulls (indices 1, 3, 5)
@@ -573,10 +754,11 @@ mod tests {
             .map(|i| if i % 2 == 0 { Some(i) } else { None })
             .collect();
         let array = Int32Array::from(data);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         let nulls = column.nulls().expect("Should have null buffer");
 
         // Verify pattern: even indices valid, odd indices null
@@ -597,10 +779,11 @@ mod tests {
     fn test_logical_nulls_equals_physical_nulls() -> Result<(), Box<dyn std::error::Error>> {
         // For primitive types, logical_nulls should equal physical nulls
         let array = Int32Array::from(vec![Some(1), None, Some(3)]);
-        let column = CuDFColumn::from_arrow_host(&array)
+        let column = CuDFColumn::try_from_arrow_host(&array)
             .expect("Failed to convert Arrow array to column")
             .into_view();
 
+        column.materialize_null_mask()?;
         let physical = column.nulls();
         let logical = column.logical_nulls();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,11 +18,9 @@
 //! `cudf::config_default_pinned_memory_resource` yourself before the first
 //! cuDF operation runs.
 
-use libcudf_sys::ffi::{
-    config_default_pinned_memory_resource, make_cuda_memory_resource, make_pool_memory_resource,
-    set_allocate_host_as_pinned_threshold, set_current_device_resource, total_device_memory,
-};
-use std::sync::Once;
+use crate::{CuDFError, Result};
+use libcudf_sys::ffi;
+use std::sync::OnceLock;
 
 /// Fraction of total VRAM reserved for the device pool. The remainder is left
 /// for the CUDA driver context, kernel scratch space, and any other CUDA
@@ -42,7 +40,7 @@ const PINNED_POOL_SIZE: usize = 1024 * 1024 * 1024;
 /// pool while keeping multi-hundred-MB internal buffers off it.
 const PINNED_THRESHOLD: usize = 16 * 1024 * 1024;
 
-static ONCE: Once = Once::new();
+static CONFIGURATION: OnceLock<std::result::Result<(), String>> = OnceLock::new();
 
 /// Apply the configuration globally for the current process. Idempotent: only
 /// the first call has effect.
@@ -50,24 +48,57 @@ static ONCE: Once = Once::new();
 /// Crate-private. We call this implicitly at every public entry point that
 /// creates GPU state (table/column/scalar constructors, pinned-buffer
 /// allocation, etc.), so callers don't need to remember to invoke it.
-pub(crate) fn ensure_pools_configured() {
-    ONCE.call_once(|| {
-        // RMM requires the pool size to be a multiple of CUDA's allocation
-        // alignment (256 bytes). Round down via a mask.
-        const ALIGN: usize = 256;
-        let device_pool_size = (total_device_memory() / DEVICE_POOL_VRAM_FRACTION_DEN
-            * DEVICE_POOL_VRAM_FRACTION_NUM)
-            & !(ALIGN - 1);
-        let upstream = make_cuda_memory_resource();
-        let pool = make_pool_memory_resource(&upstream, device_pool_size, device_pool_size);
-        set_current_device_resource(&pool);
-        // Process must keep the resource wrappers alive for the lifetime of
-        // the program: cuDF stores a raw pointer back to them. Leaking them is
-        // intentional and matches cuDF's own static-storage pattern.
-        std::mem::forget(upstream);
-        std::mem::forget(pool);
+pub(crate) fn ensure_pools_configured() -> Result<()> {
+    match CONFIGURATION.get_or_init(configure_pools) {
+        Ok(()) => Ok(()),
+        Err(message) => Err(CuDFError::Configuration(message.clone())),
+    }
+}
 
-        config_default_pinned_memory_resource(PINNED_POOL_SIZE);
-        set_allocate_host_as_pinned_threshold(PINNED_THRESHOLD);
-    });
+fn configure_pools() -> std::result::Result<(), String> {
+    // RMM requires the pool size to be a multiple of CUDA's allocation
+    // alignment (256 bytes). Round down via a mask.
+    const ALIGN: usize = 256;
+    let memory = ffi::available_device_memory().map_err(|error| error.to_string())?;
+    let memory = memory
+        .as_ref()
+        .ok_or_else(|| "RMM returned a null available-memory result".to_string())?;
+    let device_pool_size = (memory.total_bytes() / DEVICE_POOL_VRAM_FRACTION_DEN
+        * DEVICE_POOL_VRAM_FRACTION_NUM)
+        & !(ALIGN - 1);
+    let upstream = ffi::make_cuda_memory_resource();
+    let upstream_ref = upstream
+        .as_ref()
+        .ok_or_else(|| "RMM returned a null CUDA memory resource".to_string())?;
+    // `upstream` and `pool` are deliberately retained below for the
+    // process lifetime.
+    let pool = unsafe {
+        ffi::make_pool_memory_resource_with_maximum(
+            upstream_ref,
+            device_pool_size,
+            device_pool_size,
+        )
+    }
+    .map_err(|error| error.to_string())?;
+    let pool_ref = pool
+        .as_ref()
+        .ok_or_else(|| "RMM returned a null pool memory resource".to_string())?;
+    let resource = unsafe { ffi::make_device_async_resource_ref(pool_ref) };
+    let resource = resource
+        .as_ref()
+        .ok_or_else(|| "RMM returned a null device resource reference".to_string())?;
+    unsafe { ffi::set_current_device_resource_ref(resource) };
+    // Process must keep the resource wrappers alive for the lifetime of
+    // the program: cuDF stores a raw pointer back to them. Leaking them is
+    // intentional and matches cuDF's own static-storage pattern.
+    std::mem::forget(upstream);
+    std::mem::forget(pool);
+
+    let pinned = ffi::make_pinned_mr_options_with_pool_size(PINNED_POOL_SIZE);
+    let pinned = pinned
+        .as_ref()
+        .ok_or_else(|| "cuDF returned null pinned-memory options".to_string())?;
+    ffi::config_default_pinned_memory_resource(pinned);
+    ffi::set_allocate_host_as_pinned_threshold(PINNED_THRESHOLD);
+    Ok(())
 }

--- a/src/cudf_array.rs
+++ b/src/cudf_array.rs
@@ -39,7 +39,7 @@ impl From<CuDFScalar> for CuDFColumnViewOrScalar {
 /// let host_array = Int32Array::from(vec![1, 2, 3]);
 /// assert!(!is_cudf_array(&host_array));
 ///
-/// let gpu_array = CuDFColumn::from_arrow_host(&host_array)?.into_view();
+/// let gpu_array = CuDFColumn::try_from_arrow_host(&host_array)?.into_view();
 /// assert!(is_cudf_array(&gpu_array));
 /// # Ok::<(), libcudf_rs::CuDFError>(())
 /// ```
@@ -71,7 +71,7 @@ pub fn is_cudf_array(arr: &dyn Array) -> bool {
 /// assert!(!is_cudf_record_batch(&host_batch));
 ///
 /// // Create a GPU RecordBatch
-/// let gpu_array = CuDFColumn::from_arrow_host(&Int32Array::from(vec![1, 2, 3]))?.into_view();
+/// let gpu_array = CuDFColumn::try_from_arrow_host(&Int32Array::from(vec![1, 2, 3]))?.into_view();
 /// let gpu_batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(gpu_array)])?;
 /// assert!(is_cudf_record_batch(&gpu_batch));
 /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,7 +12,22 @@ pub enum CuDFError {
     /// cuDF returned a null handle where a valid handle was required
     #[error("cuDF returned a null {0} handle")]
     NullHandle(&'static str),
+
+    /// Invalid or conflicting high-level resource configuration
+    #[error("cuDF configuration error: {0}")]
+    Configuration(String),
+
+    /// CUDA Runtime API failure.
+    #[error("CUDA error {code}: {message}")]
+    Cuda { code: i32, message: String },
 }
 
 /// Result type alias for libcudf-rs operations
 pub type Result<T> = std::result::Result<T, CuDFError>;
+
+pub(crate) fn cudf_size_to_usize(value: i32, name: &'static str) -> Result<usize> {
+    usize::try_from(value).map_err(|_| {
+        arrow::error::ArrowError::ComputeError(format!("cuDF returned a negative {name}: {value}"))
+            .into()
+    })
+}

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 /// for each group. Created with key columns and then used to perform
 /// multiple aggregations.
 pub struct CuDFGroupBy {
-    _ref: Option<Arc<dyn CuDFRef>>,
     inner: UniquePtr<ffi::GroupBy>,
+    _keepalive: Option<Arc<dyn CuDFRef>>,
 }
 
 impl CuDFGroupBy {
@@ -40,8 +40,8 @@ impl CuDFGroupBy {
             null_precedence,
         );
         Self {
-            _ref: Some(Arc::new(view)),
             inner,
+            _keepalive: Some(Arc::new(view)),
         }
     }
 
@@ -54,10 +54,10 @@ impl CuDFGroupBy {
     where
         I: IntoIterator<Item = AggregationRequest>,
     {
-        let mut _refs = Vec::new();
+        let mut keepalives = Vec::new();
         let mut requests_inner = aggregation_requests_create();
         for request in requests {
-            _refs.push(request._ref.clone());
+            keepalives.push(request.keepalive.clone());
             requests_inner.pin_mut().add(request.inner);
         }
 
@@ -67,7 +67,7 @@ impl CuDFGroupBy {
             self.inner
                 .aggregate(&requests_inner, stream_ref(&stream)?, resource_ref(&mr)?)?;
         let keys = gby_result.pin_mut().release_keys();
-        let keys = CuDFTable::from_ptr(keys);
+        let keys = CuDFTable::try_from_inner(keys)?;
 
         let mut results = Vec::with_capacity(gby_result.len());
         for i in 0..gby_result.len() {
@@ -75,7 +75,7 @@ impl CuDFGroupBy {
             let mut cols = Vec::with_capacity(released_result.len());
             for j in 0..released_result.len() {
                 let col = released_result.pin_mut().release(j);
-                cols.push(CuDFColumn::new(col));
+                cols.push(CuDFColumn::try_from_inner(col)?);
             }
 
             results.push(cols)
@@ -89,8 +89,8 @@ impl CuDFGroupBy {
 /// Specifies a column of values to aggregate and the aggregations to
 /// perform on it. Multiple aggregations can be added to a single request.
 pub struct AggregationRequest {
-    _ref: Option<Arc<dyn CuDFRef>>,
     inner: UniquePtr<ffi::AggregationRequest>,
+    keepalive: Option<Arc<dyn CuDFRef>>,
 }
 
 impl AggregationRequest {
@@ -101,8 +101,8 @@ impl AggregationRequest {
     pub fn from_column_view(view: CuDFColumnView) -> Self {
         let inner = aggregation_request_create(view.inner());
         Self {
-            _ref: Some(Arc::new(view)),
             inner,
+            keepalive: Some(Arc::new(view)),
         }
     }
 
@@ -125,7 +125,7 @@ pub struct GroupByAggregation {
 
 impl GroupByAggregation {
     /// Create a groupby aggregation from a cuDF aggregation pointer
-    pub fn new(inner: UniquePtr<ffi::GroupByAggregation>) -> Self {
+    pub(crate) fn from_inner(inner: UniquePtr<ffi::GroupByAggregation>) -> Self {
         Self { inner }
     }
 }
@@ -180,22 +180,24 @@ impl AggregationOp {
     pub fn group_by(&self) -> GroupByAggregation {
         use AggregationOp::*;
         match self {
-            SUM => GroupByAggregation::new(make_sum_aggregation_groupby()),
-            MIN => GroupByAggregation::new(make_min_aggregation_groupby()),
-            MAX => GroupByAggregation::new(make_max_aggregation_groupby()),
-            MEAN => GroupByAggregation::new(make_mean_aggregation_groupby()),
-            COUNT => {
-                GroupByAggregation::new(make_count_aggregation_groupby(NullPolicy::Exclude as i32))
-            }
-            COUNT_ALL => {
-                GroupByAggregation::new(make_count_aggregation_groupby(NullPolicy::Include as i32))
-            }
-            VARIANCE { ddof } => GroupByAggregation::new(make_variance_aggregation_groupby(*ddof)),
-            STD { ddof } => GroupByAggregation::new(make_std_aggregation_groupby(*ddof)),
-            NUNIQUE => GroupByAggregation::new(make_nunique_aggregation_groupby(
+            SUM => GroupByAggregation::from_inner(make_sum_aggregation_groupby()),
+            MIN => GroupByAggregation::from_inner(make_min_aggregation_groupby()),
+            MAX => GroupByAggregation::from_inner(make_max_aggregation_groupby()),
+            MEAN => GroupByAggregation::from_inner(make_mean_aggregation_groupby()),
+            COUNT => GroupByAggregation::from_inner(make_count_aggregation_groupby(
                 NullPolicy::Exclude as i32,
             )),
-            MEDIAN => GroupByAggregation::new(make_median_aggregation_groupby()),
+            COUNT_ALL => GroupByAggregation::from_inner(make_count_aggregation_groupby(
+                NullPolicy::Include as i32,
+            )),
+            VARIANCE { ddof } => {
+                GroupByAggregation::from_inner(make_variance_aggregation_groupby(*ddof))
+            }
+            STD { ddof } => GroupByAggregation::from_inner(make_std_aggregation_groupby(*ddof)),
+            NUNIQUE => GroupByAggregation::from_inner(make_nunique_aggregation_groupby(
+                NullPolicy::Exclude as i32,
+            )),
+            MEDIAN => GroupByAggregation::from_inner(make_median_aggregation_groupby()),
         }
     }
 }
@@ -316,10 +318,10 @@ mod tests {
         let values = Int32Array::from(vec![1, 2, 3, 10, 20]);
         let keys = Int32Array::from(vec![1, 1, 1, 2, 2]);
 
-        let values_col = CuDFColumn::from_arrow_host(&values)?;
+        let values_col = CuDFColumn::try_from_arrow_host(&values)?;
         let schema = Arc::new(Schema::new(vec![Field::new("key", DataType::Int32, false)]));
         let keys_batch = RecordBatch::try_new(schema, vec![Arc::new(keys)])?;
-        let keys_table = CuDFTable::from_arrow_host(keys_batch)?;
+        let keys_table = CuDFTable::try_from_arrow_host(keys_batch)?;
         let groupby = CuDFGroupBy::from_table_view(keys_table.into_view());
 
         let mut request = AggregationRequest::from_column_view(values_col.into_view());
@@ -360,7 +362,7 @@ mod tests {
         )]));
         let keys_data = keys.to_data();
         let batch = RecordBatch::try_new(schema, vec![make_array(keys_data)])?;
-        CuDFTable::from_arrow_host(batch)
+        CuDFTable::try_from_arrow_host(batch)
     }
 
     fn run_single_group_agg<T: Array + Clone + 'static>(
@@ -370,7 +372,7 @@ mod tests {
         let n = values.len();
         let keys = Int32Array::from(vec![1; n]);
 
-        let values_col = CuDFColumn::from_arrow_host(values)?;
+        let values_col = CuDFColumn::try_from_arrow_host(values)?;
         let keys_table = make_keys_table(&keys)?;
         let groupby = CuDFGroupBy::from_table_view(keys_table.into_view());
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -5,7 +5,7 @@ use crate::{
     CuDFAstExpression, CuDFColumn, CuDFColumnView, CuDFError, CuDFRef, CuDFScalar, CuDFTable,
     CuDFTableView,
 };
-use arrow::array::{BooleanArray, Int32Array, Scalar};
+use arrow::array::{Array, BooleanArray, Int32Array, Scalar};
 use arrow_schema::DataType;
 use cxx::UniquePtr;
 use libcudf_sys::{
@@ -46,23 +46,27 @@ struct JoinIndexVector {
 }
 
 impl JoinIndexVector {
-    fn new(inner: UniquePtr<ffi::DeviceIndexVector>) -> Self {
-        Self { inner }
+    fn try_from_inner(inner: UniquePtr<ffi::DeviceIndexVector>) -> Result<Self, CuDFError> {
+        if inner.is_null() {
+            return Err(CuDFError::NullHandle("device index vector"));
+        }
+        Ok(Self { inner })
     }
 
     fn len(&self) -> usize {
         self.inner.size()
     }
 
-    fn as_sys(&self) -> &ffi::DeviceIndexVector {
+    fn as_sys(&self) -> Result<&ffi::DeviceIndexVector, CuDFError> {
         self.inner
             .as_ref()
-            .expect("device index vector should not be null")
+            .ok_or(CuDFError::NullHandle("device index vector"))
     }
 
-    fn view(self: Arc<Self>) -> CuDFColumnView {
-        let view = self.inner.view();
-        CuDFColumnView::new_with_ref(view, Some(self))
+    fn view(self: Arc<Self>) -> Result<CuDFColumnView, CuDFError> {
+        // `self` is retained through the `CuDFRef` stored in the returned view.
+        let view = unsafe { self.inner.view() };
+        CuDFColumnView::try_from_inner(view, Some(self))
     }
 }
 
@@ -100,9 +104,21 @@ fn sys_hash_join_left_join_indices(
     )?)
 }
 
-fn select_cols(view: &CuDFTableView, cols: &[usize]) -> cxx::UniquePtr<ffi::TableView> {
-    let indices: Vec<i32> = cols.iter().map(|&i| i as i32).collect();
-    view.inner().select(&indices)
+fn select_cols(
+    view: &CuDFTableView,
+    cols: &[usize],
+) -> Result<cxx::UniquePtr<ffi::TableView>, CuDFError> {
+    let indices = cols
+        .iter()
+        .map(|&index| {
+            i32::try_from(index).map_err(|_| {
+                CuDFError::ArrowError(arrow_schema::ArrowError::InvalidArgumentError(format!(
+                    "column index {index} exceeds cuDF's column-index range"
+                )))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(view.inner().select(&indices)?)
 }
 
 fn gather_join_output(
@@ -115,23 +131,23 @@ fn gather_join_output(
 ) -> Result<CuDFTable, CuDFError> {
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
-    let left = CuDFTable::from_inner(ffi::gather_with_policy(
+    let left = CuDFTable::try_from_inner(ffi::gather_with_policy(
         left_payload,
         left_indices,
         left_policy as i32,
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?);
-    let right = CuDFTable::from_inner(ffi::gather_with_policy(
+    )?)?;
+    let right = CuDFTable::try_from_inner(ffi::gather_with_policy(
         right_payload,
         right_indices,
         right_policy as i32,
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?);
-    let mut columns = left.into_columns();
-    columns.extend(right.into_columns());
-    Ok(CuDFTable::from_columns(columns))
+    )?)?;
+    let mut columns = left.into_columns()?;
+    columns.extend(right.into_columns()?);
+    CuDFTable::try_from_columns(columns)
 }
 
 fn gather_join_indices(
@@ -141,10 +157,14 @@ fn gather_join_indices(
     left_policy: OutOfBoundsPolicy,
     right_policy: OutOfBoundsPolicy,
 ) -> Result<CuDFTable, CuDFError> {
-    let left_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_left()));
-    let right_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_right()));
-    let left_indices_view = Arc::clone(&left_indices).view();
-    let right_indices_view = Arc::clone(&right_indices).view();
+    let left_indices = Arc::new(JoinIndexVector::try_from_inner(
+        indices.pin_mut().release_left(),
+    )?);
+    let right_indices = Arc::new(JoinIndexVector::try_from_inner(
+        indices.pin_mut().release_right(),
+    )?);
+    let left_indices_view = Arc::clone(&left_indices).view()?;
+    let right_indices_view = Arc::clone(&right_indices).view()?;
     gather_join_output(
         left_payload,
         right_payload,
@@ -162,10 +182,14 @@ fn gather_hash_join_indices(
     build_policy: OutOfBoundsPolicy,
     probe_policy: OutOfBoundsPolicy,
 ) -> Result<(CuDFTable, Arc<JoinIndexVector>), CuDFError> {
-    let probe_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_probe()));
-    let build_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_build()));
-    let probe_indices_view = Arc::clone(&probe_indices).view();
-    let build_indices_view = Arc::clone(&build_indices).view();
+    let probe_indices = Arc::new(JoinIndexVector::try_from_inner(
+        indices.pin_mut().release_probe(),
+    )?);
+    let build_indices = Arc::new(JoinIndexVector::try_from_inner(
+        indices.pin_mut().release_build(),
+    )?);
+    let probe_indices_view = Arc::clone(&probe_indices).view()?;
+    let build_indices_view = Arc::clone(&build_indices).view()?;
     let result = gather_join_output(
         build_payload,
         probe_payload,
@@ -195,28 +219,32 @@ fn gather_filtered_hash_join_indices(
     // Hash join returns probe/build maps. cuDF filter_join_indices expects
     // left/right maps, so pass build as left and probe as right to preserve
     // the public `[build_cols | probe_cols]` output order.
-    let probe_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_probe()));
-    let build_indices = Arc::new(JoinIndexVector::new(indices.pin_mut().release_build()));
+    let probe_indices = Arc::new(JoinIndexVector::try_from_inner(
+        indices.pin_mut().release_probe(),
+    )?);
+    let build_indices = Arc::new(JoinIndexVector::try_from_inner(
+        indices.pin_mut().release_build(),
+    )?);
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let mut filtered_indices = ffi::filter_join_indices(
         args.build_conditional,
         args.probe_conditional,
-        build_indices.as_sys(),
-        probe_indices.as_sys(),
+        build_indices.as_sys()?,
+        probe_indices.as_sys()?,
         args.predicate.inner(),
         args.join_kind as i32,
         stream_ref(&stream)?,
         resource_ref(&resource)?,
     )?;
-    let filtered_build_indices = Arc::new(JoinIndexVector::new(
+    let filtered_build_indices = Arc::new(JoinIndexVector::try_from_inner(
         filtered_indices.pin_mut().release_left(),
-    ));
-    let filtered_probe_indices = Arc::new(JoinIndexVector::new(
+    )?);
+    let filtered_probe_indices = Arc::new(JoinIndexVector::try_from_inner(
         filtered_indices.pin_mut().release_right(),
-    ));
-    let filtered_build_indices_view = Arc::clone(&filtered_build_indices).view();
-    let filtered_probe_indices_view = Arc::clone(&filtered_probe_indices).view();
+    )?);
+    let filtered_build_indices_view = Arc::clone(&filtered_build_indices).view()?;
+    let filtered_probe_indices_view = Arc::clone(&filtered_probe_indices).view()?;
     let result = gather_join_output(
         args.build_payload,
         args.probe_payload,
@@ -238,35 +266,52 @@ fn concat_join_outputs(first: CuDFTable, second: CuDFTable) -> Result<CuDFTable,
     CuDFTable::concat(vec![first.into_view(), second.into_view()])
 }
 
+fn take_only_column(table: CuDFTable, context: &'static str) -> Result<CuDFColumn, CuDFError> {
+    let mut columns = table.into_columns()?.into_iter();
+    let column = columns.next().ok_or_else(|| {
+        arrow_schema::ArrowError::ComputeError(format!("cuDF returned no column for {context}"))
+    })?;
+    if columns.next().is_some() {
+        return Err(arrow_schema::ArrowError::ComputeError(format!(
+            "cuDF returned multiple columns for {context}"
+        ))
+        .into());
+    }
+    Ok(column)
+}
+
 fn distinct_valid_indices(indices: CuDFColumnView) -> Result<Option<Arc<CuDFColumn>>, CuDFError> {
-    if indices.inner().size() == 0 {
+    if indices.len() == 0 {
         return Ok(None);
     }
 
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let zero = int32_scalar(0)?;
-    let valid_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
-        indices.inner(),
-        zero.inner(),
-        BinaryOperator::GreaterEqual as i32,
-        &bool_data_type(),
-        stream_ref(&stream)?,
-        resource_ref(&resource)?,
-    )?));
-    let indices_table = CuDFTableView::from_column_views(vec![indices])?;
-    let valid_indices_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
+    let bool_type = bool_data_type()?;
+    let valid_mask = Arc::new(CuDFColumn::try_from_inner(
+        ffi::binary_operation_col_scalar(
+            indices.inner(),
+            zero.inner(),
+            BinaryOperator::GreaterEqual as i32,
+            &bool_type,
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
+        )?,
+    )?);
+    let indices_table = CuDFTableView::try_from_column_views(vec![indices])?;
+    let valid_indices_table = CuDFTable::try_from_inner(ffi::apply_boolean_mask(
         indices_table.inner(),
         Arc::clone(&valid_mask).view().inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?);
+    )?)?;
     if valid_indices_table.num_rows() == 0 {
         return Ok(None);
     }
 
     let valid_indices_view = valid_indices_table.into_view();
-    let distinct_indices = CuDFTable::from_inner(ffi::distinct(
+    let distinct_indices = CuDFTable::try_from_inner(ffi::distinct(
         valid_indices_view.inner(),
         &[0],
         DuplicateKeepOption::KeepAny as i32,
@@ -274,18 +319,15 @@ fn distinct_valid_indices(indices: CuDFColumnView) -> Result<Option<Arc<CuDFColu
         NanEquality::AllEqual as i32,
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?);
+    )?)?;
     if distinct_indices.num_rows() == 0 {
         return Ok(None);
     }
 
-    Ok(Some(Arc::new(
-        distinct_indices
-            .into_columns()
-            .into_iter()
-            .next()
-            .expect("distinct indices has one column"),
-    )))
+    Ok(Some(Arc::new(take_only_column(
+        distinct_indices,
+        "distinct join indices",
+    )?)))
 }
 
 fn matched_row_mask(
@@ -295,13 +337,13 @@ fn matched_row_mask(
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let false_scalar = bool_scalar(false)?;
-    let mask = Arc::new(CuDFColumn::new(ffi::make_column_from_scalar(
+    let mask = Arc::new(CuDFColumn::try_from_inner(ffi::make_column_from_scalar(
         false_scalar.inner(),
         row_count,
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?));
-    let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&matched_indices).view())?
+    )?)?);
+    let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&matched_indices).view()?)?
     else {
         return Ok(mask);
     };
@@ -309,21 +351,15 @@ fn matched_row_mask(
     let distinct_indices_view = Arc::clone(&distinct_indices).view();
     let true_scalar = bool_scalar(true)?;
     let source = [true_scalar.inner().as_ptr()];
-    let target = CuDFTableView::from_column_views(vec![Arc::clone(&mask).view()])?;
-    let updated = CuDFTable::from_inner(ffi::scatter_scalars(
+    let target = CuDFTableView::try_from_column_views(vec![Arc::clone(&mask).view()])?;
+    let updated = CuDFTable::try_from_inner(ffi::scatter_scalars(
         &source,
         distinct_indices_view.inner(),
         target.inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?);
-    Ok(Arc::new(
-        updated
-            .into_columns()
-            .into_iter()
-            .next()
-            .expect("updated matched row mask has one column"),
-    ))
+    )?)?;
+    Ok(Arc::new(take_only_column(updated, "matched-row mask")?))
 }
 
 fn unmatched_indices_from_matches(
@@ -335,29 +371,29 @@ fn unmatched_indices_from_matches(
     let all_indices = join_index_sequence(row_count, 0, 1)?;
     let matched_mask = matched_row_mask(row_count, matched_indices)?;
     let false_scalar = bool_scalar(false)?;
-    let unmatched_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
-        Arc::clone(&matched_mask).view().inner(),
-        false_scalar.inner(),
-        BinaryOperator::Equal as i32,
-        &bool_data_type(),
-        stream_ref(&stream)?,
-        resource_ref(&resource)?,
-    )?));
+    let bool_type = bool_data_type()?;
+    let unmatched_mask = Arc::new(CuDFColumn::try_from_inner(
+        ffi::binary_operation_col_scalar(
+            Arc::clone(&matched_mask).view().inner(),
+            false_scalar.inner(),
+            BinaryOperator::Equal as i32,
+            &bool_type,
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
+        )?,
+    )?);
     let all_indices_table =
-        CuDFTableView::from_column_views(vec![Arc::clone(&all_indices).view()])?;
-    let unmatched_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
+        CuDFTableView::try_from_column_views(vec![Arc::clone(&all_indices).view()])?;
+    let unmatched_table = CuDFTable::try_from_inner(ffi::apply_boolean_mask(
         all_indices_table.inner(),
         Arc::clone(&unmatched_mask).view().inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?);
-    Ok(Arc::new(
-        unmatched_table
-            .into_columns()
-            .into_iter()
-            .next()
-            .expect("unmatched indices has one column"),
-    ))
+    )?)?;
+    Ok(Arc::new(take_only_column(
+        unmatched_table,
+        "unmatched join indices",
+    )?))
 }
 
 fn join_index_sequence(size: usize, init: i32, step: i32) -> Result<Arc<CuDFColumn>, CuDFError> {
@@ -365,29 +401,31 @@ fn join_index_sequence(size: usize, init: i32, step: i32) -> Result<Arc<CuDFColu
     let resource = ffi::get_current_device_resource_ref();
     let init_array = Int32Array::from(vec![init]);
     let step_array = Int32Array::from(vec![step]);
-    let init_scalar = CuDFScalar::from_arrow_host(Scalar::new(&init_array))?;
-    let step_scalar = CuDFScalar::from_arrow_host(Scalar::new(&step_array))?;
-    Ok(Arc::new(CuDFColumn::new(ffi::sequence(
+    let init_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&init_array))?;
+    let step_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&step_array))?;
+    Ok(Arc::new(CuDFColumn::try_from_inner(ffi::sequence(
         size,
         init_scalar.inner(),
         step_scalar.inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?)))
+    )?)?))
 }
 
 fn int32_scalar(value: i32) -> Result<CuDFScalar, CuDFError> {
     let array = Int32Array::from(vec![value]);
-    CuDFScalar::from_arrow_host(Scalar::new(&array))
+    CuDFScalar::try_from_arrow_host(Scalar::new(&array))
 }
 
 fn bool_scalar(value: bool) -> Result<CuDFScalar, CuDFError> {
     let array = BooleanArray::from(vec![value]);
-    CuDFScalar::from_arrow_host(Scalar::new(&array))
+    CuDFScalar::try_from_arrow_host(Scalar::new(&array))
 }
 
-fn bool_data_type() -> cxx::UniquePtr<ffi::DataType> {
-    arrow_type_to_cudf_data_type(&DataType::Boolean).expect("Boolean is supported by cuDF")
+fn bool_data_type() -> Result<cxx::UniquePtr<ffi::DataType>, CuDFError> {
+    arrow_type_to_cudf_data_type(&DataType::Boolean).ok_or_else(|| {
+        arrow_schema::ArrowError::ComputeError("Boolean is not supported by cuDF".into()).into()
+    })
 }
 
 /// Reusable hash join built from a fixed build-side key table.
@@ -397,7 +435,7 @@ pub struct CuDFHashJoin {
     inner: UniquePtr<ffi::HashJoin>,
     build_rows: usize,
     matched_build_mask: Option<Arc<CuDFColumn>>,
-    _build_ref: Option<Arc<dyn CuDFRef>>,
+    _build_keepalive: Option<Arc<dyn CuDFRef>>,
 }
 
 /// Controls whether null join-key values compare equal.
@@ -425,7 +463,7 @@ impl CuDFHashJoin {
         build_on: &[usize],
         null_equality: CuDFNullEquality,
     ) -> Result<Self, CuDFError> {
-        let build_keys = select_cols(build, build_on);
+        let build_keys = select_cols(build, build_on)?;
         let stream = ffi::get_default_stream();
         let inner = ffi::hash_join_create(
             &build_keys,
@@ -436,7 +474,7 @@ impl CuDFHashJoin {
             inner,
             build_rows: build.num_rows(),
             matched_build_mask: None,
-            _build_ref: build._ref.clone(),
+            _build_keepalive: build.keepalive.clone(),
         })
     }
 
@@ -452,9 +490,13 @@ impl CuDFHashJoin {
         build_out_cols: Option<&[usize]>,
         probe_out_cols: Option<&[usize]>,
     ) -> Result<CuDFTable, CuDFError> {
-        let probe_keys = select_cols(probe, probe_on);
-        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
-        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let probe_keys = select_cols(probe, probe_on)?;
+        let selected_build_payload = build_out_cols
+            .map(|c| select_cols(build_payload, c))
+            .transpose()?;
+        let selected_probe_payload = probe_out_cols
+            .map(|c| select_cols(probe_payload, c))
+            .transpose()?;
         let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, _) = gather_hash_join_indices(
             indices,
@@ -490,13 +532,15 @@ impl CuDFHashJoin {
         &self,
         args: CuDFFilteredHashJoinArgs<'_>,
     ) -> Result<CuDFTable, CuDFError> {
-        let probe_keys = select_cols(args.probe, args.probe_on);
+        let probe_keys = select_cols(args.probe, args.probe_on)?;
         let selected_build_payload = args
             .build_out_cols
-            .map(|c| select_cols(args.build_payload, c));
+            .map(|c| select_cols(args.build_payload, c))
+            .transpose()?;
         let selected_probe_payload = args
             .probe_out_cols
-            .map(|c| select_cols(args.probe_payload, c));
+            .map(|c| select_cols(args.probe_payload, c))
+            .transpose()?;
         let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, _, _) = gather_filtered_hash_join_indices(
             indices,
@@ -532,13 +576,15 @@ impl CuDFHashJoin {
         &mut self,
         args: CuDFFilteredHashJoinArgs<'_>,
     ) -> Result<CuDFTable, CuDFError> {
-        let probe_keys = select_cols(args.probe, args.probe_on);
+        let probe_keys = select_cols(args.probe, args.probe_on)?;
         let selected_build_payload = args
             .build_out_cols
-            .map(|c| select_cols(args.build_payload, c));
+            .map(|c| select_cols(args.build_payload, c))
+            .transpose()?;
         let selected_probe_payload = args
             .probe_out_cols
-            .map(|c| select_cols(args.probe_payload, c));
+            .map(|c| select_cols(args.probe_payload, c))
+            .transpose()?;
         let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, build_indices, _) = gather_filtered_hash_join_indices(
             indices,
@@ -571,9 +617,13 @@ impl CuDFHashJoin {
         build_out_cols: Option<&[usize]>,
         probe_out_cols: Option<&[usize]>,
     ) -> Result<CuDFTable, CuDFError> {
-        let probe_keys = select_cols(probe, probe_on);
-        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
-        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let probe_keys = select_cols(probe, probe_on)?;
+        let selected_build_payload = build_out_cols
+            .map(|c| select_cols(build_payload, c))
+            .transpose()?;
+        let selected_probe_payload = probe_out_cols
+            .map(|c| select_cols(probe_payload, c))
+            .transpose()?;
         let indices = sys_hash_join_inner_join_indices(&self.inner, &probe_keys)?;
         let (result, build_indices) = gather_hash_join_indices(
             indices,
@@ -602,9 +652,13 @@ impl CuDFHashJoin {
         build_out_cols: Option<&[usize]>,
         probe_out_cols: Option<&[usize]>,
     ) -> Result<CuDFTable, CuDFError> {
-        let probe_keys = select_cols(probe, probe_on);
-        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
-        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let probe_keys = select_cols(probe, probe_on)?;
+        let selected_build_payload = build_out_cols
+            .map(|c| select_cols(build_payload, c))
+            .transpose()?;
+        let selected_probe_payload = probe_out_cols
+            .map(|c| select_cols(probe_payload, c))
+            .transpose()?;
         let indices = sys_hash_join_left_join_indices(&self.inner, &probe_keys)?;
         let (result, build_indices) = gather_hash_join_indices(
             indices,
@@ -636,13 +690,15 @@ impl CuDFHashJoin {
         &mut self,
         args: CuDFFilteredHashJoinArgs<'_>,
     ) -> Result<CuDFTable, CuDFError> {
-        let probe_keys = select_cols(args.probe, args.probe_on);
+        let probe_keys = select_cols(args.probe, args.probe_on)?;
         let selected_build_payload = args
             .build_out_cols
-            .map(|c| select_cols(args.build_payload, c));
+            .map(|c| select_cols(args.build_payload, c))
+            .transpose()?;
         let selected_probe_payload = args
             .probe_out_cols
-            .map(|c| select_cols(args.probe_payload, c));
+            .map(|c| select_cols(args.probe_payload, c))
+            .transpose()?;
         let build_payload = selected_build_payload
             .as_ref()
             .unwrap_or_else(|| args.build_payload.inner());
@@ -691,8 +747,12 @@ impl CuDFHashJoin {
         build_out_cols: Option<&[usize]>,
         probe_out_cols: Option<&[usize]>,
     ) -> Result<CuDFTable, CuDFError> {
-        let selected_build_payload = build_out_cols.map(|c| select_cols(build_payload, c));
-        let selected_probe_payload = probe_out_cols.map(|c| select_cols(probe_payload, c));
+        let selected_build_payload = build_out_cols
+            .map(|c| select_cols(build_payload, c))
+            .transpose()?;
+        let selected_probe_payload = probe_out_cols
+            .map(|c| select_cols(probe_payload, c))
+            .transpose()?;
         let unmatched_build_indices = self.unmatched_build_indices()?;
         let null_probe_indices =
             join_index_sequence(unmatched_build_indices.len(), null_gather_index(), 0)?;
@@ -721,7 +781,7 @@ impl CuDFHashJoin {
             return Ok(());
         }
 
-        let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&build_indices).view())?
+        let Some(distinct_indices) = distinct_valid_indices(Arc::clone(&build_indices).view()?)?
         else {
             return Ok(());
         };
@@ -732,12 +792,12 @@ impl CuDFHashJoin {
             Some(mask) => Arc::clone(mask),
             None => {
                 let false_scalar = bool_scalar(false)?;
-                let mask = Arc::new(CuDFColumn::new(ffi::make_column_from_scalar(
+                let mask = Arc::new(CuDFColumn::try_from_inner(ffi::make_column_from_scalar(
                     false_scalar.inner(),
                     self.build_rows,
                     stream_ref(&stream)?,
                     resource_ref(&resource)?,
-                )?));
+                )?)?);
                 self.matched_build_mask = Some(Arc::clone(&mask));
                 mask
             }
@@ -746,21 +806,18 @@ impl CuDFHashJoin {
         let scatter_indices_view = Arc::clone(&distinct_indices).view();
         let true_scalar = bool_scalar(true)?;
         let source = [true_scalar.inner().as_ptr()];
-        let target = CuDFTableView::from_column_views(vec![matched_build_mask.view()])?;
-        let updated = CuDFTable::from_inner(ffi::scatter_scalars(
+        let target = CuDFTableView::try_from_column_views(vec![matched_build_mask.view()])?;
+        let updated = CuDFTable::try_from_inner(ffi::scatter_scalars(
             &source,
             scatter_indices_view.inner(),
             target.inner(),
             stream_ref(&stream)?,
             resource_ref(&resource)?,
-        )?);
-        self.matched_build_mask = Some(Arc::new(
-            updated
-                .into_columns()
-                .into_iter()
-                .next()
-                .expect("updated matched build mask has one column"),
-        ));
+        )?)?;
+        self.matched_build_mask = Some(Arc::new(take_only_column(
+            updated,
+            "updated matched-build mask",
+        )?));
         Ok(())
     }
 
@@ -773,29 +830,29 @@ impl CuDFHashJoin {
         let stream = ffi::get_default_stream();
         let resource = ffi::get_current_device_resource_ref();
         let false_scalar = bool_scalar(false)?;
-        let unmatched_mask = Arc::new(CuDFColumn::new(ffi::binary_operation_col_scalar(
-            Arc::clone(matched_build_mask).view().inner(),
-            false_scalar.inner(),
-            BinaryOperator::Equal as i32,
-            &bool_data_type(),
-            stream_ref(&stream)?,
-            resource_ref(&resource)?,
-        )?));
+        let bool_type = bool_data_type()?;
+        let unmatched_mask = Arc::new(CuDFColumn::try_from_inner(
+            ffi::binary_operation_col_scalar(
+                Arc::clone(matched_build_mask).view().inner(),
+                false_scalar.inner(),
+                BinaryOperator::Equal as i32,
+                &bool_type,
+                stream_ref(&stream)?,
+                resource_ref(&resource)?,
+            )?,
+        )?);
         let all_build_table =
-            CuDFTableView::from_column_views(vec![Arc::clone(&all_build_indices).view()])?;
-        let unmatched_table = CuDFTable::from_inner(ffi::apply_boolean_mask(
+            CuDFTableView::try_from_column_views(vec![Arc::clone(&all_build_indices).view()])?;
+        let unmatched_table = CuDFTable::try_from_inner(ffi::apply_boolean_mask(
             all_build_table.inner(),
             Arc::clone(&unmatched_mask).view().inner(),
             stream_ref(&stream)?,
             resource_ref(&resource)?,
-        )?);
-        Ok(Arc::new(
-            unmatched_table
-                .into_columns()
-                .into_iter()
-                .next()
-                .expect("unmatched build indices has one column"),
-        ))
+        )?)?;
+        Ok(Arc::new(take_only_column(
+            unmatched_table,
+            "unmatched build indices",
+        )?))
     }
 }
 
@@ -812,10 +869,10 @@ pub fn inner_join(
     left_out_cols: Option<&[usize]>,
     right_out_cols: Option<&[usize]>,
 ) -> Result<CuDFTable, CuDFError> {
-    let left_keys = select_cols(left, left_on);
-    let right_keys = select_cols(right, right_on);
-    let left_payload = left_out_cols.map(|c| select_cols(left, c));
-    let right_payload = right_out_cols.map(|c| select_cols(right, c));
+    let left_keys = select_cols(left, left_on)?;
+    let right_keys = select_cols(right, right_on)?;
+    let left_payload = left_out_cols.map(|c| select_cols(left, c)).transpose()?;
+    let right_payload = right_out_cols.map(|c| select_cols(right, c)).transpose()?;
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let indices = ffi::inner_join_indices(
@@ -847,10 +904,10 @@ pub fn left_join(
     left_out_cols: Option<&[usize]>,
     right_out_cols: Option<&[usize]>,
 ) -> Result<CuDFTable, CuDFError> {
-    let left_keys = select_cols(left, left_on);
-    let right_keys = select_cols(right, right_on);
-    let left_payload = left_out_cols.map(|c| select_cols(left, c));
-    let right_payload = right_out_cols.map(|c| select_cols(right, c));
+    let left_keys = select_cols(left, left_on)?;
+    let right_keys = select_cols(right, right_on)?;
+    let left_payload = left_out_cols.map(|c| select_cols(left, c)).transpose()?;
+    let right_payload = right_out_cols.map(|c| select_cols(right, c)).transpose()?;
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let indices = ffi::left_join_indices(
@@ -882,10 +939,10 @@ pub fn full_join(
     left_out_cols: Option<&[usize]>,
     right_out_cols: Option<&[usize]>,
 ) -> Result<CuDFTable, CuDFError> {
-    let left_keys = select_cols(left, left_on);
-    let right_keys = select_cols(right, right_on);
-    let left_payload = left_out_cols.map(|c| select_cols(left, c));
-    let right_payload = right_out_cols.map(|c| select_cols(right, c));
+    let left_keys = select_cols(left, left_on)?;
+    let right_keys = select_cols(right, right_on)?;
+    let left_payload = left_out_cols.map(|c| select_cols(left, c)).transpose()?;
+    let right_payload = right_out_cols.map(|c| select_cols(right, c)).transpose()?;
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let indices = ffi::full_join_indices(
@@ -913,8 +970,8 @@ pub fn left_semi_join(
     left_on: &[usize],
     right_on: &[usize],
 ) -> Result<CuDFTable, CuDFError> {
-    let left_keys = select_cols(left, left_on);
-    let right_keys = select_cols(right, right_on);
+    let left_keys = select_cols(left, left_on)?;
+    let right_keys = select_cols(right, right_on)?;
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let join = ffi::filtered_join_create(
@@ -923,19 +980,21 @@ pub fn left_semi_join(
         SetAsBuildTable::Right as i32,
         stream_ref(&stream)?,
     )?;
-    let indices = Arc::new(JoinIndexVector::new(ffi::filtered_join_semi_join(
-        &join,
-        &left_keys,
-        stream_ref(&stream)?,
-        resource_ref(&resource)?,
-    )?));
-    let indices_view = indices.view();
-    Ok(CuDFTable::from_inner(ffi::gather(
+    let indices = Arc::new(JoinIndexVector::try_from_inner(
+        ffi::filtered_join_semi_join(
+            &join,
+            &left_keys,
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
+        )?,
+    )?);
+    let indices_view = indices.view()?;
+    CuDFTable::try_from_inner(ffi::gather(
         left.inner(),
         indices_view.inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?))
+    )?)
 }
 
 /// Perform a left anti join - return only left rows that have no match.
@@ -947,8 +1006,8 @@ pub fn left_anti_join(
     left_on: &[usize],
     right_on: &[usize],
 ) -> Result<CuDFTable, CuDFError> {
-    let left_keys = select_cols(left, left_on);
-    let right_keys = select_cols(right, right_on);
+    let left_keys = select_cols(left, left_on)?;
+    let right_keys = select_cols(right, right_on)?;
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
     let join = ffi::filtered_join_create(
@@ -957,19 +1016,21 @@ pub fn left_anti_join(
         SetAsBuildTable::Right as i32,
         stream_ref(&stream)?,
     )?;
-    let indices = Arc::new(JoinIndexVector::new(ffi::filtered_join_anti_join(
-        &join,
-        &left_keys,
-        stream_ref(&stream)?,
-        resource_ref(&resource)?,
-    )?));
-    let indices_view = indices.view();
-    Ok(CuDFTable::from_inner(ffi::gather(
+    let indices = Arc::new(JoinIndexVector::try_from_inner(
+        ffi::filtered_join_anti_join(
+            &join,
+            &left_keys,
+            stream_ref(&stream)?,
+            resource_ref(&resource)?,
+        )?,
+    )?);
+    let indices_view = indices.view()?;
+    CuDFTable::try_from_inner(ffi::gather(
         left.inner(),
         indices_view.inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?))
+    )?)
 }
 
 /// Perform a cross join (Cartesian product) of two tables.
@@ -978,12 +1039,12 @@ pub fn left_anti_join(
 pub fn cross_join(left: &CuDFTableView, right: &CuDFTableView) -> Result<CuDFTable, CuDFError> {
     let stream = ffi::get_default_stream();
     let resource = ffi::get_current_device_resource_ref();
-    Ok(CuDFTable::from_inner(ffi::cross_join(
+    CuDFTable::try_from_inner(ffi::cross_join(
         left.inner(),
         right.inner(),
         stream_ref(&stream)?,
         resource_ref(&resource)?,
-    )?))
+    )?)
 }
 
 #[cfg(test)]
@@ -1007,7 +1068,7 @@ mod tests {
             ],
         )
         .unwrap();
-        CuDFTable::from_arrow_host(batch).unwrap()
+        CuDFTable::try_from_arrow_host(batch).unwrap()
     }
 
     fn int32_values(batch: &RecordBatch, column: usize) -> Vec<i32> {
@@ -1273,10 +1334,8 @@ mod tests {
             predicate.binary_operation(CuDFAstOperator::Add, build_value, five)?;
         predicate.binary_operation(CuDFAstOperator::LessEqual, build_plus_five, probe_value)?;
 
-        let build_values = select_cols(&build_view, &[1]);
-        let probe_values = select_cols(&probe_view, &[1]);
-        let build_values_view = CuDFTableView::new_with_ref(build_values, build_view._ref.clone());
-        let probe_values_view = CuDFTableView::new_with_ref(probe_values, probe_view._ref.clone());
+        let build_values_view = CuDFTableView::try_from_column_views(vec![build_view.column(1)?])?;
+        let probe_values_view = CuDFTableView::try_from_column_views(vec![probe_view.column(1)?])?;
         let result = join.inner_join_filtered(CuDFFilteredHashJoinArgs {
             probe: &probe_view,
             probe_on: &[0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! use libcudf_rs::CuDFTable;
 //!
 //! // Read a Parquet file
-//! let table = CuDFTable::from_parquet("data.parquet").expect("Failed to read Parquet");
+//! let table = CuDFTable::read_parquet("data.parquet").expect("Failed to read Parquet");
 //! println!("Loaded table with {} rows and {} columns",
 //!          table.num_rows(), table.num_columns());
 //!

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 /// ```no_run
 /// use libcudf_rs::{CuDFTable, SortOrder, stable_sorted_order, gather};
 ///
-/// let table = CuDFTable::from_parquet("data.parquet")?;
+/// let table = CuDFTable::read_parquet("data.parquet")?;
 /// let view = table.into_view();
 ///
 /// // Get sorted indices
@@ -48,7 +48,7 @@ pub fn gather(table: &CuDFTableView, gather_map: &CuDFColumnView) -> Result<CuDF
         stream_ref(&stream)?,
         resource_ref(&mr)?,
     )?;
-    Ok(CuDFTable::from_inner(inner))
+    CuDFTable::try_from_inner(inner)
 }
 
 /// Filter a table using a boolean mask
@@ -81,11 +81,11 @@ pub fn gather(table: &CuDFTableView, gather_map: &CuDFColumnView) -> Result<CuDF
 /// let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 /// let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
 /// let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
-/// let table = CuDFTable::from_arrow_host(batch)?;
+/// let table = CuDFTable::try_from_arrow_host(batch)?;
 ///
 /// // Create a boolean mask
 /// let mask = BooleanArray::from(vec![true, false, true, false, true]);
-/// let mask_column = CuDFColumn::from_arrow_host(&mask)?;
+/// let mask_column = CuDFColumn::try_from_arrow_host(&mask)?;
 /// let mask_view = Arc::new(mask_column).view();
 ///
 /// // Filter the table
@@ -106,7 +106,7 @@ pub fn apply_boolean_mask(
         stream_ref(&stream)?,
         resource_ref(&mr)?,
     )?;
-    Ok(CuDFTable::from_inner(inner))
+    CuDFTable::try_from_inner(inner)
 }
 
 /// Create a sliced view of a column
@@ -134,7 +134,7 @@ pub fn apply_boolean_mask(
 /// use std::sync::Arc;
 ///
 /// let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-/// let column = CuDFColumn::from_arrow_host(&array)?;
+/// let column = CuDFColumn::try_from_arrow_host(&array)?;
 /// let column_view = Arc::new(column).view();
 ///
 /// // Get elements 1, 2, 3 (indices 1-3)
@@ -148,10 +148,7 @@ pub fn slice_column(
 ) -> Result<CuDFColumnView, CuDFError> {
     let stream = ffi::get_default_stream();
     let inner = ffi::slice_column(column.inner(), offset, length, stream_ref(&stream)?)?;
-    Ok(CuDFColumnView::new_with_ref(
-        inner,
-        Some(Arc::new(column.clone()) as Arc<dyn CuDFRef>),
-    ))
+    CuDFColumnView::try_from_inner(inner, Some(Arc::new(column.clone()) as Arc<dyn CuDFRef>))
 }
 
 /// Cast a column to a different data type on the GPU
@@ -179,13 +176,13 @@ pub fn cast(column: &CuDFColumnView, target_type: &DataType) -> Result<CuDFColum
     })?;
     let stream = ffi::get_default_stream();
     let mr = ffi::get_current_device_resource_ref();
-    let result = ffi::cast_column(
+    let result = ffi::cast(
         column.inner(),
         &cudf_dt,
         stream_ref(&stream)?,
         resource_ref(&mr)?,
     )?;
-    Ok(CuDFColumn::new(result))
+    CuDFColumn::try_from_inner(result)
 }
 
 #[cfg(test)]
@@ -196,7 +193,7 @@ mod tests {
     #[test]
     fn test_cast_int32_to_int64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let casted = cast(&column, &DataType::Int64)?;
         let result = casted.into_view().to_arrow_host()?;
@@ -209,7 +206,7 @@ mod tests {
     #[test]
     fn test_cast_int32_to_float64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let casted = cast(&column, &DataType::Float64)?;
         let result = casted.into_view().to_arrow_host()?;
@@ -222,7 +219,7 @@ mod tests {
     #[test]
     fn test_cast_float64_to_int64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Float64Array::from(vec![1.9, 2.1, 3.5]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let casted = cast(&column, &DataType::Int64)?;
         let result = casted.into_view().to_arrow_host()?;
@@ -236,7 +233,7 @@ mod tests {
     #[test]
     fn test_cast_with_nulls() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let casted = cast(&column, &DataType::Int64)?;
         let view = casted.into_view();
@@ -258,7 +255,7 @@ mod tests {
     #[test]
     fn test_cast_int64_to_uint64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int64Array::from(vec![1, 2, 3]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let casted = cast(&column, &DataType::UInt64)?;
         let result = casted.into_view().to_arrow_host()?;
@@ -271,7 +268,7 @@ mod tests {
     #[test]
     fn test_cast_preserves_length() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![10, 20, 30, 40, 50]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         let casted = cast(&column, &DataType::Float32)?;
         let view = casted.into_view();
@@ -282,7 +279,7 @@ mod tests {
     #[test]
     fn test_cast_unsupported_type_returns_error() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![1, 2, 3]);
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         // Interval types are not supported by cuDF
         let result = cast(&column, &DataType::Null);

--- a/src/pinned.rs
+++ b/src/pinned.rs
@@ -47,7 +47,7 @@ unsafe impl Sync for PinnedHostBuffer {}
 
 impl PinnedHostBuffer {
     /// Allocate `bytes` of pinned host memory from cuDF's pinned MR.
-    fn new(bytes: usize) -> Result<Self> {
+    fn try_new(bytes: usize) -> Result<Self> {
         let ptr = pinned_mr().allocate_sync(bytes)? as *mut u8;
         Ok(Self { ptr, bytes })
     }
@@ -88,7 +88,7 @@ pub fn synchronize_default_stream() -> Result<()> {
 /// Empty buffers are passed through unchanged because `cudaMallocHost(0)` is
 /// not portable and a zero-byte buffer has no data to DMA.
 pub fn pin_record_batch(batch: RecordBatch) -> Result<RecordBatch> {
-    ensure_pools_configured();
+    ensure_pools_configured()?;
     let schema = batch.schema();
     let arrays = batch
         .columns()
@@ -146,7 +146,7 @@ fn pin_buffer(buf: &Buffer) -> Result<Buffer> {
         return Ok(buf.clone());
     }
 
-    let pinned = Arc::new(PinnedHostBuffer::new(bytes)?);
+    let pinned = Arc::new(PinnedHostBuffer::try_new(bytes)?);
     let dst = pinned.as_ptr();
     // SAFETY: `pinned` was just allocated with at least `bytes` capacity,
     // `buf.as_ptr()` is valid for `bytes` reads, and the regions do not
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn pinned_host_buffer_round_trip() -> Result<()> {
-        let buf = PinnedHostBuffer::new(64)?;
+        let buf = PinnedHostBuffer::try_new(64)?;
         // SAFETY: we own the allocation and it has 64 bytes of capacity.
         unsafe {
             let slice = std::slice::from_raw_parts_mut(buf.as_ptr(), 64);
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn drop_during_unwinding_does_not_double_panic() {
         let result = std::panic::catch_unwind(|| {
-            let _buf = PinnedHostBuffer::new(1024).expect("alloc");
+            let _buf = PinnedHostBuffer::try_new(1024).expect("alloc");
             panic!("simulated user panic");
         });
         assert!(

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -17,28 +17,37 @@ use std::sync::{Arc, RwLock};
 /// This allows scalar values to be used in contexts that expect arrays, enabling
 /// seamless integration with operations that work on both scalars and columns.
 pub struct CuDFScalar {
-    inner: UniquePtr<ffi::Scalar>,
+    inner: Arc<UniquePtr<ffi::Scalar>>,
     dt: DataType,
     cached_scalar: RwLock<Option<Arc<ArrayData>>>,
 }
 
 impl CuDFScalar {
     /// Create a CuDFScalar from an existing cuDF scalar
-    pub(crate) fn new(inner: UniquePtr<ffi::Scalar>) -> Self {
-        let cudf_dtype = inner.data_type();
+    pub(crate) fn try_from_inner(inner: UniquePtr<ffi::Scalar>) -> Result<Self, CuDFError> {
+        if inner.is_null() {
+            return Err(CuDFError::NullHandle("scalar"));
+        }
+        let cudf_dtype = inner.data_type()?;
         let dt = cudf_type_to_arrow(&cudf_dtype);
         let dt = dt.unwrap_or(DataType::Null);
         let cached_scalar = RwLock::new(None);
-        Self {
-            inner,
+        Ok(Self {
+            inner: Arc::new(inner),
             dt,
             cached_scalar,
-        }
+        })
     }
 
     /// Get a reference to the underlying cuDF scalar
     pub(crate) fn inner(&self) -> &UniquePtr<ffi::Scalar> {
         &self.inner
+    }
+
+    /// Return whether this scalar contains a valid value.
+    pub fn is_valid(&self) -> Result<bool, CuDFError> {
+        let stream = ffi::get_default_stream();
+        Ok(self.inner().is_valid(stream_ref(&stream)?)?)
     }
 
     /// Convert the cuDF scalar to a single-element Arrow array, copying data from GPU to host
@@ -62,7 +71,7 @@ impl CuDFScalar {
     /// // Create a cuDF scalar from an Arrow scalar
     /// let array = Int32Array::from(vec![42]);
     /// let scalar = Scalar::new(&array);
-    /// let cudf_scalar = CuDFScalar::from_arrow_host(scalar)?;
+    /// let cudf_scalar = CuDFScalar::try_from_arrow_host(scalar)?;
     ///
     /// // Convert back to Arrow (GPU -> CPU)
     /// let arrow_array = cudf_scalar.to_arrow_host()?;
@@ -89,8 +98,21 @@ impl CuDFScalar {
                 &mut device_array as *mut libcudf_sys::ArrowDeviceArray as *mut u8;
             let stream = ffi::get_default_stream();
             let mr = ffi::get_current_device_resource_ref();
-            self.inner
-                .to_arrow_array(device_array_ptr, stream_ref(&stream)?, resource_ref(&mr)?);
+            let column = ffi::make_column_from_scalar(
+                self.inner(),
+                1,
+                stream_ref(&stream)?,
+                resource_ref(&mr)?,
+            )?;
+            // The owning column remains alive through the Arrow conversion.
+            let column_view = column.view()?;
+            ffi::to_arrow_host_column(
+                &column_view,
+                device_array_ptr,
+                stream_ref(&stream)?,
+                resource_ref(&mr)?,
+            )?;
+            stream_ref(&stream)?.synchronize()?;
         }
 
         // Convert from FFI structures to Arrow ArrayData
@@ -121,23 +143,23 @@ impl CuDFScalar {
     ///
     /// let array = Int32Array::from(vec![42]);
     /// let scalar = Scalar::new(&array);
-    /// let cudf_scalar = CuDFScalar::from_arrow_host(scalar)?;
+    /// let cudf_scalar = CuDFScalar::try_from_arrow_host(scalar)?;
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
-    pub fn from_arrow_host<T: Array>(scalar: Scalar<T>) -> Result<Self, CuDFError> {
+    pub fn try_from_arrow_host<T: Array>(scalar: Scalar<T>) -> Result<Self, CuDFError> {
         // Convert scalar to a single-element array
         let array = scalar.into_inner();
 
         // Convert the array to a cuDF column (this copies to GPU)
-        let column = CuDFColumn::from_arrow_host(&array)?.into_view();
+        let column = CuDFColumn::try_from_arrow_host(&array)?.into_view();
 
         // Extract the scalar from the column at index 0
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
         let cudf_scalar =
-            ffi::get_element(column.inner(), 0, stream_ref(&stream)?, resource_ref(&mr)?);
+            ffi::get_element(column.inner(), 0, stream_ref(&stream)?, resource_ref(&mr)?)?;
 
-        Ok(Self::new(cudf_scalar))
+        Self::try_from_inner(cudf_scalar)
     }
 
     /// Get or compute the cached ArrayData for this scalar
@@ -160,7 +182,7 @@ impl CuDFScalar {
     ///
     /// let array = Int32Array::from(vec![42]);
     /// let scalar = Scalar::new(&array);
-    /// let cudf_scalar = CuDFScalar::from_arrow_host(scalar)?;
+    /// let cudf_scalar = CuDFScalar::try_from_arrow_host(scalar)?;
     ///
     /// // First call: converts GPU -> CPU and caches
     /// let data1 = cudf_scalar.get_scalar_data()?;
@@ -198,7 +220,7 @@ impl Debug for CuDFScalar {
 impl Clone for CuDFScalar {
     fn clone(&self) -> Self {
         Self {
-            inner: self.inner.clone(),
+            inner: Arc::clone(&self.inner),
             dt: self.dt.clone(),
             cached_scalar: RwLock::new(None),
         }
@@ -230,7 +252,7 @@ unsafe impl Array for CuDFScalar {
             arrow::array::new_empty_array(&self.dt)
         } else {
             Arc::new(Self {
-                inner: self.inner.clone(),
+                inner: Arc::clone(&self.inner),
                 dt: self.dt.clone(),
                 cached_scalar: RwLock::new(None),
             })
@@ -351,7 +373,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_int32() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int32Array::from(vec![42]);
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&array))?;
         let result = cudf_scalar.to_arrow_host()?;
 
         assert_eq!(result.len(), 1);
@@ -365,7 +387,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_int64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Int64Array::from(vec![12345_i64]);
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&array))?;
         let result = cudf_scalar.to_arrow_host()?;
 
         assert_eq!(result.len(), 1);
@@ -379,7 +401,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_float64() -> Result<(), Box<dyn std::error::Error>> {
         let array = Float64Array::from(vec![std::f64::consts::PI]);
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&array))?;
         let result = cudf_scalar.to_arrow_host()?;
 
         assert_eq!(result.len(), 1);
@@ -393,7 +415,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_boolean() -> Result<(), Box<dyn std::error::Error>> {
         let array = BooleanArray::from(vec![true]);
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&array))?;
         let result = cudf_scalar.to_arrow_host()?;
 
         assert_eq!(result.len(), 1);
@@ -407,7 +429,7 @@ mod tests {
     #[test]
     fn test_to_arrow_host_string() -> Result<(), Box<dyn std::error::Error>> {
         let array = StringArray::from(vec!["hello world"]);
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&array))?;
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&array))?;
         let result = cudf_scalar.to_arrow_host()?;
 
         assert_eq!(result.len(), 1);
@@ -420,7 +442,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_slice_behavior_int32() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
         assert_slice_behavior(&scalar);
 
@@ -429,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_slice_behavior_float64() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Float64Array::from(vec![
             std::f64::consts::PI,
         ])))
         .expect("Failed to create scalar");
@@ -440,7 +462,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_slice_behavior_string() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
             .expect("Failed to create scalar");
         assert_slice_behavior(&scalar);
 
@@ -449,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_slice_behavior_null() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
             .expect("Failed to create scalar");
         assert_slice_behavior(&scalar);
 
@@ -458,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_slice_clears_cache() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![999])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int64Array::from(vec![999])))
             .expect("Failed to create scalar");
         assert_slice_clears_cache(&scalar);
 
@@ -467,7 +489,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_basics_int32() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
         assert_array_trait_basics(&scalar, &DataType::Int32);
 
@@ -476,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_basics_string() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
             .expect("Failed to create scalar");
         assert_array_trait_basics(&scalar, &DataType::Utf8);
 
@@ -485,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_basics_boolean() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&BooleanArray::from(vec![true])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&BooleanArray::from(vec![true])))
             .expect("Failed to create scalar");
         assert_array_trait_basics(&scalar, &DataType::Boolean);
 
@@ -494,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_array_trait_basics_null() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
             .expect("Failed to create scalar");
         assert_array_trait_basics(&scalar, &DataType::Int32);
 
@@ -503,7 +525,7 @@ mod tests {
 
     #[test]
     fn test_as_any_downcast() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
         assert!(scalar.as_any().downcast_ref::<CuDFScalar>().is_some());
 
@@ -512,7 +534,7 @@ mod tests {
 
     #[test]
     fn test_caching_works_int32() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
         let size1 = scalar.get_buffer_memory_size();
         let size2 = scalar.get_buffer_memory_size();
@@ -523,8 +545,9 @@ mod tests {
 
     #[test]
     fn test_caching_works_string() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["cached"])))
-            .expect("Failed to create scalar");
+        let scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&StringArray::from(vec!["cached"])))
+                .expect("Failed to create scalar");
         let size1 = scalar.get_buffer_memory_size();
         let size2 = scalar.get_buffer_memory_size();
         assert_eq!(size1, size2, "Cached and uncached sizes should match");
@@ -534,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_caching_memory_sizes() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
             .expect("Failed to create scalar");
 
         // Buffer size caching
@@ -554,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_caching_clone_clears_cache() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
 
         // Populate cache
@@ -571,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_caching_slice_clears_cache() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
 
         // Populate original cache
@@ -589,22 +612,25 @@ mod tests {
 
     #[test]
     fn test_memory_size() -> Result<(), Box<dyn std::error::Error>> {
-        let int32_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
-            .expect("Failed to create scalar");
+        let int32_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+                .expect("Failed to create scalar");
         assert_memory_size(&int32_scalar, 4, "Int32");
 
-        let int64_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
-            .expect("Failed to create scalar");
+        let int64_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
+                .expect("Failed to create scalar");
         assert_memory_size(&int64_scalar, 8, "Int64");
 
-        let float_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+        let float_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Float64Array::from(vec![
             std::f64::consts::PI,
         ])))
         .expect("Failed to create scalar");
         assert_memory_size(&float_scalar, 8, "Float64");
 
-        let bool_scalar = CuDFScalar::from_arrow_host(Scalar::new(&BooleanArray::from(vec![true])))
-            .expect("Failed to create scalar");
+        let bool_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&BooleanArray::from(vec![true])))
+                .expect("Failed to create scalar");
         let buffer_size = bool_scalar.get_buffer_memory_size();
         let array_size = bool_scalar.get_array_memory_size();
         assert!(buffer_size > 0, "Boolean buffer size should be positive");
@@ -615,7 +641,7 @@ mod tests {
 
         let test_string = "hello world";
         let string_scalar =
-            CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec![test_string])))
+            CuDFScalar::try_from_arrow_host(Scalar::new(&StringArray::from(vec![test_string])))
                 .expect("Failed to create scalar");
         let buffer_size = string_scalar.get_buffer_memory_size();
         let array_size = string_scalar.get_array_memory_size();
@@ -626,7 +652,7 @@ mod tests {
         );
         assert!(array_size >= buffer_size);
 
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
             .expect("Failed to create scalar");
         let buffer_size = scalar.get_buffer_memory_size();
         let array_size = scalar.get_array_memory_size();
@@ -641,20 +667,22 @@ mod tests {
 
     #[test]
     fn test_null_handling() -> Result<(), Box<dyn std::error::Error>> {
-        let null_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
-            .expect("Failed to create scalar");
-        assert!(!null_scalar.inner().is_valid(), "Scalar should be null");
+        let null_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+                .expect("Failed to create scalar");
+        assert!(!null_scalar.is_valid()?, "Scalar should be null");
 
-        let valid_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
-            .expect("Failed to create scalar");
-        assert!(valid_scalar.inner().is_valid(), "Scalar should be valid");
+        let valid_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+                .expect("Failed to create scalar");
+        assert!(valid_scalar.is_valid()?, "Scalar should be valid");
 
         Ok(())
     }
 
     #[test]
     fn test_null_scalar_to_arrow() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))?;
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))?;
         let result = scalar.to_arrow_host()?;
 
         assert_eq!(result.len(), 1);
@@ -670,14 +698,14 @@ mod tests {
 
     #[test]
     fn test_data_conversions() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
 
         let data = scalar.to_data();
         assert_eq!(data.len(), 1);
         assert_eq!(data.data_type(), &DataType::Int32);
 
-        let scalar2 = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar2 = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
         let data2 = scalar2.into_data();
         assert_eq!(data2.len(), 1);
@@ -688,7 +716,7 @@ mod tests {
 
     #[test]
     fn test_data_type_preserved_int32() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to create scalar");
         assert_eq!(scalar.data_type(), &DataType::Int32);
 
@@ -697,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_data_type_preserved_float64() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Float64Array::from(vec![
             std::f64::consts::PI,
         ])))
         .expect("Failed to create scalar");
@@ -708,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_data_type_preserved_string() -> Result<(), Box<dyn std::error::Error>> {
-        let scalar = CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
+        let scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&StringArray::from(vec!["test"])))
             .expect("Failed to create scalar");
         assert_eq!(scalar.data_type(), &DataType::Utf8);
 
@@ -717,7 +745,7 @@ mod tests {
 
     #[test]
     fn test_from_arrow_host_int32() -> Result<(), Box<dyn std::error::Error>> {
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![42])))
             .expect("Failed to convert Int32");
         assert_eq!(cudf_scalar.data_type(), &DataType::Int32);
 
@@ -726,8 +754,9 @@ mod tests {
 
     #[test]
     fn test_from_arrow_host_int64() -> Result<(), Box<dyn std::error::Error>> {
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
-            .expect("Failed to convert Int64");
+        let cudf_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&Int64Array::from(vec![12345])))
+                .expect("Failed to convert Int64");
         assert_eq!(cudf_scalar.data_type(), &DataType::Int64);
 
         Ok(())
@@ -735,7 +764,7 @@ mod tests {
 
     #[test]
     fn test_from_arrow_host_float64() -> Result<(), Box<dyn std::error::Error>> {
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Float64Array::from(vec![
+        let cudf_scalar = CuDFScalar::try_from_arrow_host(Scalar::new(&Float64Array::from(vec![
             std::f64::consts::PI,
         ])))
         .expect("Failed to convert Float64");
@@ -747,7 +776,7 @@ mod tests {
     #[test]
     fn test_from_arrow_host_string() -> Result<(), Box<dyn std::error::Error>> {
         let cudf_scalar =
-            CuDFScalar::from_arrow_host(Scalar::new(&StringArray::from(vec!["hello"])))
+            CuDFScalar::try_from_arrow_host(Scalar::new(&StringArray::from(vec!["hello"])))
                 .expect("Failed to convert String");
         assert_eq!(cudf_scalar.data_type(), &DataType::Utf8);
 
@@ -756,17 +785,18 @@ mod tests {
 
     #[test]
     fn test_from_arrow_host_null() -> Result<(), Box<dyn std::error::Error>> {
-        let cudf_scalar = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
-            .expect("Failed to convert null");
+        let cudf_scalar =
+            CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![None])))
+                .expect("Failed to convert null");
         assert_eq!(cudf_scalar.data_type(), &DataType::Int32);
-        assert!(!cudf_scalar.inner().is_valid());
+        assert!(!cudf_scalar.is_valid()?);
 
         Ok(())
     }
 
     #[test]
     fn test_scalar_clone() -> Result<(), Box<dyn std::error::Error>> {
-        let original = CuDFScalar::from_arrow_host(Scalar::new(&Int32Array::from(vec![999])))
+        let original = CuDFScalar::try_from_arrow_host(Scalar::new(&Int32Array::from(vec![999])))
             .expect("Failed to create scalar");
         let cloned = original.clone();
         assert_eq!(cloned.data_type(), original.data_type());

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -55,7 +55,7 @@ impl SortOrder {
 /// ```no_run
 /// use libcudf_rs::{CuDFTable, SortOrder, sort};
 ///
-/// let table = CuDFTable::from_parquet("data.parquet")?;
+/// let table = CuDFTable::read_parquet("data.parquet")?;
 /// let view = table.into_view();
 ///
 /// // Sort by column 0 ascending, then column 2 descending as tiebreaker
@@ -97,12 +97,12 @@ pub fn sort(
                     )),
                 ))
             } else {
-                Ok(table.column(idx as i32))
+                table.column(idx as i32)
             }
         })
         .collect();
     let key_views = key_views?;
-    let keys_view = CuDFTableView::from_column_views(key_views)?;
+    let keys_view = CuDFTableView::try_from_column_views(key_views)?;
 
     let column_order_i32: Vec<i32> = sort_orders.iter().map(|&o| o.order() as i32).collect();
     let null_precedence_i32: Vec<i32> =
@@ -118,7 +118,7 @@ pub fn sort(
         stream_ref(&stream)?,
         resource_ref(&mr)?,
     )?;
-    Ok(CuDFTable::from_inner(inner))
+    CuDFTable::try_from_inner(inner)
 }
 
 /// Sort a table by all columns in lexicographic order
@@ -142,7 +142,7 @@ pub fn sort(
 /// ```no_run
 /// use libcudf_rs::{CuDFTable, SortOrder, sort_by_all};
 ///
-/// let table = CuDFTable::from_parquet("data.parquet")?;
+/// let table = CuDFTable::read_parquet("data.parquet")?;
 /// let view = table.into_view();
 ///
 /// // Sort by first column ascending (nulls last), second column descending (nulls first)
@@ -167,7 +167,7 @@ pub fn sort_by_all(
         stream_ref(&stream)?,
         resource_ref(&mr)?,
     )?;
-    Ok(CuDFTable::from_inner(inner))
+    CuDFTable::try_from_inner(inner)
 }
 
 /// Get the sorted order (indices) of a table
@@ -189,7 +189,7 @@ pub fn sort_by_all(
 /// ```no_run
 /// use libcudf_rs::{CuDFTable, SortOrder, stable_sorted_order};
 ///
-/// let table = CuDFTable::from_parquet("data.parquet")?;
+/// let table = CuDFTable::read_parquet("data.parquet")?;
 /// let view = table.into_view();
 ///
 /// let sort_orders = vec![SortOrder::AscendingNullsLast, SortOrder::DescendingNullsFirst];
@@ -213,7 +213,7 @@ pub fn stable_sorted_order(
         stream_ref(&stream)?,
         resource_ref(&mr)?,
     )?;
-    Ok(CuDFColumn::new(inner))
+    CuDFColumn::try_from_inner(inner)
 }
 
 #[cfg(test)]
@@ -225,7 +225,7 @@ mod tests {
     fn test_sort_ascending() -> Result<(), Box<dyn std::error::Error>> {
         let batch = record_batch!(("a", Int32, [3, 1, 4, 1, 5, 9, 2, 6]))?;
 
-        let table = CuDFTable::from_arrow_host(batch)?;
+        let table = CuDFTable::try_from_arrow_host(batch)?;
         let view = table.into_view();
 
         let sorted = sort(&view, &[0], &[SortOrder::AscendingNullsLast])?;
@@ -241,7 +241,7 @@ mod tests {
     fn test_sort_descending() -> Result<(), Box<dyn std::error::Error>> {
         let batch = record_batch!(("a", Int32, [3, 1, 4, 1, 5]))?;
 
-        let table = CuDFTable::from_arrow_host(batch)?;
+        let table = CuDFTable::try_from_arrow_host(batch)?;
         let view = table.into_view();
 
         let sorted = sort(&view, &[0], &[SortOrder::DescendingNullsLast])?;
@@ -260,7 +260,7 @@ mod tests {
             ("b", Int32, [10, 20, 30, 40, 50])
         )?;
 
-        let table = CuDFTable::from_arrow_host(batch)?;
+        let table = CuDFTable::try_from_arrow_host(batch)?;
         let view = table.into_view();
 
         // Sort by column A ascending, then column B ascending
@@ -288,7 +288,7 @@ mod tests {
             ("b", Int32, [10, 40, 30, 20, 50])
         )?;
 
-        let table = CuDFTable::from_arrow_host(batch)?;
+        let table = CuDFTable::try_from_arrow_host(batch)?;
         let view = table.into_view();
 
         // Sort by column A only - column B order should be preserved (stable sort)
@@ -312,7 +312,7 @@ mod tests {
             ("b", Int32, [10, 40, 30, 20, 50])
         )?;
 
-        let table = CuDFTable::from_arrow_host(batch)?;
+        let table = CuDFTable::try_from_arrow_host(batch)?;
         let view = table.into_view();
 
         // Sort by all columns

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -37,46 +37,45 @@ pub struct CuDFStream {
 }
 
 impl CuDFStream {
-    /// Try to create a stream using the sync-default creation flag.
-    pub fn try_new() -> Result<Self> {
-        Ok(Self {
-            inner: libcudf_sys::ffi::cuda_stream_create()?,
-        })
+    fn try_from_inner(inner: UniquePtr<ffi::CudaStream>) -> Result<Self> {
+        if inner.is_null() {
+            return Err(CuDFError::NullHandle("CUDA stream"));
+        }
+        Ok(Self { inner })
     }
 
-    /// Create a stream using the sync-default creation flag.
-    pub fn new() -> Self {
-        Self::try_new().expect("failed to create CUDA stream")
+    /// Try to create a stream using the sync-default creation flag.
+    pub fn try_new() -> Result<Self> {
+        Self::try_from_inner(ffi::cuda_stream_create()?)
     }
 
     /// Try to create a stream with explicit creation flags.
     pub fn try_with_flags(flags: CuDFStreamFlags) -> Result<Self> {
-        Ok(Self {
-            inner: libcudf_sys::ffi::cuda_stream_create_with_flags(flags.into())?,
-        })
-    }
-
-    /// Create a stream with explicit creation flags.
-    pub fn with_flags(flags: CuDFStreamFlags) -> Self {
-        Self::try_with_flags(flags).expect("failed to create CUDA stream")
+        Self::try_from_inner(ffi::cuda_stream_create_with_flags(flags.into())?)
     }
 
     /// Block until all work submitted to this stream has completed.
     pub fn synchronize(&self) -> Result<()> {
-        self.inner().synchronize()?;
+        self.inner()?.synchronize()?;
         Ok(())
     }
 
-    /// Returns an owned [ffi::CudaStreamView] for this stream.
+    /// Returns a non-owning [ffi::CudaStreamView] for this stream.
+    ///
+    /// # Safety
+    ///
+    /// The returned view must not outlive `self`.
     #[allow(dead_code)]
-    pub(crate) fn view(&self) -> UniquePtr<ffi::CudaStreamView> {
-        ffi::cuda_stream_view(self.inner())
+    pub(crate) unsafe fn view(&self) -> Result<UniquePtr<ffi::CudaStreamView>> {
+        Ok(unsafe { ffi::cuda_stream_view(self.inner()?) })
     }
 
     /// Get a reference to the underlying FFI stream handle.
     #[allow(dead_code)]
-    pub(crate) fn inner(&self) -> &libcudf_sys::ffi::CudaStream {
-        self.inner.as_ref().expect("CudaStream should not be null")
+    pub(crate) fn inner(&self) -> Result<&ffi::CudaStream> {
+        self.inner
+            .as_ref()
+            .ok_or(CuDFError::NullHandle("CUDA stream"))
     }
 }
 
@@ -88,10 +87,4 @@ pub(crate) fn stream_ref(stream: &UniquePtr<ffi::CudaStreamView>) -> Result<&ffi
     stream
         .as_ref()
         .ok_or(CuDFError::NullHandle("CUDA stream view"))
-}
-
-impl Default for CuDFStream {
-    fn default() -> Self {
-        Self::new()
-    }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -16,7 +16,10 @@ use std::sync::Arc;
 ///
 /// This is a safe wrapper around cuDF's table type.
 pub struct CuDFTable {
+    view: Arc<UniquePtr<ffi::TableView>>,
     pub(crate) inner: UniquePtr<ffi::Table>,
+    num_rows: usize,
+    column_device_memory_sizes: Vec<usize>,
 }
 
 /// Result of reading Parquet with cuDF, including metadata needed for schema adaptation.
@@ -54,8 +57,20 @@ where
 
 impl CuDFTable {
     /// Create a CuDFTable from a raw FFI table (internal use)
-    pub(crate) fn from_inner(inner: UniquePtr<ffi::Table>) -> Self {
-        Self { inner }
+    pub(crate) fn try_from_inner(inner: UniquePtr<ffi::Table>) -> Result<Self, CuDFError> {
+        if inner.is_null() {
+            return Err(CuDFError::NullHandle("table"));
+        }
+        let num_rows = crate::errors::cudf_size_to_usize(inner.num_rows()?, "table row count")?;
+        let column_device_memory_sizes = table_column_device_memory_sizes(&inner)?;
+        // `inner` is stored alongside the view and therefore outlives it.
+        let view = unsafe { inner.view() }?;
+        Ok(Self {
+            inner,
+            view: Arc::new(view),
+            num_rows,
+            column_device_memory_sizes,
+        })
     }
     /// Create an empty table
     ///
@@ -64,27 +79,22 @@ impl CuDFTable {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// assert_eq!(table.num_rows(), 0);
     /// assert_eq!(table.num_columns(), 0);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
-    pub(crate) fn new() -> Self {
-        Self {
-            inner: ffi::create_empty_table(),
-        }
+    pub fn try_empty() -> Result<Self, CuDFError> {
+        Self::try_from_inner(ffi::create_empty_table()?)
     }
 
-    pub(crate) fn from_ptr(inner: UniquePtr<ffi::Table>) -> Self {
-        Self { inner }
-    }
-
-    pub(crate) fn from_columns(mut columns: Vec<CuDFColumn>) -> Self {
+    pub(crate) fn try_from_columns(mut columns: Vec<CuDFColumn>) -> Result<Self, CuDFError> {
         let ptrs: Vec<_> = columns
             .iter_mut()
             .map(|col| col.inner.as_mut_ptr())
             .collect();
-        let inner = ffi::create_table_from_columns_move(&ptrs);
-        Self { inner }
+        let inner = unsafe { ffi::create_table_from_columns_move(&ptrs) }?;
+        Self::try_from_inner(inner)
     }
 
     /// Read a table from a Parquet file
@@ -106,20 +116,20 @@ impl CuDFTable {
     /// ```no_run
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::from_parquet("data.parquet")?;
+    /// let table = CuDFTable::read_parquet("data.parquet")?;
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
-    pub fn from_parquet<P: AsRef<Path>>(path: P) -> Result<Self, CuDFError> {
-        Self::from_parquet_files(std::slice::from_ref(&path))
+    pub fn read_parquet<P: AsRef<Path>>(path: P) -> Result<Self, CuDFError> {
+        Self::read_parquet_files(std::slice::from_ref(&path))
     }
 
     /// Read a table from one or more Parquet files.
-    pub fn from_parquet_files<P: AsRef<Path>>(paths: &[P]) -> Result<Self, CuDFError> {
-        Self::from_parquet_files_with_columns(paths, Option::<&[String]>::None)
+    pub fn read_parquet_files<P: AsRef<Path>>(paths: &[P]) -> Result<Self, CuDFError> {
+        Self::read_parquet_files_with_columns(paths, Option::<&[String]>::None)
     }
 
     /// Read selected columns from one or more Parquet files.
-    pub fn from_parquet_files_with_columns<P, S>(
+    pub fn read_parquet_files_with_columns<P, S>(
         paths: &[P],
         columns: Option<&[S]>,
     ) -> Result<Self, CuDFError>
@@ -127,30 +137,19 @@ impl CuDFTable {
         P: AsRef<Path>,
         S: AsRef<str>,
     {
-        Ok(Self::read_parquet_files_with_columns(paths, columns)?.table)
-    }
-
-    /// Read selected columns from one or more Parquet files with cuDF metadata.
-    pub fn read_parquet_files_with_columns<P, S>(
-        paths: &[P],
-        columns: Option<&[S]>,
-    ) -> Result<CuDFParquetReadResult, CuDFError>
-    where
-        P: AsRef<Path>,
-        S: AsRef<str>,
-    {
-        Self::read_parquet_files(CuDFParquetReadOptions {
+        Ok(Self::read_parquet_with_options(CuDFParquetReadOptions {
             paths,
             columns,
             row_groups: None,
             filter: None,
             allow_mismatched_pq_schemas: false,
             ignore_missing_columns: true,
-        })
+        })?
+        .table)
     }
 
     /// Read Parquet files with cuDF metadata.
-    pub fn read_parquet_files<P, S>(
+    pub fn read_parquet_with_options<P, S>(
         read_options: CuDFParquetReadOptions<'_, P, S>,
     ) -> Result<CuDFParquetReadResult, CuDFError>
     where
@@ -209,7 +208,7 @@ impl CuDFTable {
         P: AsRef<Path>,
         S: AsRef<str>,
     {
-        crate::config::ensure_pools_configured();
+        crate::config::ensure_pools_configured()?;
         let CuDFParquetReadOptions {
             paths,
             columns,
@@ -328,9 +327,10 @@ impl CuDFTable {
             .map(|index| result.schema_info_name(index))
             .collect();
         let inner = result.pin_mut().release_table();
-        let num_rows = inner.num_rows();
+        let table = Self::try_from_inner(inner)?;
+        let num_rows = table.num_rows();
         Ok(CuDFParquetReadResult {
-            table: Self { inner },
+            table,
             column_names,
             num_rows,
         })
@@ -359,7 +359,7 @@ impl CuDFTable {
 
         while reader.has_next() {
             let mut result = reader.read_chunk()?;
-            if !callback(Self::parquet_read_result_from_metadata(&mut result))? {
+            if !callback(Self::parquet_read_result_from_metadata(&mut result)?)? {
                 break;
             }
         }
@@ -368,17 +368,18 @@ impl CuDFTable {
 
     fn parquet_read_result_from_metadata(
         result: &mut UniquePtr<ffi::TableWithMetadata>,
-    ) -> CuDFParquetReadResult {
+    ) -> Result<CuDFParquetReadResult, CuDFError> {
         let column_names = (0..result.schema_info_count())
             .map(|index| result.schema_info_name(index))
             .collect();
         let inner = result.pin_mut().release_table();
-        let num_rows = inner.num_rows();
-        CuDFParquetReadResult {
-            table: Self { inner },
+        let table = Self::try_from_inner(inner)?;
+        let num_rows = table.num_rows();
+        Ok(CuDFParquetReadResult {
+            table,
             column_names,
             num_rows,
-        }
+        })
     }
 
     /// Write the table to a Parquet file
@@ -407,11 +408,10 @@ impl CuDFTable {
             ArrowError::InvalidArgumentError("Path contains invalid UTF-8".to_string())
         })?;
 
-        let view = self.inner.view();
         let sink = ffi::sink_info_from_file_path(path_str);
         let options = ffi::parquet_writer_options_create(
             sink.as_ref().expect("sink_info should not be null"),
-            &view,
+            &self.view,
         );
         let stream = ffi::get_default_stream();
         let _metadata = ffi::write_parquet(
@@ -447,11 +447,11 @@ impl CuDFTable {
     ///
     /// # let batch: RecordBatch = todo!();
     /// // Convert Arrow RecordBatch to cuDF table for GPU acceleration
-    /// let table = CuDFTable::from_arrow_host(batch)?;
+    /// let table = CuDFTable::try_from_arrow_host(batch)?;
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
-    pub fn from_arrow_host(batch: RecordBatch) -> Result<Self, CuDFError> {
-        crate::config::ensure_pools_configured();
+    pub fn try_from_arrow_host(batch: RecordBatch) -> Result<Self, CuDFError> {
+        crate::config::ensure_pools_configured()?;
         for col in batch.columns() {
             if is_cudf_array(col) {
                 return Err(ArrowError::InvalidArgumentError("Tried to move a RecordBatch from the host to CuDF, but a column was already in CuDF".to_string()))?;
@@ -471,7 +471,7 @@ impl CuDFTable {
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
         let inner = unsafe {
-            ffi::table_from_arrow_host(
+            ffi::from_arrow_host(
                 schema_ptr,
                 device_array_ptr,
                 stream_ref(&stream)?,
@@ -479,7 +479,7 @@ impl CuDFTable {
             )
         }?;
 
-        Ok(Self { inner })
+        Self::try_from_inner(inner)
     }
 
     /// Get the number of rows in the table
@@ -489,11 +489,12 @@ impl CuDFTable {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// assert_eq!(table.num_rows(), 0);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn num_rows(&self) -> usize {
-        self.inner.num_rows()
+        self.num_rows
     }
 
     /// Get the number of columns in the table
@@ -503,11 +504,12 @@ impl CuDFTable {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// assert_eq!(table.num_columns(), 0);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn num_columns(&self) -> usize {
-        self.inner.num_columns()
+        self.column_device_memory_sizes.len()
     }
 
     /// Check if the table is empty
@@ -517,11 +519,17 @@ impl CuDFTable {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// assert!(table.is_empty());
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         self.num_rows() == 0
+    }
+
+    /// Return the bytes allocated for this table in device memory.
+    pub fn device_memory_size(&self) -> usize {
+        self.column_device_memory_sizes.iter().sum()
     }
 
     /// Get a non-owning view of this table
@@ -529,26 +537,29 @@ impl CuDFTable {
     /// The returned view borrows from this table and remains valid as long as
     /// the table exists.
     pub fn view(self: Arc<Self>) -> CuDFTableView {
-        CuDFTableView::new_with_ref(self.inner.view(), Some(self))
+        let view = Arc::clone(&self.view);
+        let num_rows = self.num_rows;
+        let sizes = self.column_device_memory_sizes.clone();
+        CuDFTableView::from_shared_view(view, Some(self), num_rows, sizes)
     }
 
     /// Get a non-owning view of this table
     pub fn into_view(self) -> CuDFTableView {
-        CuDFTableView::new_with_ref(self.inner.view(), Some(Arc::new(self)))
+        Arc::new(self).view()
     }
 
     /// Take ownership of the table's columns
     ///
     /// This consumes the table structure and returns its columns as a collection
     /// that can be individually released.
-    pub fn into_columns(mut self) -> Vec<CuDFColumn> {
-        let mut columns = self.inner.pin_mut().release();
+    pub fn into_columns(mut self) -> Result<Vec<CuDFColumn>, CuDFError> {
+        let mut columns = self.inner.pin_mut().release()?;
         let mut result = Vec::with_capacity(columns.len());
         for i in 0..columns.len() {
             let col = columns.pin_mut().release(i);
-            result.push(CuDFColumn::new(col));
+            result.push(CuDFColumn::try_from_inner(col));
         }
-        result
+        result.into_iter().collect()
     }
 
     /// Concatenate multiple table views into a single table
@@ -568,36 +579,40 @@ impl CuDFTable {
     /// ```no_run
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table1 = CuDFTable::from_parquet("data1.parquet")?;
-    /// let table2 = CuDFTable::from_parquet("data2.parquet")?;
+    /// let table1 = CuDFTable::read_parquet("data1.parquet")?;
+    /// let table2 = CuDFTable::read_parquet("data2.parquet")?;
     ///
     /// let views = vec![table1.into_view(), table2.into_view()];
     /// let concatenated = CuDFTable::concat(views)?;
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn concat(views: Vec<CuDFTableView>) -> Result<Self, CuDFError> {
-        // The CuDFTableView need to leave at least until the ffi::concat_table_views operation
-        // has finished.
-        let mut _refs = Vec::with_capacity(views.len());
         let inner_views: Vec<_> = views
-            .into_iter()
-            .map(|v| {
-                _refs.push(v._ref.clone());
-                v.into_inner()
-            })
-            .collect();
+            .iter()
+            .map(CuDFTableView::clone_inner)
+            .collect::<Result<_, _>>()?;
         let stream = ffi::get_default_stream();
         let mr = ffi::get_current_device_resource_ref();
         let inner =
             ffi::concat_table_views(&inner_views, stream_ref(&stream)?, resource_ref(&mr)?)?;
-        Ok(Self { inner })
+        Self::try_from_inner(inner)
     }
 }
 
-impl Default for CuDFTable {
-    fn default() -> Self {
-        Self::new()
-    }
+fn table_column_device_memory_sizes(
+    table: &UniquePtr<ffi::Table>,
+) -> Result<Vec<usize>, CuDFError> {
+    let num_columns =
+        crate::errors::cudf_size_to_usize(table.num_columns()?, "table column count")?;
+    (0..num_columns)
+        .map(|index| {
+            let index = i32::try_from(index).map_err(|_| {
+                ArrowError::ComputeError("cuDF table column index overflowed i32".into())
+            })?;
+            let column = unsafe { table.get_column(index) }?;
+            Ok(column.alloc_size()?)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -607,17 +622,12 @@ mod tests {
     use arrow::datatypes::*;
 
     #[test]
-    fn test_empty_table() {
-        let table = CuDFTable::new();
+    fn test_empty_table() -> Result<(), Box<dyn std::error::Error>> {
+        let table = CuDFTable::try_empty()?;
         assert_eq!(table.num_rows(), 0);
         assert_eq!(table.num_columns(), 0);
         assert!(table.is_empty());
-    }
-
-    #[test]
-    fn test_default_table() {
-        let table = CuDFTable::default();
-        assert!(table.is_empty());
+        Ok(())
     }
 
     #[test]
@@ -669,7 +679,8 @@ mod tests {
         let batch =
             RecordBatch::try_new(Arc::new(schema), arrays).expect("Failed to create RecordBatch");
 
-        let table = CuDFTable::from_arrow_host(batch.clone()).expect("Failed to convert to cuDF");
+        let table =
+            CuDFTable::try_from_arrow_host(batch.clone()).expect("Failed to convert to cuDF");
 
         assert_eq!(table.num_rows(), 5);
         assert_eq!(table.num_columns(), 14);
@@ -729,7 +740,7 @@ mod tests {
         )
         .expect("Failed to create RecordBatch");
 
-        let table = CuDFTable::from_arrow_host(batch).expect("Failed to convert to cuDF");
+        let table = CuDFTable::try_from_arrow_host(batch).expect("Failed to convert to cuDF");
         assert_eq!(table.num_rows(), 0);
         assert_eq!(table.num_columns(), 2);
 
@@ -743,7 +754,7 @@ mod tests {
 
     #[test]
     fn test_arrow_parquet_roundtrip() {
-        let table = CuDFTable::from_parquet("testdata/weather/result-000000.parquet")
+        let table = CuDFTable::read_parquet("testdata/weather/result-000000.parquet")
             .expect("Failed to read parquet");
 
         let batch = table
@@ -754,7 +765,7 @@ mod tests {
         let original_rows = batch.num_rows();
         let original_cols = batch.num_columns();
 
-        let table2 = CuDFTable::from_arrow_host(batch).expect("Failed to convert from Arrow");
+        let table2 = CuDFTable::try_from_arrow_host(batch).expect("Failed to convert from Arrow");
 
         assert_eq!(table2.num_rows(), original_rows);
         assert_eq!(table2.num_columns(), original_cols);
@@ -762,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_parquet_file_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
-        let table = CuDFTable::from_parquet("testdata/weather/result-000000.parquet")?;
+        let table = CuDFTable::read_parquet("testdata/weather/result-000000.parquet")?;
         let output = std::env::temp_dir().join(format!(
             "libcudf-rs-roundtrip-{}-{}.parquet",
             std::process::id(),
@@ -773,7 +784,7 @@ mod tests {
 
         let result = (|| -> Result<(), Box<dyn std::error::Error>> {
             table.to_parquet(&output)?;
-            let roundtrip = CuDFTable::from_parquet(&output)?;
+            let roundtrip = CuDFTable::read_parquet(&output)?;
 
             assert_eq!(roundtrip.num_rows(), table.num_rows());
             assert_eq!(roundtrip.num_columns(), table.num_columns());
@@ -788,7 +799,7 @@ mod tests {
     fn test_read_all_weather_files() {
         for i in 0..3 {
             let filename = format!("testdata/weather/result-{:06}.parquet", i);
-            let table = CuDFTable::from_parquet(&filename)
+            let table = CuDFTable::read_parquet(&filename)
                 .unwrap_or_else(|_| panic!("Failed to read {}", filename));
 
             assert!(table.num_rows() > 0);
@@ -804,7 +815,7 @@ mod tests {
         ];
         let columns = vec!["MinTemp".to_string(), "MaxTemp".to_string()];
 
-        let projected = CuDFTable::from_parquet_files_with_columns(&files, Some(&columns))?;
+        let projected = CuDFTable::read_parquet_files_with_columns(&files, Some(&columns))?;
 
         assert!(projected.num_rows() > 0);
         assert_eq!(projected.num_columns(), columns.len());

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -3,11 +3,11 @@ use crate::device_resource::resource_ref;
 use crate::stream::stream_ref;
 use crate::{CuDFColumnView, CuDFError};
 use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, StructArray};
-use arrow::ffi::{from_ffi, FFI_ArrowArray};
+use arrow::ffi::from_ffi;
 use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::{ArrowError, Schema, SchemaRef};
 use cxx::UniquePtr;
-use libcudf_sys::ffi;
+use libcudf_sys::{ffi, ArrowDeviceArray};
 use std::sync::Arc;
 
 /// A non-owning view of a GPU table
@@ -15,25 +15,39 @@ use std::sync::Arc;
 /// This is a safe wrapper around cuDF's table_view type.
 /// Views provide a lightweight way to reference table data without ownership.
 pub struct CuDFTableView {
-    // Keep the table alive so view remains valid
-    pub(crate) _ref: Option<Arc<dyn CuDFRef>>,
-    inner: UniquePtr<ffi::TableView>,
+    inner: Arc<UniquePtr<ffi::TableView>>,
+    // Keep cuDF owners alive until after the non-owning view is dropped.
+    pub(crate) keepalive: Option<Arc<dyn CuDFRef>>,
+    num_rows: usize,
+    column_device_memory_sizes: Vec<usize>,
 }
 
 impl CuDFTableView {
-    pub(crate) fn new_with_ref(
-        inner: UniquePtr<ffi::TableView>,
-        _ref: Option<Arc<dyn CuDFRef>>,
+    pub(crate) fn from_shared_view(
+        inner: Arc<UniquePtr<ffi::TableView>>,
+        keepalive: Option<Arc<dyn CuDFRef>>,
+        num_rows: usize,
+        column_device_memory_sizes: Vec<usize>,
     ) -> Self {
-        Self { _ref, inner }
+        Self {
+            inner,
+            keepalive,
+            num_rows,
+            column_device_memory_sizes,
+        }
     }
 
-    pub fn inner(&self) -> &UniquePtr<ffi::TableView> {
+    pub(crate) fn inner(&self) -> &UniquePtr<ffi::TableView> {
         &self.inner
     }
 
-    pub(crate) fn into_inner(self) -> UniquePtr<ffi::TableView> {
-        self.inner
+    pub(crate) fn clone_inner(&self) -> Result<UniquePtr<ffi::TableView>, CuDFError> {
+        let inner = self
+            .inner
+            .as_ref()
+            .as_ref()
+            .ok_or(CuDFError::NullHandle("table view"))?;
+        Ok(ffi::table_view_clone(inner)?)
     }
 
     /// Create a table view from a slice of column view references
@@ -57,27 +71,39 @@ impl CuDFTableView {
     /// // Create column views
     /// let col1 = Int32Array::from(vec![1, 2, 3]);
     /// let col2 = Int32Array::from(vec![4, 5, 6]);
-    /// let view1 = CuDFColumn::from_arrow_host(&col1)?.into_view();
-    /// let view2 = CuDFColumn::from_arrow_host(&col2)?.into_view();
+    /// let view1 = CuDFColumn::try_from_arrow_host(&col1)?.into_view();
+    /// let view2 = CuDFColumn::try_from_arrow_host(&col2)?.into_view();
     ///
     /// // Create a table view from the column views
-    /// let table_view = CuDFTableView::from_column_views(vec![view1, view2])?;
+    /// let table_view = CuDFTableView::try_from_column_views(vec![view1, view2])?;
     /// assert_eq!(table_view.num_columns(), 2);
     /// assert_eq!(table_view.num_rows(), 3);
     /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
-    pub fn from_column_views(column_views: Vec<CuDFColumnView>) -> Result<Self, CuDFError> {
+    pub fn try_from_column_views(column_views: Vec<CuDFColumnView>) -> Result<Self, CuDFError> {
         let mut view_ptrs: Vec<*const ffi::ColumnView> = Vec::with_capacity(column_views.len());
-        let mut _refs = Vec::with_capacity(column_views.len());
+        let mut keepalives = Vec::with_capacity(column_views.len());
+        let column_device_memory_sizes = column_views
+            .iter()
+            .map(CuDFColumnView::device_memory_size)
+            .collect();
         for view in column_views {
-            view_ptrs.push(view.inner().as_ref().unwrap() as _);
-            _refs.push(Arc::new(view) as Arc<dyn CuDFRef>)
+            let inner = view
+                .inner()
+                .as_ref()
+                .ok_or(CuDFError::NullHandle("column view"))?;
+            view_ptrs.push(inner as _);
+            keepalives.push(Arc::new(view) as Arc<dyn CuDFRef>)
         }
 
-        let inner = ffi::create_table_view_from_column_views(&view_ptrs);
+        let inner = unsafe { ffi::create_table_view_from_column_views(&view_ptrs) }?;
+        let num_rows =
+            crate::errors::cudf_size_to_usize(inner.num_rows()?, "table-view row count")?;
         Ok(Self {
-            _ref: Some(Arc::new(_refs)),
-            inner,
+            inner: Arc::new(inner),
+            keepalive: Some(Arc::new(keepalives)),
+            num_rows,
+            column_device_memory_sizes,
         })
     }
 
@@ -88,12 +114,13 @@ impl CuDFTableView {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// let view = table.into_view();
     /// assert_eq!(view.num_rows(), 0);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn num_rows(&self) -> usize {
-        self.inner.num_rows()
+        self.num_rows
     }
 
     /// Get the number of columns in the table view
@@ -103,12 +130,13 @@ impl CuDFTableView {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// let view = table.into_view();
     /// assert_eq!(view.num_columns(), 0);
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn num_columns(&self) -> usize {
-        self.inner.num_columns()
+        self.column_device_memory_sizes.len()
     }
 
     /// Check if the table view is empty
@@ -118,9 +146,10 @@ impl CuDFTableView {
     /// ```
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::default();
+    /// let table = CuDFTable::try_empty()?;
     /// let view = table.into_view();
     /// assert!(view.is_empty());
+    /// # Ok::<(), libcudf_rs::CuDFError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         self.num_rows() == 0
@@ -131,9 +160,23 @@ impl CuDFTableView {
     /// # Arguments
     ///
     /// * `index` - The column index (0-based)
-    pub fn column(&self, index: i32) -> CuDFColumnView {
-        let inner = self.inner.column(index);
-        CuDFColumnView::new_with_ref(inner, Some(Arc::new(self.clone())))
+    pub fn column(&self, index: i32) -> Result<CuDFColumnView, CuDFError> {
+        let usize_index = usize::try_from(index).map_err(|_| {
+            ArrowError::InvalidArgumentError(format!("negative column index {index}"))
+        })?;
+        if usize_index >= self.num_columns() {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "column index {index} out of bounds for {} columns",
+                self.num_columns()
+            ))
+            .into());
+        }
+        let inner = self.inner.column(index)?;
+        CuDFColumnView::try_from_inner_with_device_size(
+            inner,
+            Some(Arc::new(self.clone())),
+            self.column_device_memory_sizes.get(usize_index).copied(),
+        )
     }
 
     /// Convert the CuDF table allocated on the GPU to an Arrow RecordBatch allocated on the host.
@@ -152,7 +195,7 @@ impl CuDFTableView {
     /// ```no_run
     /// use libcudf_rs::CuDFTable;
     ///
-    /// let table = CuDFTable::from_parquet("data.parquet")?;
+    /// let table = CuDFTable::read_parquet("data.parquet")?;
     /// // Perform GPU operations...
     ///
     /// // Convert back to Arrow for further processing
@@ -161,22 +204,28 @@ impl CuDFTableView {
     /// ```
     pub fn to_arrow_host(&self) -> Result<RecordBatch, CuDFError> {
         let mut ffi_schema = FFI_ArrowSchema::empty();
-        let mut ffi_array = FFI_ArrowArray::empty();
+        let mut device_array = ArrowDeviceArray::new_cpu();
 
         unsafe {
-            self.inner
-                .to_arrow_schema(&mut ffi_schema as *mut FFI_ArrowSchema as *mut u8);
+            let metadata = ffi::get_table_metadata(self.inner())?;
+            ffi::to_arrow_schema(
+                self.inner(),
+                &metadata,
+                &mut ffi_schema as *mut FFI_ArrowSchema as *mut u8,
+            )?;
             let stream = ffi::get_default_stream();
             let mr = ffi::get_current_device_resource_ref();
-            self.inner.to_arrow_array(
-                &mut ffi_array as *mut FFI_ArrowArray as *mut u8,
+            ffi::to_arrow_host_table(
+                self.inner(),
+                &mut device_array as *mut ArrowDeviceArray as *mut u8,
                 stream_ref(&stream)?,
                 resource_ref(&mr)?,
-            );
+            )?;
+            stream_ref(&stream)?.synchronize()?;
         }
 
         let schema = Arc::new(Schema::try_from(&ffi_schema)?);
-        let array_data = unsafe { from_ffi(ffi_array, &ffi_schema)? };
+        let array_data = unsafe { from_ffi(device_array.array, &ffi_schema)? };
         let struct_array = StructArray::from(array_data);
 
         // Carry the row count explicitly so zero-column batches (e.g. produced by
@@ -194,8 +243,12 @@ impl CuDFTableView {
         // Extract schema information
         let mut ffi_schema = FFI_ArrowSchema::empty();
         unsafe {
-            self.inner
-                .to_arrow_schema(&mut ffi_schema as *mut FFI_ArrowSchema as *mut u8);
+            let metadata = ffi::get_table_metadata(self.inner())?;
+            ffi::to_arrow_schema(
+                self.inner(),
+                &metadata,
+                &mut ffi_schema as *mut FFI_ArrowSchema as *mut u8,
+            )?;
         }
         Ok(Schema::try_from(&ffi_schema)?)
     }
@@ -207,8 +260,11 @@ impl CuDFTableView {
     pub fn to_record_batch(&self) -> Result<RecordBatch, CuDFError> {
         // Create CuDFColumnView for each column (keeps data on GPU)
         let columns: Vec<ArrayRef> = (0..self.num_columns())
-            .map(|i| Arc::new(self.column(i as i32)) as _)
-            .collect();
+            .map(|i| {
+                self.column(i as i32)
+                    .map(|column| Arc::new(column) as ArrayRef)
+            })
+            .collect::<Result<_, _>>()?;
 
         let options = RecordBatchOptions::new().with_row_count(Some(self.num_rows()));
         Ok(RecordBatch::try_new_with_options(
@@ -236,8 +292,11 @@ impl CuDFTableView {
             )));
         }
         let columns: Vec<ArrayRef> = (0..self.num_columns())
-            .map(|i| Arc::new(self.column(i as i32)) as _)
-            .collect();
+            .map(|i| {
+                self.column(i as i32)
+                    .map(|column| Arc::new(column) as ArrayRef)
+            })
+            .collect::<Result<_, _>>()?;
         record_batch_with_schema(columns, schema, self.num_rows()).map_err(CuDFError::ArrowError)
     }
 
@@ -245,7 +304,7 @@ impl CuDFTableView {
     ///
     /// This expects the RecordBatch to already contain CuDF arrays allocated on GPU.
     /// The columns will be extracted and composed into a table view.
-    pub fn from_record_batch(batch: &RecordBatch) -> Result<Self, CuDFError> {
+    pub fn try_from_record_batch(batch: &RecordBatch) -> Result<Self, CuDFError> {
         let column_views: Result<Vec<_>, _> = batch
             .columns()
             .iter()
@@ -260,7 +319,7 @@ impl CuDFTableView {
             .collect();
         let column_views = column_views?;
 
-        Self::from_column_views(column_views)
+        Self::try_from_column_views(column_views)
     }
 }
 
@@ -298,8 +357,10 @@ pub fn record_batch_with_schema(
 impl Clone for CuDFTableView {
     fn clone(&self) -> Self {
         Self {
-            _ref: self._ref.clone(),
-            inner: self.inner.clone(),
+            inner: Arc::clone(&self.inner),
+            keepalive: self.keepalive.clone(),
+            num_rows: self.num_rows,
+            column_device_memory_sizes: self.column_device_memory_sizes.clone(),
         }
     }
 }


### PR DESCRIPTION
Aligns core cuDF, RMM, CUDA, and Arrow bindings with upstream types and ownership.

This provides foundation runtime redesign.